### PR TITLE
feat(ui): MessageBubble update message time format logic

### DIFF
--- a/mateclaw-ui/src/components/chat/MessageBubble.vue
+++ b/mateclaw-ui/src/components/chat/MessageBubble.vue
@@ -665,10 +665,31 @@ watch(model3dAttachments, (atts) => {
 // --- 时间 ---
 const formattedTime = computed(() => {
   if (!props.message.createTime) return ''
-  return new Date(props.message.createTime).toLocaleTimeString('zh-CN', {
-    hour: '2-digit',
-    minute: '2-digit',
-  })
+
+  const date = new Date(props.message.createTime)
+  const now = new Date()
+
+  const isSameDay =
+    date.getFullYear() === now.getFullYear() &&
+    date.getMonth() === now.getMonth() &&
+    date.getDate() === now.getDate()
+
+  if (isSameDay) {
+    // 当天：时:分
+    return date.toLocaleTimeString('zh-CN', {
+      hour: '2-digit',
+      minute: '2-digit',
+    })
+  } else {
+    // 非当天：年-月-日 时:分
+    return date.toLocaleString('zh-CN', {
+      year: 'numeric',
+      month: '2-digit',
+      day: '2-digit',
+      hour: '2-digit',
+      minute: '2-digit',
+    })
+  }
 })
 
 const formatFileSize = (size: number) => {


### PR DESCRIPTION
## What

修改了MessageBubble.vue 中关于时间的显示逻辑 formattedTime显示调整

## Why

区分出今天发的还是昨天的消息

## How

formattedTime显示调整

## Screenshots (if UI changes)
非当天
<img width="530" height="145" alt="image" src="https://github.com/user-attachments/assets/2ec72371-6861-47a2-921a-ceabe9799c8e" />
当天
<img width="559" height="114" alt="image" src="https://github.com/user-attachments/assets/054590bc-74e1-464c-b6f1-0b8c9e40af34" />
