### PR TITLE
fix(mcp):support Java system property placeholders

### DIFF
--- a/mateclaw-server/src/main/java/vip/mate/tool/mcp/runtime/McpClientManager.java
+++ b/mateclaw-server/src/main/java/vip/mate/tool/mcp/runtime/McpClientManager.java
@@ -269,6 +269,7 @@ public class McpClientManager {
         // Args
         if (server.getArgsJson() != null && !server.getArgsJson().isBlank()) {
             List<String> args = JSONUtil.toList(server.getArgsJson(), String.class);
+            args = args.stream().map(McpClientManager::expandEnvVars).toList();
             builder.args(args);
         }
 
@@ -376,9 +377,10 @@ public class McpClientManager {
     }
 
     /**
-     * 展开环境变量引用，如 ${ENV_VAR} 或 $ENV_VAR
+     * 展开系统属性和环境变量引用，如 ${user.home}、${ENV_VAR} 或 $ENV_VAR
      * <p>
-     * 先处理 ${VAR}（精确匹配），再用正则处理 $VAR（word boundary），
+     * 先处理 ${VAR}（精确匹配），优先系统属性，再回退环境变量；
+     * 再用正则处理 $VAR（word boundary），
      * 避免 $PATH 误替换 $PATH_HOME 的问题。
      */
     private static String expandEnvVars(String value) {
@@ -386,7 +388,12 @@ public class McpClientManager {
             return value;
         }
         String result = value;
-        // Phase 1: 精确匹配 ${VAR} 模式（不会误替换）
+        // Phase 1: 精确匹配 ${VAR} 模式（不会误替换），支持 Java 系统属性如 ${user.home}
+        //JVM 里的系统属性
+        for (String key : System.getProperties().stringPropertyNames()) {
+            result = result.replace("${" + key + "}", System.getProperty(key));
+        }
+        //操作系统环境变量
         for (Map.Entry<String, String> env : System.getenv().entrySet()) {
             result = result.replace("${" + env.getKey() + "}", env.getValue());
         }


### PR DESCRIPTION
## What

McpClientManager中 expandEnvVars 调整一下 先获取 jvm的环境变量 在获取系统的环境变量

## Why
filesystem这个mcp中 有需要用到环境变量 user.home 正在系统环境变量里面是没有的，当点击启动的时候会报错
<img width="1721" height="234" alt="image" src="https://github.com/user-attachments/assets/c12f6a36-d666-43f2-8288-76a9ad5bf84a" />

## How

 //JVM 里的系统属性
        for (String key : System.getProperties().stringPropertyNames()) {
            result = result.replace("${" + key + "}", System.getProperty(key));
        }

