### PR TITLE
增加一个特性，在mcp技能工具列表中，除显示mcp_<serverId>_<slug>_<hash6>工具名，在后面用括号也显示原始mcp…

### DIFF
--- a/mateclaw-server/src/main/java/vip/mate/skill/controller/SkillController.java
+++ b/mateclaw-server/src/main/java/vip/mate/skill/controller/SkillController.java
@@ -1,6 +1,8 @@
 package vip.mate.skill.controller;
 
 import com.baomidou.mybatisplus.core.metadata.IPage;
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
@@ -57,6 +59,7 @@ public class SkillController {
     private final AgentBindingService agentBindingService;
     private final vip.mate.skill.mcp.McpSkillBridge mcpSkillBridge;
     private final vip.mate.skill.acp.AcpSkillBridge acpSkillBridge;
+    private final ObjectMapper objectMapper;
 
     @Operation(summary = "获取技能分页列表（RFC-042 §2.1）")
     @GetMapping
@@ -392,8 +395,32 @@ public class SkillController {
 
     @Operation(summary = "获取所有技能的运行时解析状态（管理页面使用）")
     @GetMapping("/runtime/status")
-    public R<List<ResolvedSkill>> getRuntimeStatus() {
-        return R.ok(skillRuntimeService.resolveAllSkillsStatus());
+    public R<List<Map<String, Object>>> getRuntimeStatus() {
+        List<ResolvedSkill> skills = skillRuntimeService.resolveAllSkillsStatus();
+        return R.ok(skills.stream().map(this::toRuntimeStatusView).toList());
+    }
+
+    /**
+     * 把返回给前端的 effectiveAllowedTools 做展示转换
+     * 除显示mcp_<serverId>_<slug>_<hash6>工具名，在后面用括号也显示原始mcp工具名
+     *
+     * @param skill
+     * @return
+     */
+    private Map<String, Object> toRuntimeStatusView(ResolvedSkill skill) {
+        Map<String, Object> view = objectMapper.convertValue(
+                skill,
+                new TypeReference<Map<String, Object>>() {}
+        );
+
+        if ("mcp".equalsIgnoreCase(skill.getSource())) {
+            List<String> displayTools = skill.getEffectiveAllowedTools().stream()
+                    .map(mcpSkillBridge::decorateToolNameForDisplay)
+                    .toList();
+            view.put("effectiveAllowedTools", displayTools);
+        }
+
+        return view;
     }
 
     @Operation(summary = "刷新 active skills 缓存，resync=true 时同步内置技能到 workspace")

--- a/mateclaw-server/src/main/java/vip/mate/skill/controller/SkillController.java
+++ b/mateclaw-server/src/main/java/vip/mate/skill/controller/SkillController.java
@@ -401,8 +401,10 @@ public class SkillController {
     }
 
     /**
-     * 把返回给前端的 effectiveAllowedTools 做展示转换
-     * 除显示mcp_<serverId>_<slug>_<hash6>工具名，在后面用括号也显示原始mcp工具名
+     * Perform a display transformation on `effectiveAllowedTools` (returned to the frontend),
+     * and store the transformed result in `effectiveAllowedToolsDisplay`.
+     * In addition to displaying the tool name in the format `mcp_<serverId>_<slug>_<hash6>`,
+     * also display the original MCP tool name in parentheses immediately following it.
      *
      * @param skill
      * @return
@@ -417,7 +419,7 @@ public class SkillController {
             List<String> displayTools = skill.getEffectiveAllowedTools().stream()
                     .map(mcpSkillBridge::decorateToolNameForDisplay)
                     .toList();
-            view.put("effectiveAllowedTools", displayTools);
+            view.put("effectiveAllowedToolsDisplay", displayTools);
         }
 
         return view;

--- a/mateclaw-server/src/main/java/vip/mate/skill/mcp/McpSkillBridge.java
+++ b/mateclaw-server/src/main/java/vip/mate/skill/mcp/McpSkillBridge.java
@@ -121,6 +121,25 @@ public class McpSkillBridge {
         }
     }
 
+    /**
+     * 增加一个“仅展示用”的方法，把 prefixed name 反查成 raw name
+     * @param prefixedName
+     * @return
+     */
+    public String decorateToolNameForDisplay(String prefixedName) {
+        McpToolNameResolver.ParsedRef ref = McpToolNameResolver.parse(prefixedName);
+        if (ref == null) return prefixedName;
+
+        McpServerEntity server = mcpServerService.getById(ref.serverId());
+        for (String raw : readToolRawNames(server)) {
+            String rebuilt = McpToolNameResolver.prefixedName(ref.serverId(), raw);
+            if (rebuilt.equals(prefixedName)) {
+                return prefixedName + " (" + raw + ")";
+            }
+        }
+        return prefixedName;
+    }
+
     private List<McpServerEntity> listEnabledServers() {
         try {
             return mcpServerService.listEnabled();

--- a/mateclaw-server/src/main/java/vip/mate/skill/mcp/McpSkillBridge.java
+++ b/mateclaw-server/src/main/java/vip/mate/skill/mcp/McpSkillBridge.java
@@ -122,7 +122,8 @@ public class McpSkillBridge {
     }
 
     /**
-     * 增加一个“仅展示用”的方法，把 prefixed name 反查成 raw name
+     * Add a "display-only" method to reverse-lookup a prefixed name back to its raw name.
+     *
      * @param prefixedName
      * @return
      */

--- a/mateclaw-ui/src/types/index.ts
+++ b/mateclaw-ui/src/types/index.ts
@@ -278,6 +278,8 @@ export interface SkillRuntimeStatus {
   activeFeatures?: string[]
   /** Tools advertised to the LLM after feature filtering */
   effectiveAllowedTools?: string[]
+  /** Human-readable tool names for display after feature filtering */
+  effectiveAllowedToolsDisplay?: string[]
 }
 
 /** RFC-090 §14.6 — typed view onto manifest_json */

--- a/mateclaw-ui/src/views/SkillMarket.vue
+++ b/mateclaw-ui/src/views/SkillMarket.vue
@@ -787,7 +787,9 @@ const detailManifest = computed(() => detailRuntime.value?.manifest ?? null)
 const detailManifestPretty = computed(() =>
   detailManifest.value ? JSON.stringify(detailManifest.value, null, 2) : '',
 )
-const detailEffectiveTools = computed(() => detailRuntime.value?.effectiveAllowedTools || [])
+const detailEffectiveTools = computed(() =>
+  detailRuntime.value?.effectiveAllowedToolsDisplay || detailRuntime.value?.effectiveAllowedTools || [],
+)
 const detailToolsCount = computed(() => detailEffectiveTools.value.length)
 const detailFeatures = computed(() => {
   const m = detailManifest.value


### PR DESCRIPTION
增加一个特性，在mcp技能工具列表中，除显示mcp_<serverId>_<slug>_<hash6>工具名，在后面用括号也显示原始mcp工具名，以方便查看
<img width="489" height="300" alt="image" src="https://github.com/user-attachments/assets/72682c7c-f459-47e6-8fa1-c4f08d112471" />
