### PR TITLE
在安全配置中，增加通过mcp工具名进行人工确认的代码。在前端确认时，显示工具名和调用工具时的参数。

### DIFF
--- a/mateclaw-server/src/main/java/vip/mate/tool/guard/guardian/McpToolApprovalGuardian.java
+++ b/mateclaw-server/src/main/java/vip/mate/tool/guard/guardian/McpToolApprovalGuardian.java
@@ -1,0 +1,147 @@
+package vip.mate.tool.guard.guardian;
+
+import io.modelcontextprotocol.spec.McpSchema;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+import vip.mate.tool.guard.engine.ToolGuardRuleRegistry;
+import vip.mate.tool.guard.model.*;
+import vip.mate.tool.mcp.runtime.McpClientManager;
+import vip.mate.tool.mcp.runtime.McpToolNameResolver;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * MCP 工具名审批守卫。
+ *
+ * <p>仅匹配明确配置了 {@code tool_name} 的规则，允许配置运行时 prefixed
+ * 名称，或配置 MCP server 暴露的 raw tool name。
+ */
+@Slf4j
+@Component
+public class McpToolApprovalGuardian implements ToolGuardGuardian {
+
+    private final ToolGuardRuleRegistry ruleRegistry;
+    private final McpClientManager mcpClientManager;
+
+    public McpToolApprovalGuardian(ToolGuardRuleRegistry ruleRegistry,
+                                   McpClientManager mcpClientManager) {
+        this.ruleRegistry = ruleRegistry;
+        this.mcpClientManager = mcpClientManager;
+    }
+
+    @Override
+    public boolean supports(ToolInvocationContext context) {
+        return McpToolNameResolver.isMcpPrefixedName(context.toolName());
+    }
+
+    @Override
+    public int priority() {
+        return 180;
+    }
+
+    @Override
+    public List<GuardFinding> evaluate(ToolInvocationContext context) {
+        String prefixedName = context.toolName();
+        String rawName = resolveRawToolName(prefixedName);
+        List<GuardFinding> findings = new ArrayList<>();
+
+        for (ToolGuardRuleEntity rule : ruleRegistry.getAllEnabled()) {
+            String configuredToolName = normalize(rule.getToolName());
+            if (configuredToolName == null) {
+                continue;
+            }
+            if (!matchesRule(rule, configuredToolName, prefixedName, rawName)) {
+                continue;
+            }
+
+            findings.add(new GuardFinding(
+                    fallback(rule.getRuleId(), "MCP_TOOL_APPROVAL"),
+                    approvalSeverity(rule.getSeverity()),
+                    category(rule.getCategory()),
+                    fallback(rule.getName(), "MCP 工具调用审批"),
+                    fallback(rule.getDescription(), "MCP 工具调用匹配审批规则，需要用户确认后执行"),
+                    fallback(rule.getRemediation(), "请确认是否允许执行该 MCP 工具"),
+                    prefixedName,
+                    "tool_name",
+                    configuredToolName,
+                    rawName != null ? rawName : prefixedName,
+                    Map.of(
+                            "configuredToolName", configuredToolName,
+                            "prefixedToolName", prefixedName,
+                            "rawToolName", rawName != null ? rawName : ""
+                    )
+            ));
+        }
+
+        return findings;
+    }
+
+    private static boolean matchesRule(ToolGuardRuleEntity rule, String configuredToolName,
+                                       String prefixedName, String rawName) {
+        if (configuredToolName.equals(prefixedName)) {
+            return true;
+        }
+        if (rawName == null || !configuredToolName.equals(rawName)) {
+            return false;
+        }
+        return !Boolean.TRUE.equals(rule.getBuiltin());
+    }
+
+    private String resolveRawToolName(String prefixedName) {
+        McpToolNameResolver.ParsedRef parsed = McpToolNameResolver.parse(prefixedName);
+        if (parsed == null) {
+            return null;
+        }
+        try {
+            for (McpSchema.Tool tool : mcpClientManager.getServerTools(parsed.serverId())) {
+                String raw = tool != null ? tool.name() : null;
+                if (raw != null && McpToolNameResolver.hash6(raw).equals(parsed.hash6())) {
+                    return raw;
+                }
+            }
+        } catch (Exception e) {
+            log.debug("[McpToolApprovalGuardian] Failed to resolve raw MCP tool name for {}: {}",
+                    prefixedName, e.getMessage());
+        }
+        return null;
+    }
+
+    private static GuardSeverity approvalSeverity(String configuredSeverity) {
+        if (configuredSeverity == null || configuredSeverity.isBlank()) {
+            return GuardSeverity.MEDIUM;
+        }
+        try {
+            GuardSeverity severity = GuardSeverity.valueOf(configuredSeverity.trim());
+            if (severity == GuardSeverity.HIGH) {
+                return GuardSeverity.HIGH;
+            }
+        } catch (IllegalArgumentException ignored) {
+            // Fall through to MEDIUM so a malformed rule still asks for approval.
+        }
+        return GuardSeverity.MEDIUM;
+    }
+
+    private static GuardCategory category(String configuredCategory) {
+        if (configuredCategory == null || configuredCategory.isBlank()) {
+            return GuardCategory.CODE_EXECUTION;
+        }
+        try {
+            return GuardCategory.valueOf(configuredCategory.trim());
+        } catch (IllegalArgumentException e) {
+            return GuardCategory.CODE_EXECUTION;
+        }
+    }
+
+    private static String normalize(String value) {
+        if (value == null || value.isBlank()) {
+            return null;
+        }
+        return value.trim();
+    }
+
+    private static String fallback(String value, String fallback) {
+        return value == null || value.isBlank() ? fallback : value;
+    }
+}

--- a/mateclaw-server/src/test/java/vip/mate/tool/guard/guardian/McpToolApprovalGuardianTest.java
+++ b/mateclaw-server/src/test/java/vip/mate/tool/guard/guardian/McpToolApprovalGuardianTest.java
@@ -1,0 +1,130 @@
+package vip.mate.tool.guard.guardian;
+
+import io.modelcontextprotocol.spec.McpSchema;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import vip.mate.tool.guard.engine.ToolGuardRuleRegistry;
+import vip.mate.tool.guard.model.*;
+import vip.mate.tool.mcp.runtime.McpClientManager;
+import vip.mate.tool.mcp.runtime.McpToolNameResolver;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+class McpToolApprovalGuardianTest {
+
+    private ToolGuardRuleRegistry ruleRegistry;
+    private McpClientManager mcpClientManager;
+    private McpToolApprovalGuardian guardian;
+
+    @BeforeEach
+    void setUp() {
+        ruleRegistry = mock(ToolGuardRuleRegistry.class);
+        mcpClientManager = mock(McpClientManager.class);
+        guardian = new McpToolApprovalGuardian(ruleRegistry, mcpClientManager);
+    }
+
+    @Test
+    @DisplayName("prefixed MCP tool name rule creates approval finding")
+    void prefixedRuleMatches() {
+        String toolName = McpToolNameResolver.prefixedName(42L, "search_entity");
+        when(ruleRegistry.getAllEnabled()).thenReturn(List.of(rule("MCP_SEARCH", toolName, "HIGH")));
+
+        List<GuardFinding> findings = guardian.evaluate(context(toolName));
+
+        assertEquals(1, findings.size());
+        assertEquals("MCP_SEARCH", findings.get(0).ruleId());
+        assertEquals(GuardSeverity.HIGH, findings.get(0).severity());
+        assertEquals(toolName, findings.get(0).toolName());
+        assertEquals(toolName, findings.get(0).matchedPattern());
+    }
+
+    @Test
+    @DisplayName("raw MCP tool name rule matches through server tool cache")
+    void rawRuleMatches() {
+        String rawName = "search_entity";
+        String toolName = McpToolNameResolver.prefixedName(42L, rawName);
+        when(ruleRegistry.getAllEnabled()).thenReturn(List.of(rule("MCP_SEARCH_RAW", rawName, "MEDIUM")));
+        when(mcpClientManager.getServerTools(42L)).thenReturn(List.of(tool(rawName)));
+
+        List<GuardFinding> findings = guardian.evaluate(context(toolName));
+
+        assertEquals(1, findings.size());
+        assertEquals("MCP_SEARCH_RAW", findings.get(0).ruleId());
+        assertEquals(rawName, findings.get(0).matchedPattern());
+        assertEquals(rawName, findings.get(0).snippet());
+    }
+
+    @Test
+    @DisplayName("blank tool_name rules are ignored for MCP approval")
+    void blankToolRuleIgnored() {
+        String toolName = McpToolNameResolver.prefixedName(42L, "search_entity");
+        when(ruleRegistry.getAllEnabled()).thenReturn(List.of(rule("GLOBAL", "", "HIGH")));
+
+        List<GuardFinding> findings = guardian.evaluate(context(toolName));
+
+        assertTrue(findings.isEmpty());
+    }
+
+    @Test
+    @DisplayName("raw name matching does not reuse builtin non-MCP rules")
+    void rawRuleDoesNotMatchBuiltinRule() {
+        String rawName = "execute_shell_command";
+        String toolName = McpToolNameResolver.prefixedName(42L, rawName);
+        ToolGuardRuleEntity builtinShellRule = rule("SHELL_RM", rawName, "HIGH");
+        builtinShellRule.setBuiltin(true);
+        when(ruleRegistry.getAllEnabled()).thenReturn(List.of(builtinShellRule));
+        when(mcpClientManager.getServerTools(42L)).thenReturn(List.of(tool(rawName)));
+
+        List<GuardFinding> findings = guardian.evaluate(context(toolName));
+
+        assertTrue(findings.isEmpty());
+    }
+
+    @Test
+    @DisplayName("critical severity is coerced to approval severity")
+    void criticalSeverityDoesNotBlock() {
+        String toolName = McpToolNameResolver.prefixedName(42L, "search_entity");
+        when(ruleRegistry.getAllEnabled()).thenReturn(List.of(rule("MCP_SEARCH", toolName, "CRITICAL")));
+
+        List<GuardFinding> findings = guardian.evaluate(context(toolName));
+        GuardDecision decision = new vip.mate.tool.guard.engine.ToolPolicyResolver()
+                .resolve(findings, context(toolName));
+
+        assertEquals(1, findings.size());
+        assertEquals(GuardSeverity.MEDIUM, findings.get(0).severity());
+        assertEquals(GuardDecision.NEEDS_APPROVAL, decision);
+    }
+
+    @Test
+    @DisplayName("non-MCP tools are not supported")
+    void nonMcpUnsupported() {
+        assertFalse(guardian.supports(context("execute_shell_command")));
+    }
+
+    private static ToolInvocationContext context(String toolName) {
+        return ToolInvocationContext.of(toolName, "{}", "conv-1", "agent-1");
+    }
+
+    private static ToolGuardRuleEntity rule(String ruleId, String toolName, String severity) {
+        ToolGuardRuleEntity rule = new ToolGuardRuleEntity();
+        rule.setRuleId(ruleId);
+        rule.setName(ruleId);
+        rule.setDescription(ruleId);
+        rule.setToolName(toolName);
+        rule.setSeverity(severity);
+        rule.setCategory(GuardCategory.CODE_EXECUTION.name());
+        rule.setDecision(GuardDecision.NEEDS_APPROVAL.name());
+        rule.setPattern(".*");
+        rule.setEnabled(true);
+        return rule;
+    }
+
+    private static McpSchema.Tool tool(String name) {
+        return new McpSchema.Tool(name, null, "Test tool", null, null, null, null);
+    }
+}

--- a/mateclaw-ui/src/components/chat/ChatInput.vue
+++ b/mateclaw-ui/src/components/chat/ChatInput.vue
@@ -59,31 +59,37 @@
 
     <!-- 审批栏：有待审批时替换输入区域 -->
     <div v-if="pendingApproval?.status === 'pending_approval'" class="approval-bar">
-      <div class="approval-bar__info">
-        <span class="approval-bar__icon">
-          <el-icon><WarningFilled /></el-icon>
-        </span>
-        <span class="approval-bar__label">{{ t('chat.approvalAllow') }}</span>
-        <span class="approval-bar__tool">{{ getToolLabel(pendingApproval.toolName) }}</span>
-        <span class="approval-bar__label">{{ t('chat.approvalExecute') }}</span>
+      <div class="approval-bar__top">
+        <div class="approval-bar__info">
+          <span class="approval-bar__icon">
+            <el-icon><WarningFilled /></el-icon>
+          </span>
+          <span class="approval-bar__label">{{ t('chat.approvalAllow') }}</span>
+          <span class="approval-bar__tool">{{ getToolLabel(pendingApproval.toolName) }}</span>
+          <span class="approval-bar__label">{{ t('chat.approvalExecute') }}</span>
+        </div>
+        <div class="approval-bar__actions">
+          <button
+            type="button"
+            class="approval-bar__btn approval-bar__btn--deny"
+            @click="emit('deny', pendingApproval.pendingId)"
+          >
+            <el-icon><CloseBold /></el-icon>
+            {{ t('chat.deny') }}
+          </button>
+          <button
+            type="button"
+            class="approval-bar__btn approval-bar__btn--approve"
+            @click="emit('approve', pendingApproval.pendingId)"
+          >
+            <el-icon><Select /></el-icon>
+            {{ t('chat.approve') }}
+          </button>
+        </div>
       </div>
-      <div class="approval-bar__actions">
-        <button
-          type="button"
-          class="approval-bar__btn approval-bar__btn--deny"
-          @click="emit('deny', pendingApproval.pendingId)"
-        >
-          <el-icon><CloseBold /></el-icon>
-          {{ t('chat.deny') }}
-        </button>
-        <button
-          type="button"
-          class="approval-bar__btn approval-bar__btn--approve"
-          @click="emit('approve', pendingApproval.pendingId)"
-        >
-          <el-icon><Select /></el-icon>
-          {{ t('chat.approve') }}
-        </button>
+      <div v-if="showApprovalArguments" class="approval-bar__params">
+        <div class="approval-bar__params-label">{{ t('chat.approvalParameters') }}</div>
+        <pre class="approval-bar__params-code">{{ formattedApprovalArguments }}</pre>
       </div>
     </div>
 
@@ -206,6 +212,7 @@ import { ref, computed, nextTick, watch } from 'vue'
 import { useI18n } from 'vue-i18n'
 import { CloseBold, MagicStick, Microphone, Paperclip, Promotion, Select, Timer, WarningFilled } from '@element-plus/icons-vue'
 import { useToolLabel } from '@/composables/useToolLabel'
+import { formatToolArguments, shouldShowMcpToolArguments } from '@/utils/toolArguments'
 import type { ChatAttachment, PendingApprovalMeta, StreamPhase, QueuedMessage } from '@/types'
 
 interface Props {
@@ -309,6 +316,11 @@ const inputPlaceholder = computed(() => {
   }
   return props.placeholder
 })
+
+const formattedApprovalArguments = computed(() => formatToolArguments(props.pendingApproval?.arguments))
+const showApprovalArguments = computed(() =>
+  shouldShowMcpToolArguments(props.pendingApproval?.toolName, props.pendingApproval?.arguments)
+)
 
 // 处理提交
 const handleSubmit = () => {
@@ -681,14 +693,21 @@ defineExpose({
 /* 审批栏 */
 .approval-bar {
   display: flex;
+  flex-direction: column;
+  gap: 8px;
+  background: var(--mc-input-bg, #ffffff);
+  border-radius: 16px;
+  padding: 8px;
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.08), 0 0 0 1px rgba(217, 119, 87, 0.3);
+  min-height: 50px;
+}
+
+.approval-bar__top {
+  display: flex;
   align-items: center;
   justify-content: space-between;
   gap: 12px;
-  background: var(--mc-input-bg, #ffffff);
-  border-radius: 16px;
-  padding: 8px 8px 8px 12px;
-  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.08), 0 0 0 1px rgba(217, 119, 87, 0.3);
-  min-height: 50px;
+  width: 100%;
 }
 
 .approval-bar__info {
@@ -732,6 +751,34 @@ defineExpose({
   gap: 8px;
   align-items: center;
   flex-shrink: 0;
+}
+
+.approval-bar__params {
+  width: 100%;
+  min-width: 0;
+  padding: 7px 9px 8px;
+  border-radius: 10px;
+  background: var(--mc-bg-sunken, #f1f5f9);
+  border: 1px solid var(--mc-border-light, #e5e7eb);
+}
+
+.approval-bar__params-label {
+  margin-bottom: 5px;
+  font-size: 12px;
+  font-weight: 600;
+  color: var(--mc-text-secondary, #64748b);
+}
+
+.approval-bar__params-code {
+  margin: 0;
+  max-height: 150px;
+  overflow: auto;
+  white-space: pre-wrap;
+  word-break: break-word;
+  font-family: ui-monospace, 'SFMono-Regular', Consolas, monospace;
+  font-size: 12px;
+  line-height: 1.5;
+  color: var(--mc-text-primary, #1e293b);
 }
 
 .approval-bar__btn {
@@ -810,6 +857,16 @@ defineExpose({
   .chat-textarea {
     min-height: 34px;
     line-height: 1.55;
+  }
+
+  .approval-bar__top {
+    align-items: stretch;
+    flex-direction: column;
+    gap: 8px;
+  }
+
+  .approval-bar__actions {
+    justify-content: flex-end;
   }
 
   .action-btn {

--- a/mateclaw-ui/src/components/chat/MessageBubble.vue
+++ b/mateclaw-ui/src/components/chat/MessageBubble.vue
@@ -122,16 +122,22 @@
 
         <!-- 工具审批状态（极简一行，操作在输入栏） -->
         <div v-if="pendingApproval" class="approval-inline">
-          <el-icon class="approval-inline__icon"><WarningFilled /></el-icon>
-          <span v-if="pendingApproval.status === 'pending_approval'" class="approval-inline__text">
-            {{ $t('chat.approvalWaiting') }} <code>{{ getToolLabel(pendingApproval.toolName) }}</code>
-          </span>
-          <span v-else-if="pendingApproval.status === 'approved'" class="approval-inline__text approval-inline--approved">
-            {{ $t('chat.approved') }}: <code>{{ getToolLabel(pendingApproval.toolName) }}</code>
-          </span>
-          <span v-else class="approval-inline__text approval-inline--denied">
-            {{ $t('chat.denied') }}: <code>{{ getToolLabel(pendingApproval.toolName) }}</code>
-          </span>
+          <div class="approval-inline__main">
+            <el-icon class="approval-inline__icon"><WarningFilled /></el-icon>
+            <span v-if="pendingApproval.status === 'pending_approval'" class="approval-inline__text">
+              {{ $t('chat.approvalWaiting') }} <code>{{ getToolLabel(pendingApproval.toolName) }}</code>
+            </span>
+            <span v-else-if="pendingApproval.status === 'approved'" class="approval-inline__text approval-inline--approved">
+              {{ $t('chat.approved') }}: <code>{{ getToolLabel(pendingApproval.toolName) }}</code>
+            </span>
+            <span v-else class="approval-inline__text approval-inline--denied">
+              {{ $t('chat.denied') }}: <code>{{ getToolLabel(pendingApproval.toolName) }}</code>
+            </span>
+          </div>
+          <div v-if="showApprovalArguments" class="approval-inline__params">
+            <div class="approval-inline__params-label">{{ $t('chat.approvalParameters') }}</div>
+            <pre class="approval-inline__params-code">{{ formattedApprovalArguments }}</pre>
+          </div>
         </div>
 
         <!-- 主要内容 -->
@@ -411,6 +417,7 @@ import { useAuthenticatedAttachment } from '@/composables/useAuthenticatedAttach
 import { useToolLabel } from '@/composables/useToolLabel'
 import { http } from '@/api'
 import { copyToClipboard } from '@/utils/clipboard'
+import { formatToolArguments, shouldShowMcpToolArguments } from '@/utils/toolArguments'
 import TypingCursor from './TypingCursor.vue'
 import BrowserTimeline from './BrowserTimeline.vue'
 import ToolCallSegment from './ToolCallSegment.vue'
@@ -1086,6 +1093,11 @@ const pendingApproval = computed(() => {
   return approval
 })
 
+const formattedApprovalArguments = computed(() => formatToolArguments(pendingApproval.value?.arguments))
+const showApprovalArguments = computed(() =>
+  shouldShowMcpToolArguments(pendingApproval.value?.toolName, pendingApproval.value?.arguments)
+)
+
 const approvalSeverityClass = computed(() => {
   const sev = pendingApproval.value?.maxSeverity?.toLowerCase()
   if (!sev) return ''
@@ -1545,7 +1557,8 @@ watch(isGenerating, (generating) => {
 /* 极简审批状态（一行式） */
 .approval-inline {
   display: flex;
-  align-items: center;
+  flex-direction: column;
+  align-items: stretch;
   gap: 6px;
   padding: 8px 12px;
   margin-bottom: 8px;
@@ -1553,6 +1566,13 @@ watch(isGenerating, (generating) => {
   color: var(--mc-text-secondary, #64748b);
   background: var(--mc-bg-muted, #f9f7f5);
   border-radius: 8px;
+}
+
+.approval-inline__main {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  min-width: 0;
 }
 
 .approval-inline__icon {
@@ -1566,6 +1586,33 @@ watch(isGenerating, (generating) => {
   padding: 1px 5px;
   border-radius: 4px;
   font-weight: 500;
+}
+
+.approval-inline__params {
+  min-width: 0;
+  padding: 7px 9px;
+  border-radius: 7px;
+  background: var(--mc-bg-sunken, #f1f5f9);
+  border: 1px solid var(--mc-border-light, #e5e7eb);
+}
+
+.approval-inline__params-label {
+  margin-bottom: 5px;
+  font-size: 12px;
+  font-weight: 600;
+  color: var(--mc-text-secondary, #64748b);
+}
+
+.approval-inline__params-code {
+  margin: 0;
+  max-height: 180px;
+  overflow: auto;
+  white-space: pre-wrap;
+  word-break: break-word;
+  font-family: ui-monospace, 'SFMono-Regular', Consolas, monospace;
+  font-size: 12px;
+  line-height: 1.5;
+  color: var(--mc-text-primary, #1e293b);
 }
 
 .approval-inline--approved {

--- a/mateclaw-ui/src/i18n/locales/en-US.ts
+++ b/mateclaw-ui/src/i18n/locales/en-US.ts
@@ -350,6 +350,7 @@ export default {
     // Approval bar
     approvalAllow: 'Allow',
     approvalExecute: 'to execute?',
+    approvalParameters: 'Parameters',
     // Time format
     timeJustNow: 'Just now',
     timeMinutesAgo: '{n}m ago',

--- a/mateclaw-ui/src/i18n/locales/zh-CN.ts
+++ b/mateclaw-ui/src/i18n/locales/zh-CN.ts
@@ -350,6 +350,7 @@ export default {
     // 审批栏
     approvalAllow: '允许',
     approvalExecute: '执行？',
+    approvalParameters: '参数',
     // 时间格式
     timeJustNow: '刚刚',
     timeMinutesAgo: '{n} 分钟前',

--- a/mateclaw-ui/src/utils/toolArguments.ts
+++ b/mateclaw-ui/src/utils/toolArguments.ts
@@ -1,0 +1,15 @@
+export function formatToolArguments(args?: string | null): string {
+  if (!args) return ''
+  const trimmed = args.trim()
+  if (!trimmed) return ''
+
+  try {
+    return JSON.stringify(JSON.parse(trimmed), null, 2)
+  } catch {
+    return trimmed
+  }
+}
+
+export function shouldShowMcpToolArguments(toolName?: string | null, args?: string | null): boolean {
+  return !!toolName?.startsWith('mcp_') && !!formatToolArguments(args)
+}


### PR DESCRIPTION
利用现在的安全机制，增加对mcp工具的人工确认。
<img width="504" height="414" alt="image" src="https://github.com/user-attachments/assets/428ea0a5-5c35-4e64-9f33-0c0db7a871e5" />
直接用工具名配置规则。

<img width="1127" height="246" alt="image" src="https://github.com/user-attachments/assets/3977c23d-c7ed-4cdd-b79e-8522a86d377b" />
当执行到工具调用时，在前端提示用户确认，同时显示调用工具时的参数。