### PR TITLE
fix(feishu): register no-op handlers for reaction events

### DIFF
--- a/mateclaw-server/src/main/java/vip/mate/channel/feishu/FeishuChannelAdapter.java
+++ b/mateclaw-server/src/main/java/vip/mate/channel/feishu/FeishuChannelAdapter.java
@@ -221,6 +221,15 @@ public class FeishuChannelAdapter extends AbstractChannelAdapter {
                         }
                     }
                 })
+                // 静默忽略消息表情回应事件，避免 HandlerNotFoundException
+                .onP2MessageReactionCreatedV1(new ImService.P2MessageReactionCreatedV1Handler() {
+                    @Override
+                    public void handle(com.lark.oapi.service.im.v1.model.P2MessageReactionCreatedV1 event) {}
+                })
+                .onP2MessageReactionDeletedV1(new ImService.P2MessageReactionDeletedV1Handler() {
+                    @Override
+                    public void handle(com.lark.oapi.service.im.v1.model.P2MessageReactionDeletedV1 event) {}
+                })
                 .build();
 
         return new com.lark.oapi.ws.Client.Builder(appId, appSecret)


### PR DESCRIPTION
## Summary

- 为 `im.message.reaction.created_v1` 和 `im.message.reaction.deleted_v1` 注册 no-op handler
- 修复飞书 WebSocket 连接因 `HandlerNotFoundException` 断开的问题

## Test plan

- [ ] 启动 mateclaw-server 并连接飞书渠道
- [ ] 在任意飞书群聊中对某条消息添加 emoji reaction
- [ ] 确认日志无 `HandlerNotFoundException`，连接保持稳定