### PR TITLE
fix(feishu): add handler for im.chat.member.bot.added_v1 event

### DIFF
--- a/mateclaw-server/src/main/java/vip/mate/channel/feishu/FeishuChannelAdapter.java
+++ b/mateclaw-server/src/main/java/vip/mate/channel/feishu/FeishuChannelAdapter.java
@@ -231,7 +231,7 @@ public class FeishuChannelAdapter extends AbstractChannelAdapter {
                     public void handle(com.lark.oapi.service.im.v1.model.P2MessageReactionDeletedV1 event) {}
                 })
                 // Silently ignore bot added to chat event to avoid HandlerNotFoundException (#153)
-                .onP2ChatMemberBotAdded(new ImService.P2ChatMemberBotAddedV1Handler() {
+                .onP2ChatMemberBotAddedV1(new ImService.P2ChatMemberBotAddedV1Handler() {
                     @Override
                     public void handle(com.lark.oapi.service.im.v1.model.P2ChatMemberBotAddedV1 event) {}
                 })

--- a/mateclaw-server/src/main/java/vip/mate/channel/feishu/FeishuChannelAdapter.java
+++ b/mateclaw-server/src/main/java/vip/mate/channel/feishu/FeishuChannelAdapter.java
@@ -230,6 +230,11 @@ public class FeishuChannelAdapter extends AbstractChannelAdapter {
                     @Override
                     public void handle(com.lark.oapi.service.im.v1.model.P2MessageReactionDeletedV1 event) {}
                 })
+                // Silently ignore bot added to chat event to avoid HandlerNotFoundException (#153)
+                .onP2ChatMemberBotAdded(new ImService.P2ChatMemberBotAddedV1Handler() {
+                    @Override
+                    public void handle(com.lark.oapi.service.im.v1.model.P2ChatMemberBotAddedV1 event) {}
+                })
                 .build();
 
         return new com.lark.oapi.ws.Client.Builder(appId, appSecret)


### PR DESCRIPTION
## Summary

- Add empty handler for `im.chat.member.bot.added_v1` event to prevent `HandlerNotFoundException`
- This fixes the WebSocket connection drop when bot is added to a group chat
- Similar fix to #139 (reaction events)

## Test Plan

- [ ] Add bot to a Feishu group chat
- [ ] Verify no `HandlerNotFoundException` in logs
- [ ] Verify WebSocket connection stays alive

Fixes #153