### PR TITLE
feat(feishu): support Interactive Card JSON for structured message rendering

### DIFF
--- a/mateclaw-server/src/main/java/vip/mate/channel/feishu/FeishuCardFormatter.java
+++ b/mateclaw-server/src/main/java/vip/mate/channel/feishu/FeishuCardFormatter.java
@@ -47,4 +47,122 @@ final class FeishuCardFormatter {
                 })
                 .count();
     }
+
+    // ==================== 渲染层 ====================
+
+    static java.util.Map<String, Object> render(String content, ContentFormat format) {
+        return switch (format) {
+            case JSON      -> renderJson(content);
+            case MARKDOWN  -> renderMarkdown(content);
+            case LONG_TEXT, PLAIN_TEXT -> renderLongText(content);
+        };
+    }
+
+    private static java.util.Map<String, Object> renderMarkdown(String content) {
+        return cardOf(
+            java.util.Map.of("title", java.util.Map.of("tag", "plain_text", "content", "AI 助手")),
+            java.util.List.of(java.util.Map.of(
+                "tag", "div",
+                "text", java.util.Map.of("tag", "lark_md", "content", content)
+            ))
+        );
+    }
+
+    private static java.util.Map<String, Object> renderLongText(String content) {
+        return cardOf(
+            null,
+            java.util.List.of(java.util.Map.of(
+                "tag", "div",
+                "text", java.util.Map.of("tag", "plain_text", "content", content)
+            ))
+        );
+    }
+
+    private static java.util.Map<String, Object> renderJson(String content) {
+        try {
+            JsonNode node = MAPPER.readTree(content);
+            if (node.isObject()) return renderJsonObject(node);
+            if (node.isArray())  return renderJsonArray(node);
+        } catch (Exception ignored) {}
+        return renderLongText(content);
+    }
+
+    private static java.util.Map<String, Object> renderJsonObject(JsonNode node) {
+        java.util.List<Object> elements = new java.util.ArrayList<>();
+        node.fields().forEachRemaining(entry -> {
+            String key = entry.getKey();
+            String value = entry.getValue().isTextual()
+                    ? entry.getValue().asText()
+                    : entry.getValue().toString();
+            elements.add(java.util.Map.of(
+                "tag", "column_set",
+                "flex_mode", "none",
+                "columns", java.util.List.of(
+                    java.util.Map.of("tag", "column", "width", "weighted", "weight", 1,
+                        "elements", java.util.List.of(java.util.Map.of("tag", "div",
+                            "text", java.util.Map.of("tag", "plain_text", "content", key)))),
+                    java.util.Map.of("tag", "column", "width", "weighted", "weight", 2,
+                        "elements", java.util.List.of(java.util.Map.of("tag", "div",
+                            "text", java.util.Map.of("tag", "plain_text", "content", value))))
+                )
+            ));
+        });
+        return cardOf(null, elements);
+    }
+
+    private static java.util.Map<String, Object> renderJsonArray(JsonNode array) {
+        JsonNode first = array.get(0);
+        java.util.List<String> fields = new java.util.ArrayList<>();
+        first.fieldNames().forEachRemaining(fields::add);
+        return fields.size() <= 4
+                ? renderJsonTable(array, fields)
+                : renderJsonList(array);
+    }
+
+    private static java.util.Map<String, Object> renderJsonTable(JsonNode array, java.util.List<String> fields) {
+        java.util.List<java.util.Map<String, Object>> columns = fields.stream()
+                .<java.util.Map<String, Object>>map(name -> java.util.Map.of("name", name, "display_name", name))
+                .toList();
+        java.util.List<java.util.Map<String, Object>> rows = new java.util.ArrayList<>();
+        for (JsonNode item : array) {
+            java.util.Map<String, Object> row = new java.util.LinkedHashMap<>();
+            for (String field : fields) {
+                JsonNode val = item.get(field);
+                row.put(field, val == null ? "" : (val.isTextual() ? val.asText() : val.toString()));
+            }
+            rows.add(row);
+        }
+        java.util.Map<String, Object> table = new java.util.LinkedHashMap<>();
+        table.put("tag", "table");
+        table.put("columns", columns);
+        table.put("rows", rows);
+        table.put("page_size", 10);
+        table.put("row_height", "low");
+        return cardOf(null, java.util.List.of(table));
+    }
+
+    private static java.util.Map<String, Object> renderJsonList(JsonNode array) {
+        java.util.List<Object> elements = new java.util.ArrayList<>();
+        for (JsonNode item : array) {
+            StringBuilder sb = new StringBuilder();
+            item.fields().forEachRemaining(e -> {
+                String val = e.getValue().isTextual() ? e.getValue().asText() : e.getValue().toString();
+                sb.append("**").append(e.getKey()).append("**: ").append(val).append("\n");
+            });
+            elements.add(java.util.Map.of(
+                "tag", "div",
+                "text", java.util.Map.of("tag", "lark_md", "content", sb.toString().trim())
+            ));
+        }
+        return cardOf(null, elements);
+    }
+
+    private static java.util.Map<String, Object> cardOf(java.util.Map<String, Object> header, java.util.List<?> elements) {
+        java.util.Map<String, Object> card = new java.util.LinkedHashMap<>();
+        card.put("schema", "2.0");
+        card.put("config", java.util.Map.of("wide_screen_mode", true));
+        if (header != null) card.put("header", header);
+        card.put("body", java.util.Map.of("elements", elements));
+        return card;
+    }
 }

--- a/mateclaw-server/src/main/java/vip/mate/channel/feishu/FeishuCardFormatter.java
+++ b/mateclaw-server/src/main/java/vip/mate/channel/feishu/FeishuCardFormatter.java
@@ -3,6 +3,10 @@ package vip.mate.channel.feishu;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
 import java.util.regex.Pattern;
 
 final class FeishuCardFormatter {
@@ -50,7 +54,7 @@ final class FeishuCardFormatter {
 
     // ==================== 渲染层 ====================
 
-    static java.util.Map<String, Object> render(String content, ContentFormat format) {
+    static Map<String, Object> render(String content, ContentFormat format) {
         return switch (format) {
             case JSON      -> renderJson(content);
             case MARKDOWN  -> renderMarkdown(content);
@@ -58,27 +62,27 @@ final class FeishuCardFormatter {
         };
     }
 
-    private static java.util.Map<String, Object> renderMarkdown(String content) {
+    private static Map<String, Object> renderMarkdown(String content) {
         return cardOf(
-            java.util.Map.of("title", java.util.Map.of("tag", "plain_text", "content", "AI 助手")),
-            java.util.List.of(java.util.Map.of(
+            Map.of("title", Map.of("tag", "plain_text", "content", "AI 助手")),
+            List.of(Map.of(
                 "tag", "div",
-                "text", java.util.Map.of("tag", "lark_md", "content", content)
+                "text", Map.of("tag", "lark_md", "content", content)
             ))
         );
     }
 
-    private static java.util.Map<String, Object> renderLongText(String content) {
+    private static Map<String, Object> renderLongText(String content) {
         return cardOf(
             null,
-            java.util.List.of(java.util.Map.of(
+            List.of(Map.of(
                 "tag", "div",
-                "text", java.util.Map.of("tag", "plain_text", "content", content)
+                "text", Map.of("tag", "plain_text", "content", content)
             ))
         );
     }
 
-    private static java.util.Map<String, Object> renderJson(String content) {
+    private static Map<String, Object> renderJson(String content) {
         try {
             JsonNode node = MAPPER.readTree(content);
             if (node.isObject()) return renderJsonObject(node);
@@ -87,82 +91,82 @@ final class FeishuCardFormatter {
         return renderLongText(content);
     }
 
-    private static java.util.Map<String, Object> renderJsonObject(JsonNode node) {
-        java.util.List<Object> elements = new java.util.ArrayList<>();
+    private static Map<String, Object> renderJsonObject(JsonNode node) {
+        List<Object> elements = new ArrayList<>();
         node.fields().forEachRemaining(entry -> {
             String key = entry.getKey();
             String value = entry.getValue().isTextual()
                     ? entry.getValue().asText()
                     : entry.getValue().toString();
-            elements.add(java.util.Map.of(
+            elements.add(Map.of(
                 "tag", "column_set",
                 "flex_mode", "none",
-                "columns", java.util.List.of(
-                    java.util.Map.of("tag", "column", "width", "weighted", "weight", 1,
-                        "elements", java.util.List.of(java.util.Map.of("tag", "div",
-                            "text", java.util.Map.of("tag", "plain_text", "content", key)))),
-                    java.util.Map.of("tag", "column", "width", "weighted", "weight", 2,
-                        "elements", java.util.List.of(java.util.Map.of("tag", "div",
-                            "text", java.util.Map.of("tag", "plain_text", "content", value))))
+                "columns", List.of(
+                    Map.of("tag", "column", "width", "weighted", "weight", 1,
+                        "elements", List.of(Map.of("tag", "div",
+                            "text", Map.of("tag", "plain_text", "content", key)))),
+                    Map.of("tag", "column", "width", "weighted", "weight", 2,
+                        "elements", List.of(Map.of("tag", "div",
+                            "text", Map.of("tag", "plain_text", "content", value))))
                 )
             ));
         });
         return cardOf(null, elements);
     }
 
-    private static java.util.Map<String, Object> renderJsonArray(JsonNode array) {
+    private static Map<String, Object> renderJsonArray(JsonNode array) {
         JsonNode first = array.get(0);
-        java.util.List<String> fields = new java.util.ArrayList<>();
+        List<String> fields = new ArrayList<>();
         first.fieldNames().forEachRemaining(fields::add);
         return fields.size() <= 4
                 ? renderJsonTable(array, fields)
                 : renderJsonList(array);
     }
 
-    private static java.util.Map<String, Object> renderJsonTable(JsonNode array, java.util.List<String> fields) {
-        java.util.List<java.util.Map<String, Object>> columns = fields.stream()
-                .<java.util.Map<String, Object>>map(name -> java.util.Map.of("name", name, "display_name", name))
+    private static Map<String, Object> renderJsonTable(JsonNode array, List<String> fields) {
+        List<Map<String, Object>> columns = fields.stream()
+                .<Map<String, Object>>map(name -> Map.of("name", name, "display_name", name))
                 .toList();
-        java.util.List<java.util.Map<String, Object>> rows = new java.util.ArrayList<>();
+        List<Map<String, Object>> rows = new ArrayList<>();
         for (JsonNode item : array) {
-            java.util.Map<String, Object> row = new java.util.LinkedHashMap<>();
+            Map<String, Object> row = new LinkedHashMap<>();
             for (String field : fields) {
                 JsonNode val = item.get(field);
                 row.put(field, val == null ? "" : (val.isTextual() ? val.asText() : val.toString()));
             }
             rows.add(row);
         }
-        java.util.Map<String, Object> table = new java.util.LinkedHashMap<>();
+        Map<String, Object> table = new LinkedHashMap<>();
         table.put("tag", "table");
         table.put("columns", columns);
         table.put("rows", rows);
         table.put("page_size", 10);
         table.put("row_height", "low");
-        return cardOf(null, java.util.List.of(table));
+        return cardOf(null, List.of(table));
     }
 
-    private static java.util.Map<String, Object> renderJsonList(JsonNode array) {
-        java.util.List<Object> elements = new java.util.ArrayList<>();
+    private static Map<String, Object> renderJsonList(JsonNode array) {
+        List<Object> elements = new ArrayList<>();
         for (JsonNode item : array) {
             StringBuilder sb = new StringBuilder();
             item.fields().forEachRemaining(e -> {
                 String val = e.getValue().isTextual() ? e.getValue().asText() : e.getValue().toString();
                 sb.append("**").append(e.getKey()).append("**: ").append(val).append("\n");
             });
-            elements.add(java.util.Map.of(
+            elements.add(Map.of(
                 "tag", "div",
-                "text", java.util.Map.of("tag", "lark_md", "content", sb.toString().trim())
+                "text", Map.of("tag", "lark_md", "content", sb.toString().trim())
             ));
         }
         return cardOf(null, elements);
     }
 
-    private static java.util.Map<String, Object> cardOf(java.util.Map<String, Object> header, java.util.List<?> elements) {
-        java.util.Map<String, Object> card = new java.util.LinkedHashMap<>();
+    private static Map<String, Object> cardOf(Map<String, Object> header, List<?> elements) {
+        Map<String, Object> card = new LinkedHashMap<>();
         card.put("schema", "2.0");
-        card.put("config", java.util.Map.of("wide_screen_mode", true));
+        card.put("config", Map.of("wide_screen_mode", true));
         if (header != null) card.put("header", header);
-        card.put("body", java.util.Map.of("elements", elements));
+        card.put("body", Map.of("elements", elements));
         return card;
     }
 }

--- a/mateclaw-server/src/main/java/vip/mate/channel/feishu/FeishuCardFormatter.java
+++ b/mateclaw-server/src/main/java/vip/mate/channel/feishu/FeishuCardFormatter.java
@@ -1,0 +1,50 @@
+package vip.mate.channel.feishu;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import java.util.regex.Pattern;
+
+final class FeishuCardFormatter {
+
+    enum ContentFormat { JSON, MARKDOWN, LONG_TEXT, PLAIN_TEXT }
+
+    private static final ObjectMapper MAPPER = new ObjectMapper();
+    private static final int JSON_MAX_LEN = 32_000;
+    private static final Pattern HEADER    = Pattern.compile("(?m)^#{1,6}\\s");
+    private static final Pattern TABLE_SEP = Pattern.compile("(?m)^\\|[\\s|:-]+\\|\\s*$");
+
+    private FeishuCardFormatter() {}
+
+    static ContentFormat detect(String content) {
+        if (content == null || content.isBlank()) return ContentFormat.PLAIN_TEXT;
+        String s = content.trim();
+
+        if ((s.startsWith("{") || s.startsWith("[")) && s.length() <= JSON_MAX_LEN) {
+            try {
+                JsonNode node = MAPPER.readTree(s);
+                if (node.isObject() && !node.isEmpty()) return ContentFormat.JSON;
+                if (node.isArray() && node.size() > 0 && node.get(0).isObject()) return ContentFormat.JSON;
+            } catch (Exception ignored) {}
+        }
+
+        if (s.contains("```"))               return ContentFormat.MARKDOWN;
+        if (HEADER.matcher(s).find())         return ContentFormat.MARKDOWN;
+        if (TABLE_SEP.matcher(s).find())      return ContentFormat.MARKDOWN;
+        if (bulletCount(s) >= 2)              return ContentFormat.MARKDOWN;
+
+        if (s.length() > 300 && s.contains("\n\n")) return ContentFormat.LONG_TEXT;
+
+        return ContentFormat.PLAIN_TEXT;
+    }
+
+    private static long bulletCount(String s) {
+        return s.lines()
+                .filter(line -> {
+                    String t = line.stripLeading();
+                    return t.startsWith("- ") || t.startsWith("* ")
+                            || t.matches("^\\d+\\.\\s.*");
+                })
+                .count();
+    }
+}

--- a/mateclaw-server/src/main/java/vip/mate/channel/feishu/FeishuCardFormatter.java
+++ b/mateclaw-server/src/main/java/vip/mate/channel/feishu/FeishuCardFormatter.java
@@ -36,13 +36,16 @@ final class FeishuCardFormatter {
         }
 
         if (s.contains("```")) {
-            String extracted = extractJsonCodeBlock(s);
-            if (extracted != null && extracted.length() <= JSON_MAX_LEN) {
-                try {
-                    JsonNode node = MAPPER.readTree(extracted);
-                    if (node.isObject() && !node.isEmpty()) return ContentFormat.JSON;
-                    if (node.isArray() && node.size() > 0 && node.get(0).isObject()) return ContentFormat.JSON;
-                } catch (Exception ignored) {}
+            Matcher cm = JSON_CODE_BLOCK.matcher(s);
+            while (cm.find()) {
+                String extracted = cm.group(1).strip();
+                if (extracted.length() <= JSON_MAX_LEN) {
+                    try {
+                        JsonNode node = MAPPER.readTree(extracted);
+                        if (node.isObject() && !node.isEmpty()) return ContentFormat.JSON;
+                        if (node.isArray() && node.size() > 0 && node.get(0).isObject()) return ContentFormat.JSON;
+                    } catch (Exception ignored) {}
+                }
             }
             return ContentFormat.MARKDOWN;
         }
@@ -107,8 +110,9 @@ final class FeishuCardFormatter {
             if (node.isArray())  return renderJsonArray(node);
         } catch (Exception ignored) {}
 
-        String extracted = extractJsonCodeBlock(content);
-        if (extracted != null) {
+        Matcher rm = JSON_CODE_BLOCK.matcher(content);
+        while (rm.find()) {
+            String extracted = rm.group(1).strip();
             try {
                 JsonNode node = MAPPER.readTree(extracted);
                 if (node.isObject()) return renderJsonObject(node);

--- a/mateclaw-server/src/main/java/vip/mate/channel/feishu/FeishuCardFormatter.java
+++ b/mateclaw-server/src/main/java/vip/mate/channel/feishu/FeishuCardFormatter.java
@@ -7,6 +7,7 @@ import java.util.ArrayList;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
 final class FeishuCardFormatter {
@@ -17,6 +18,8 @@ final class FeishuCardFormatter {
     private static final int JSON_MAX_LEN = 32_000;
     private static final Pattern HEADER    = Pattern.compile("(?m)^#{1,6}\\s");
     private static final Pattern TABLE_SEP = Pattern.compile("(?m)^\\|[\\s|:-]+\\|\\s*$");
+    private static final Pattern JSON_CODE_BLOCK =
+            Pattern.compile("(?s)```(?:json)?\\s*([\\[{][\\s\\S]*?[\\]\\}])\\s*```");
 
     private FeishuCardFormatter() {}
 
@@ -32,7 +35,17 @@ final class FeishuCardFormatter {
             } catch (Exception ignored) {}
         }
 
-        if (s.contains("```"))               return ContentFormat.MARKDOWN;
+        if (s.contains("```")) {
+            String extracted = extractJsonCodeBlock(s);
+            if (extracted != null && extracted.length() <= JSON_MAX_LEN) {
+                try {
+                    JsonNode node = MAPPER.readTree(extracted);
+                    if (node.isObject() && !node.isEmpty()) return ContentFormat.JSON;
+                    if (node.isArray() && node.size() > 0 && node.get(0).isObject()) return ContentFormat.JSON;
+                } catch (Exception ignored) {}
+            }
+            return ContentFormat.MARKDOWN;
+        }
         if (HEADER.matcher(s).find())         return ContentFormat.MARKDOWN;
         if (TABLE_SEP.matcher(s).find())      return ContentFormat.MARKDOWN;
         if (bulletCount(s) >= 2)              return ContentFormat.MARKDOWN;
@@ -50,6 +63,11 @@ final class FeishuCardFormatter {
                             || t.matches("^\\d+\\.\\s.*");
                 })
                 .count();
+    }
+
+    private static String extractJsonCodeBlock(String s) {
+        Matcher m = JSON_CODE_BLOCK.matcher(s);
+        return m.find() ? m.group(1).strip() : null;
     }
 
     // ==================== 渲染层 ====================
@@ -88,6 +106,15 @@ final class FeishuCardFormatter {
             if (node.isObject()) return renderJsonObject(node);
             if (node.isArray())  return renderJsonArray(node);
         } catch (Exception ignored) {}
+
+        String extracted = extractJsonCodeBlock(content);
+        if (extracted != null) {
+            try {
+                JsonNode node = MAPPER.readTree(extracted);
+                if (node.isObject()) return renderJsonObject(node);
+                if (node.isArray())  return renderJsonArray(node);
+            } catch (Exception ignored) {}
+        }
         return renderLongText(content);
     }
 

--- a/mateclaw-server/src/main/java/vip/mate/channel/feishu/FeishuChannelAdapter.java
+++ b/mateclaw-server/src/main/java/vip/mate/channel/feishu/FeishuChannelAdapter.java
@@ -52,6 +52,8 @@ import java.util.concurrent.TimeUnit;
  * - enable_quoted_context: 是否拉取被引用消息内容注入到 prompt（默认 true）
  * - silent_disconnect_threshold_seconds: WebSocket 静默断连阈值（默认 1800，0 禁用）
  * - stale_event_threshold_seconds: 过滤旧事件阈值（默认 30，0 禁用）
+ * - card_format: 卡片格式化模式 "auto"（默认）| "always" | "never"
+ *               auto: 根据内容自动检测；always: 全部包卡片；never: 全部纯文本（降级/调试用）
  *
  * @author MateClaw Team
  */
@@ -1244,13 +1246,22 @@ public class FeishuChannelAdapter extends AbstractChannelAdapter {
         }
 
         ensureTokenValid();
-        List<String> chunks = splitTextForFeishu(content, MAX_TEXT_MESSAGE_CHARS);
-        if (chunks.size() > 1) {
-            log.info("[feishu] Splitting message into {} chunks ({} chars total) before send",
-                    chunks.size(), content.length());
+
+        String cardFormat = getConfigString("card_format", "auto");
+
+        if ("never".equals(cardFormat)) {
+            splitTextForFeishu(content, MAX_TEXT_MESSAGE_CHARS)
+                    .forEach(c -> sendOneTextChunk(targetId, c));
+            return;
         }
-        for (String chunk : chunks) {
-            sendOneTextChunk(targetId, chunk);
+
+        FeishuCardFormatter.ContentFormat fmt = FeishuCardFormatter.detect(content);
+
+        if ("always".equals(cardFormat) || fmt != FeishuCardFormatter.ContentFormat.PLAIN_TEXT) {
+            sendCard(targetId, FeishuCardFormatter.render(content, fmt));
+        } else {
+            splitTextForFeishu(content, MAX_TEXT_MESSAGE_CHARS)
+                    .forEach(c -> sendOneTextChunk(targetId, c));
         }
     }
 
@@ -1279,6 +1290,56 @@ public class FeishuChannelAdapter extends AbstractChannelAdapter {
 
         } catch (Exception e) {
             log.error("[feishu] Failed to send message: {}", e.getMessage(), e);
+        }
+    }
+
+    public void sendCard(String targetId, Map<String, Object> cardJson) {
+        String apiBase = getApiBaseUrl();
+        String receiveIdType = targetId.startsWith("ou_") ? "open_id" : "chat_id";
+        try {
+            String jsonBody = objectMapper.writeValueAsString(Map.of(
+                    "receive_id", targetId,
+                    "msg_type", "interactive",
+                    "content", objectMapper.writeValueAsString(cardJson)
+            ));
+            HttpRequest request = HttpRequest.newBuilder()
+                    .uri(URI.create(apiBase + "/open-apis/im/v1/messages?receive_id_type=" + receiveIdType))
+                    .header("Content-Type", "application/json; charset=utf-8")
+                    .header("Authorization", "Bearer " + tenantAccessToken)
+                    .POST(HttpRequest.BodyPublishers.ofString(jsonBody))
+                    .build();
+            HttpResponse<String> response = httpClient.send(request, HttpResponse.BodyHandlers.ofString());
+            if (response.statusCode() != 200) {
+                log.warn("[feishu] Send card failed: status={}, body={}", response.statusCode(), response.body());
+            } else {
+                log.debug("[feishu] Card sent to {} (type={})", targetId, receiveIdType);
+            }
+        } catch (Exception e) {
+            log.error("[feishu] Failed to send card: {}", e.getMessage(), e);
+        }
+    }
+
+    public void updateCard(String messageId, Map<String, Object> cardJson) {
+        String apiBase = getApiBaseUrl();
+        try {
+            String jsonBody = objectMapper.writeValueAsString(Map.of(
+                    "msg_type", "interactive",
+                    "content", objectMapper.writeValueAsString(cardJson)
+            ));
+            HttpRequest request = HttpRequest.newBuilder()
+                    .uri(URI.create(apiBase + "/open-apis/im/v1/messages/" + messageId))
+                    .header("Content-Type", "application/json; charset=utf-8")
+                    .header("Authorization", "Bearer " + tenantAccessToken)
+                    .method("PATCH", HttpRequest.BodyPublishers.ofString(jsonBody))
+                    .build();
+            HttpResponse<String> response = httpClient.send(request, HttpResponse.BodyHandlers.ofString());
+            if (response.statusCode() != 200) {
+                log.warn("[feishu] Update card failed: status={}, body={}", response.statusCode(), response.body());
+            } else {
+                log.debug("[feishu] Card updated: messageId={}", messageId);
+            }
+        } catch (Exception e) {
+            log.error("[feishu] Failed to update card: {}", e.getMessage(), e);
         }
     }
 

--- a/mateclaw-server/src/main/java/vip/mate/channel/feishu/FeishuChannelAdapter.java
+++ b/mateclaw-server/src/main/java/vip/mate/channel/feishu/FeishuChannelAdapter.java
@@ -1294,6 +1294,11 @@ public class FeishuChannelAdapter extends AbstractChannelAdapter {
     }
 
     public void sendCard(String targetId, Map<String, Object> cardJson) {
+        if (httpClient == null) {
+            log.warn("[feishu] Channel not started, cannot send card");
+            return;
+        }
+        ensureTokenValid();
         String apiBase = getApiBaseUrl();
         String receiveIdType = targetId.startsWith("ou_") ? "open_id" : "chat_id";
         try {
@@ -1320,6 +1325,11 @@ public class FeishuChannelAdapter extends AbstractChannelAdapter {
     }
 
     public void updateCard(String messageId, Map<String, Object> cardJson) {
+        if (httpClient == null) {
+            log.warn("[feishu] Channel not started, cannot update card");
+            return;
+        }
+        ensureTokenValid();
         String apiBase = getApiBaseUrl();
         try {
             String jsonBody = objectMapper.writeValueAsString(Map.of(

--- a/mateclaw-server/src/test/java/vip/mate/channel/feishu/FeishuCardFormatterTest.java
+++ b/mateclaw-server/src/test/java/vip/mate/channel/feishu/FeishuCardFormatterTest.java
@@ -105,4 +105,85 @@ class FeishuCardFormatterTest {
     void detect_shortPlainText_returnsPlainText() {
         assertEquals(PLAIN_TEXT, FeishuCardFormatter.detect("好的，明白了。"));
     }
+
+    // ==================== render() ====================
+
+    @Test
+    @SuppressWarnings("unchecked")
+    void render_markdown_hasSchema20AndLarkMdElement() {
+        String md = "## 标题\n- 第一条\n- 第二条";
+        var card = FeishuCardFormatter.render(md, MARKDOWN);
+
+        assertEquals("2.0", card.get("schema"));
+        assertNotNull(card.get("header"));
+        var body = (java.util.Map<String, Object>) card.get("body");
+        var elems = (java.util.List<java.util.Map<String, Object>>) body.get("elements");
+        assertEquals("div", elems.get(0).get("tag"));
+        var text = (java.util.Map<String, Object>) elems.get(0).get("text");
+        assertEquals("lark_md", text.get("tag"));
+        assertEquals(md, text.get("content"));
+    }
+
+    @Test
+    @SuppressWarnings("unchecked")
+    void render_longText_hasNoHeaderAndPlainTextElement() {
+        String content = "x".repeat(150) + "\n\n" + "y".repeat(155);
+        var card = FeishuCardFormatter.render(content, LONG_TEXT);
+
+        assertEquals("2.0", card.get("schema"));
+        assertNull(card.get("header"));
+        var body = (java.util.Map<String, Object>) card.get("body");
+        var elems = (java.util.List<java.util.Map<String, Object>>) body.get("elements");
+        var text = (java.util.Map<String, Object>) elems.get(0).get("text");
+        assertEquals("plain_text", text.get("tag"));
+        assertEquals(content, text.get("content"));
+    }
+
+    @Test
+    @SuppressWarnings("unchecked")
+    void render_jsonObject_hasColumnSetPerField() {
+        var card = FeishuCardFormatter.render("{\"name\":\"Alice\",\"score\":95}", JSON);
+
+        assertEquals("2.0", card.get("schema"));
+        assertNull(card.get("header")); // 摘要卡片无 header
+        var body = (java.util.Map<String, Object>) card.get("body");
+        var elems = (java.util.List<java.util.Map<String, Object>>) body.get("elements");
+        assertEquals(2, elems.size()); // 2 个字段 → 2 个 column_set
+        assertEquals("column_set", elems.get(0).get("tag"));
+    }
+
+    @Test
+    @SuppressWarnings("unchecked")
+    void render_jsonArrayFewColumns_usesTableComponent() {
+        var card = FeishuCardFormatter.render("[{\"a\":1,\"b\":2},{\"a\":3,\"b\":4}]", JSON);
+
+        var body = (java.util.Map<String, Object>) card.get("body");
+        var elems = (java.util.List<java.util.Map<String, Object>>) body.get("elements");
+        assertEquals("table", elems.get(0).get("tag"));
+        assertNotNull(elems.get(0).get("columns"));
+        assertNotNull(elems.get(0).get("rows"));
+    }
+
+    @Test
+    @SuppressWarnings("unchecked")
+    void render_jsonArrayManyColumns_usesDivPerItem() {
+        // >4 字段 → 列表卡片（每条 item 一个 div）
+        var card = FeishuCardFormatter.render(
+                "[{\"a\":1,\"b\":2,\"c\":3,\"d\":4,\"e\":5}]", JSON);
+
+        var body = (java.util.Map<String, Object>) card.get("body");
+        var elems = (java.util.List<java.util.Map<String, Object>>) body.get("elements");
+        assertEquals("div", elems.get(0).get("tag"));
+    }
+
+    @Test
+    @SuppressWarnings("unchecked")
+    void render_plainText_fallsBackToLongTextLayout() {
+        // PLAIN_TEXT 传入 render()（"always" 模式下会发生）→ 应渲染为 plain_text div
+        var card = FeishuCardFormatter.render("简单的一句话", PLAIN_TEXT);
+        var body = (java.util.Map<String, Object>) card.get("body");
+        var elems = (java.util.List<java.util.Map<String, Object>>) body.get("elements");
+        var text = (java.util.Map<String, Object>) elems.get(0).get("text");
+        assertEquals("plain_text", text.get("tag"));
+    }
 }

--- a/mateclaw-server/src/test/java/vip/mate/channel/feishu/FeishuCardFormatterTest.java
+++ b/mateclaw-server/src/test/java/vip/mate/channel/feishu/FeishuCardFormatterTest.java
@@ -1,0 +1,108 @@
+package vip.mate.channel.feishu;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static vip.mate.channel.feishu.FeishuCardFormatter.ContentFormat.*;
+
+class FeishuCardFormatterTest {
+
+    // ==================== detect() ====================
+
+    @Test
+    void detect_nullAndBlank_returnsPlainText() {
+        assertEquals(PLAIN_TEXT, FeishuCardFormatter.detect(null));
+        assertEquals(PLAIN_TEXT, FeishuCardFormatter.detect(""));
+        assertEquals(PLAIN_TEXT, FeishuCardFormatter.detect("   "));
+    }
+
+    @Test
+    void detect_nonEmptyJsonObject_returnsJson() {
+        assertEquals(JSON, FeishuCardFormatter.detect("{\"key\": \"value\"}"));
+    }
+
+    @Test
+    void detect_jsonArrayOfObjects_returnsJson() {
+        assertEquals(JSON, FeishuCardFormatter.detect("[{\"a\": 1, \"b\": 2}]"));
+    }
+
+    @Test
+    void detect_emptyJsonObject_doesNotReturnJson() {
+        assertNotEquals(JSON, FeishuCardFormatter.detect("{}"));
+    }
+
+    @Test
+    void detect_primitiveArray_doesNotReturnJson() {
+        assertNotEquals(JSON, FeishuCardFormatter.detect("[1, 2, 3]"));
+        assertNotEquals(JSON, FeishuCardFormatter.detect("[\"a\", \"b\"]"));
+    }
+
+    @Test
+    void detect_invalidJsonStartingWithBrace_doesNotReturnJson() {
+        assertNotEquals(JSON, FeishuCardFormatter.detect("{invalid json}"));
+        assertNotEquals(JSON, FeishuCardFormatter.detect("[引用消息: 你好]"));
+    }
+
+    @Test
+    void detect_jsonOverSizeLimit_doesNotReturnJson() {
+        String big = "{\"k\":\"" + "x".repeat(32_000) + "\"}";
+        assertNotEquals(JSON, FeishuCardFormatter.detect(big));
+    }
+
+    @Test
+    void detect_codeBlock_returnsMarkdown() {
+        assertEquals(MARKDOWN, FeishuCardFormatter.detect("看这段代码：\n```java\nint x = 1;\n```"));
+    }
+
+    @Test
+    void detect_h2Header_returnsMarkdown() {
+        assertEquals(MARKDOWN, FeishuCardFormatter.detect("## 标题\n正文内容"));
+    }
+
+    @Test
+    void detect_h1Header_returnsMarkdown() {
+        assertEquals(MARKDOWN, FeishuCardFormatter.detect("# 一级标题"));
+    }
+
+    @Test
+    void detect_tableSeparatorRow_returnsMarkdown() {
+        assertEquals(MARKDOWN, FeishuCardFormatter.detect("| A | B |\n|---|---|\n| 1 | 2 |"));
+    }
+
+    @Test
+    void detect_hrTripleDash_doesNotReturnMarkdown() {
+        assertEquals(PLAIN_TEXT, FeishuCardFormatter.detect("---"));
+    }
+
+    @Test
+    void detect_twoBulletItems_returnsMarkdown() {
+        assertEquals(MARKDOWN, FeishuCardFormatter.detect("- 第一条\n- 第二条"));
+    }
+
+    @Test
+    void detect_oneBulletItem_doesNotReturnMarkdown() {
+        assertNotEquals(MARKDOWN, FeishuCardFormatter.detect("- 只有一条"));
+    }
+
+    @Test
+    void detect_inlineDashNotBullet_doesNotReturnMarkdown() {
+        String text = "价格 - 折扣 = 净价\n成本 - 税 = 实际";
+        assertNotEquals(MARKDOWN, FeishuCardFormatter.detect(text));
+    }
+
+    @Test
+    void detect_longTextWithDoubleNewline_returnsLongText() {
+        String text = "x".repeat(150) + "\n\n" + "y".repeat(155);
+        assertEquals(LONG_TEXT, FeishuCardFormatter.detect(text));
+    }
+
+    @Test
+    void detect_longTextWithoutDoubleNewline_returnsPlainText() {
+        assertEquals(PLAIN_TEXT, FeishuCardFormatter.detect("x".repeat(400)));
+    }
+
+    @Test
+    void detect_shortPlainText_returnsPlainText() {
+        assertEquals(PLAIN_TEXT, FeishuCardFormatter.detect("好的，明白了。"));
+    }
+}

--- a/mateclaw-server/src/test/java/vip/mate/channel/feishu/FeishuCardFormatterTest.java
+++ b/mateclaw-server/src/test/java/vip/mate/channel/feishu/FeishuCardFormatterTest.java
@@ -159,9 +159,20 @@ class FeishuCardFormatterTest {
 
         var body = (java.util.Map<String, Object>) card.get("body");
         var elems = (java.util.List<java.util.Map<String, Object>>) body.get("elements");
-        assertEquals("table", elems.get(0).get("tag"));
-        assertNotNull(elems.get(0).get("columns"));
-        assertNotNull(elems.get(0).get("rows"));
+        var table = elems.get(0);
+        assertEquals("table", table.get("tag"));
+
+        var columns = (java.util.List<java.util.Map<String, Object>>) table.get("columns");
+        assertEquals(2, columns.size());
+        assertEquals("a", columns.get(0).get("name"));
+        assertEquals("b", columns.get(1).get("name"));
+
+        var rows = (java.util.List<java.util.Map<String, Object>>) table.get("rows");
+        assertEquals(2, rows.size());
+        assertEquals("1", rows.get(0).get("a"));
+        assertEquals("2", rows.get(0).get("b"));
+        assertEquals("3", rows.get(1).get("a"));
+        assertEquals("4", rows.get(1).get("b"));
     }
 
     @Test
@@ -173,7 +184,14 @@ class FeishuCardFormatterTest {
 
         var body = (java.util.Map<String, Object>) card.get("body");
         var elems = (java.util.List<java.util.Map<String, Object>>) body.get("elements");
-        assertEquals("div", elems.get(0).get("tag"));
+        var div = elems.get(0);
+        assertEquals("div", div.get("tag"));
+
+        var text = (java.util.Map<String, Object>) div.get("text");
+        assertEquals("lark_md", text.get("tag"));
+        String content = (String) text.get("content");
+        assertTrue(content.contains("**a**:"), "content should contain **a**: field");
+        assertTrue(content.contains("**b**:"), "content should contain **b**: field");
     }
 
     @Test

--- a/mateclaw-server/src/test/java/vip/mate/channel/feishu/FeishuCardFormatterTest.java
+++ b/mateclaw-server/src/test/java/vip/mate/channel/feishu/FeishuCardFormatterTest.java
@@ -262,4 +262,12 @@ class FeishuCardFormatterTest {
         assertEquals(2, elems.size()); // 2 fields → 2 column_sets
         assertEquals("column_set", elems.get(0).get("tag"));
     }
+
+    @Test
+    void detect_markdownWithJsonBlockSecond_returnsJson() {
+        // JSON 对象代码块在原始数组块后面，应该仍能识别
+        // 原始数组 [1,2,3] 不是有效 JSON，但 JSON 对象 {"ok":true} 是
+        String md = "示例：\n```\n[1,2,3]\n```\n\n结果：\n```json\n{\"ok\":true,\"count\":5}\n```";
+        assertEquals(JSON, FeishuCardFormatter.detect(md));
+    }
 }

--- a/mateclaw-server/src/test/java/vip/mate/channel/feishu/FeishuCardFormatterTest.java
+++ b/mateclaw-server/src/test/java/vip/mate/channel/feishu/FeishuCardFormatterTest.java
@@ -204,4 +204,62 @@ class FeishuCardFormatterTest {
         var text = (java.util.Map<String, Object>) elems.get(0).get("text");
         assertEquals("plain_text", text.get("tag"));
     }
+
+    // ==================== detect() — Markdown 内嵌 JSON ====================
+
+    @Test
+    void detect_markdownWithJsonObjectCodeBlock_returnsJson() {
+        String md = "上海今天天气如下：\n\n```json\n{\"city\":\"上海\",\"temp\":24}\n```";
+        assertEquals(JSON, FeishuCardFormatter.detect(md));
+    }
+
+    @Test
+    void detect_markdownWithBareCodeBlockContainingJson_returnsJson() {
+        // 无 json 标注的代码块，内容是 JSON 对象也识别
+        String md = "结果：\n```\n{\"status\":\"ok\"}\n```";
+        assertEquals(JSON, FeishuCardFormatter.detect(md));
+    }
+
+    @Test
+    void detect_markdownWithJsonArrayCodeBlock_returnsJson() {
+        String md = "列表：\n```json\n[{\"a\":1},{\"a\":2}]\n```";
+        assertEquals(JSON, FeishuCardFormatter.detect(md));
+    }
+
+    @Test
+    void detect_markdownWithPrimitiveArrayCodeBlock_returnsMarkdown() {
+        // 原始类型数组不识别为 JSON
+        String md = "数据：\n```json\n[1,2,3]\n```";
+        assertEquals(MARKDOWN, FeishuCardFormatter.detect(md));
+    }
+
+    @Test
+    void detect_markdownWithNonJsonCodeBlock_returnsMarkdown() {
+        // Python 代码块不识别为 JSON
+        String md = "代码：\n```python\nprint('hello')\n```";
+        assertEquals(MARKDOWN, FeishuCardFormatter.detect(md));
+    }
+
+    @Test
+    void detect_markdownWithEmptyJsonObjectCodeBlock_returnsMarkdown() {
+        // 空对象 {} 不识别为 JSON
+        String md = "空：\n```json\n{}\n```";
+        assertEquals(MARKDOWN, FeishuCardFormatter.detect(md));
+    }
+
+    // ==================== render() — Markdown 内嵌 JSON ====================
+
+    @Test
+    @SuppressWarnings("unchecked")
+    void render_markdownWithJsonCodeBlock_rendersAsSummaryCard() {
+        String md = "天气结果：\n```json\n{\"city\":\"上海\",\"temp\":24}\n```";
+        var card = FeishuCardFormatter.render(md, JSON);
+
+        assertEquals("2.0", card.get("schema"));
+        assertNull(card.get("header")); // JSON object card has no header
+        var body = (java.util.Map<String, Object>) card.get("body");
+        var elems = (java.util.List<java.util.Map<String, Object>>) body.get("elements");
+        assertEquals(2, elems.size()); // 2 fields → 2 column_sets
+        assertEquals("column_set", elems.get(0).get("tag"));
+    }
 }


### PR DESCRIPTION
Closes #141

## 概述

为飞书渠道适配器增加 Interactive Card（JSON v2）发送侧支持。Agent 回复中的结构化数据（JSON、Markdown、长文本）将自动以卡片形式渲染，而非裸文本。

## 核心设计

新增 `FeishuCardFormatter`（package-private 静态工具类），负责内容检测和卡片构建：

**检测优先级（`detect()`）：**

| 内容形态 | 判定条件 | 渲染结果 |
|---|---|---|
| JSON 对象/数组 | 合法 JSON（≤32KB），非原始类型数组 | 摘要卡片 / 表格卡片 |
| Markdown 内嵌 JSON | ` ```json ` 代码块内含合法 JSON（遍历所有代码块） | 同上 |
| Markdown | 含代码块、标题、表格分隔行或 ≥2 列表项 | lark_md 富文本卡片 |
| 长文本 | >300字 + 含 `\n\n` | plain_text 卡片 |
| 短纯文本 | 无结构 | 原有文本消息（不走卡片） |

**卡片渲染（`render()`）：**

- JSON 对象 → 双列 `column_set` 摘要卡片
- JSON 数组 ≤4 字段 → `table` 组件
- JSON 数组 >4 字段 → 每条 `div`（lark_md 格式）
- Markdown → `lark_md` div（header: "AI 助手"）
- 长文本 → `plain_text` div

## 改动文件

| 文件 | 改动类型 |
|---|---|
| `FeishuCardFormatter.java` | 新建 |
| `FeishuCardFormatterTest.java` | 新建（32 个单元测试） |
| `FeishuChannelAdapter.java` | 修改 |

**`FeishuChannelAdapter` 变动：**
- `sendMessage()` 根据 `card_format` 配置路由（`auto` 默认 \| `always` \| `never`）
- 新增 `sendCard(String targetId, Map<String, Object> cardJson)`（`ou_` 前缀自动识别 `receive_id_type`）
- 新增 `updateCard(String messageId, Map<String, Object> cardJson)`（PATCH API，流式更新预留接口）

**配置项**（渠道 configJson，无需前端表单改动）：
```json
"card_format": "auto"
```

## 测试

- `FeishuCardFormatterTest`：32 个单元测试，覆盖全部检测路径和渲染分支
- `FeishuTextSplitTest`：7 个原有测试，未回归

## 不在本次范围

- 卡片交互回调（`card.action.trigger`）
- `updateCard()` 接入 Agent 流式输出管道（接口已预留）
- 文件 / 图片发送（见 #160）