### PR TITLE
fix(embedding): use chatModel field for protocol routing instead of providerId matching

### DIFF
--- a/mateclaw-server/src/main/java/vip/mate/llm/embedding/EmbeddingModelFactory.java
+++ b/mateclaw-server/src/main/java/vip/mate/llm/embedding/EmbeddingModelFactory.java
@@ -111,9 +111,16 @@ public class EmbeddingModelFactory {
                     "Embedding provider '" + modelConfig.getProvider() + "' not found in mate_model_provider");
         }
 
-        EmbeddingProtocol protocol = EmbeddingProtocol.fromProviderId(provider.getProviderId());
-        log.info("[EmbeddingFactory] Building embedding model: provider={}, model={}, protocol={}",
-                provider.getProviderId(), modelConfig.getModelName(), protocol);
+        // Use chatModel column (same signal as ModelProtocol.fromChatModel) rather than
+        // providerId substring matching. dashscope-compat has "dashscope" in its id but
+        // uses OpenAIChatModel + compatible-mode URL — routing it to DASHSCOPE_EMBEDDING
+        // causes DashScopeApi to construct a native path that returns 404 against the
+        // compat base URL.
+        EmbeddingProtocol protocol = "DashScopeChatModel".equals(provider.getChatModel())
+                ? EmbeddingProtocol.DASHSCOPE_EMBEDDING
+                : EmbeddingProtocol.OPENAI_EMBEDDING;
+        log.info("[EmbeddingFactory] Building embedding model: provider={}, chatModel={}, model={}, protocol={}",
+                provider.getProviderId(), provider.getChatModel(), modelConfig.getModelName(), protocol);
 
         return switch (protocol) {
             case DASHSCOPE_EMBEDDING -> buildDashScope(provider, modelConfig);

--- a/mateclaw-server/src/main/java/vip/mate/llm/model/EmbeddingProtocol.java
+++ b/mateclaw-server/src/main/java/vip/mate/llm/model/EmbeddingProtocol.java
@@ -10,7 +10,9 @@ package vip.mate.llm.model;
  *   <li>OpenAI 兼容协议的 embedding 统一走 /v1/embeddings</li>
  * </ul>
  * <p>
- * 通过 {@link #fromProviderId} 从 providerId 推断协议，新增 provider 时只需扩展这里。
+ * <b>注意</b>：{@link EmbeddingModelFactory} 现在优先通过 {@code chatModel} 列判断协议
+ * （与 {@link ModelProtocol#fromChatModel} 保持一致），{@link #fromProviderId} 已不再使用。
+ * 保留该方法仅作参考；不要在新代码中调用它。
  *
  * @author MateClaw Team
  */


### PR DESCRIPTION
## Summary

Fixes #166

`EmbeddingModelFactory` 之前通过 `EmbeddingProtocol.fromProviderId()` 判断 embedding 协议，该方法对 providerId 做字符串匹配（含 "dashscope" → DASHSCOPE_EMBEDDING）。

`dashscope-compat` 供应商的 `providerId` 含 "dashscope"，但实际使用 OpenAI 兼容模式 URL。路由到 `DASHSCOPE_EMBEDDING` 后，DashScope SDK 会构造原生路径（`/api/v1/services/embeddings/...`），对兼容模式 base URL 发请求 → **404**。

改为使用 `chatModel` 列（与 `ModelProtocol.fromChatModel()` chat 路径保持一致）：
- `chatModel = "DashScopeChatModel"` → `DASHSCOPE_EMBEDDING`（原生 SDK）
- 其他 → `OPENAI_EMBEDDING`（OpenAI 兼容）

## Test plan

- [ ] 在 `dashscope-compat` 供应商下添加 `text-embedding-v3`，点击「测试」，应返回成功
- [ ] 在原生 `dashscope` 供应商下添加 `text-embedding-v4`，点击「测试」，应返回成功
- [ ] Chat 模型连通性测试不受影响