### PR TITLE
fix(embedding): respect requireApiKey flag in OpenAI-compatible embedding factory

### DIFF
--- a/mateclaw-server/src/main/java/vip/mate/llm/embedding/EmbeddingModelFactory.java
+++ b/mateclaw-server/src/main/java/vip/mate/llm/embedding/EmbeddingModelFactory.java
@@ -158,7 +158,11 @@ public class EmbeddingModelFactory {
                     "Provider '" + provider.getProviderId() + "' 未完成配置（缺少 API Key 或 Base URL）");
         }
         String apiKey = provider.getApiKey();
-        if (!providerService.hasUsableApiKey(apiKey)) {
+        // Mirror the chat model builder: only require an API key when the provider row says so.
+        // Keyless providers (requireApiKey=false, e.g. OpenCode, local Ollama) must be allowed
+        // through; otherwise their cloud-model connection test passes but embedding test fails.
+        boolean keyRequired = !Boolean.FALSE.equals(provider.getRequireApiKey());
+        if (keyRequired && !providerService.hasUsableApiKey(apiKey)) {
             throw new MateClawException("err.embedding.openai_key_invalid",
                     "Provider API Key 未配置或无效: " + provider.getProviderId());
         }
@@ -168,10 +172,11 @@ public class EmbeddingModelFactory {
                     "Provider Base URL 未配置: " + provider.getProviderId());
         }
 
+        String effectiveApiKey = providerService.hasUsableApiKey(apiKey) ? apiKey.trim() : "";
         // 最简构造：不做 chat-specific 的 header 重写、reasoning patch 等
         OpenAiApi api = OpenAiApi.builder()
                 .baseUrl(baseUrl)
-                .apiKey(apiKey.trim())
+                .apiKey(effectiveApiKey)
                 .embeddingsPath(resolveEmbeddingsPath(baseUrl))
                 .build();
 


### PR DESCRIPTION
## Summary

Fixes #167

`EmbeddingModelFactory.buildOpenAi()` 无条件要求 API Key 存在，导致 `requireApiKey=false` 的供应商（Ollama、OpenCode 等）在 Embedding 测试时失败，而同一供应商的 Chat 连通性测试却正常通过。

镜像 Chat 构建路径的逻辑，先判断 `requireApiKey` 标志：
- `requireApiKey=false` → 允许空 key，传 `""` 给 `OpenAiApi.builder()`
- `requireApiKey=true`（默认）→ 保持原有校验逻辑

## Test plan

- [ ] Ollama 本地供应商下的 embedding 模型「测试」应成功（`requireApiKey=false`）
- [ ] OpenCode 供应商下的 embedding 模型「测试」应成功
- [ ] 正常需要 API Key 的供应商在 key 为空时仍报错