### PR TITLE
fix(llm): add text-embedding- prefix to DashScope native model allow-list

### DIFF
--- a/mateclaw-server/src/main/java/vip/mate/llm/service/ModelDiscoveryService.java
+++ b/mateclaw-server/src/main/java/vip/mate/llm/service/ModelDiscoveryService.java
@@ -141,8 +141,8 @@ public class ModelDiscoveryService {
 
     /**
      * Allow-list prefixes for DashScope models that are known to work on the native
-     * chat protocol. An empty set means "no prefix filter" (we still apply DENY).
-     * Extend conservatively as new families are verified.
+     * protocol (chat or embedding). An empty set means "no prefix filter" (we still
+     * apply DENY). Extend conservatively as new families are verified.
      */
     private static final Set<String> DASHSCOPE_NATIVE_ALLOW_PREFIXES = Set.of(
             "qwen-",          // qwen-max / qwen-plus / qwen-turbo / qwen-coder-* / qwen-long
@@ -151,7 +151,8 @@ public class ModelDiscoveryService {
             "deepseek-",      // deepseek-v3.x / deepseek-r1*
             "baichuan",
             "yi-",
-            "llama"
+            "llama",
+            "text-embedding-" // DashScope embedding models (text-embedding-v1/v2/v3/v4)
     );
 
     // ==================== 模型发现 ====================


### PR DESCRIPTION
## Summary

Fixes #168

`ModelDiscoveryService.DASHSCOPE_NATIVE_ALLOW_PREFIXES` 仅包含 Chat 模型前缀，缺少嵌入模型前缀 `text-embedding-`，导致用户在原生 DashScope 供应商下手动添加 `text-embedding-v1/v2/v3/v4` 时被 `assertModelIdAcceptable()` 拒绝。

将 `"text-embedding-"` 加入允许前缀列表，覆盖 DashScope 全系列嵌入模型。

## Test plan

- [ ] 在原生 `dashscope` 供应商「管理模型」中手动添加 `text-embedding-v4`，应成功
- [ ] 添加后点击「测试」，应正常调用 DashScope 原生嵌入 endpoint
- [ ] 非法前缀（如 `gpt-4o`）仍应被拒绝