### PR TITLE
fix(llm): exclude soft-deleted models from uniqueness check in validateModel

### DIFF
--- a/mateclaw-server/src/main/java/vip/mate/llm/service/ModelConfigService.java
+++ b/mateclaw-server/src/main/java/vip/mate/llm/service/ModelConfigService.java
@@ -354,6 +354,7 @@ public class ModelConfigService {
         ModelConfigEntity duplicate = modelConfigMapper.selectOne(new LambdaQueryWrapper<ModelConfigEntity>()
                 .eq(ModelConfigEntity::getProvider, entity.getProvider())
                 .eq(ModelConfigEntity::getModelName, entity.getModelName())
+                .eq(ModelConfigEntity::getDeleted, 0)
                 .ne(currentId != null, ModelConfigEntity::getId, currentId)
                 .last("LIMIT 1"));
         if (duplicate != null) {


### PR DESCRIPTION
## Summary

Fixes #169

`ModelConfigService.validateModel()` 的重复性检查未过滤软删除记录（`deleted=1`），导致删除某个模型后，立即重新添加相同 `(provider, modelName)` 组合时报「模型标识已存在」，但管理界面中已找不到该模型。

显式添加 `.eq(ModelConfigEntity::getDeleted, 0)` 条件，确保仅检查逻辑上存在的记录。

> **注**：`ModelConfigEntity` 使用 `@TableLogic` 注解 `deleted` 字段，但在 `LambdaQueryWrapper` 的手动查询中，MyBatis Plus 并未自动追加软删除过滤，因此需显式声明。

## Test plan

- [ ] 添加嵌入模型 → 删除 → 重新添加相同标识，应成功（不再报「已存在」）
- [ ] 正常的重复添加（未删除时）仍应报错