### PR TITLE
fix(llm): add @Slf4j and log.error to ModelConfigController embedding test

### DIFF
--- a/mateclaw-server/src/main/java/vip/mate/llm/controller/ModelConfigController.java
+++ b/mateclaw-server/src/main/java/vip/mate/llm/controller/ModelConfigController.java
@@ -3,6 +3,7 @@ package vip.mate.llm.controller;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.web.bind.annotation.*;
 import vip.mate.common.result.R;
 import vip.mate.llm.model.*;
@@ -22,6 +23,7 @@ import java.util.List;
 import java.util.Map;
 import vip.mate.workspace.core.annotation.RequireWorkspaceRole;
 
+@Slf4j
 @Tag(name = "模型配置管理")
 @RestController
 @RequestMapping("/api/v1/models")
@@ -264,6 +266,7 @@ public class ModelConfigController {
             result.put("model", config.getModelName());
             result.put("message", "连通性测试成功");
         } catch (Exception e) {
+            log.error("[EmbeddingTest] modelId={} test failed", modelId, e);
             result.put("success", false);
             result.put("message", e.getMessage());
         }


### PR DESCRIPTION
## Summary

Fixes #175

`ModelConfigController.testEmbedding()` 的 catch 块静默吞掉异常，只将 `e.getMessage()` 写入响应体，完整堆栈不写日志，导致 Embedding 测试失败时无法从服务端排查根本原因。

- 为 `ModelConfigController` 类添加 `@Slf4j`
- 在 catch 块中添加 `log.error("[EmbeddingTest] modelId={} test failed", modelId, e)`

## Test plan

- [ ] Embedding 模型使用无效 API Key 测试，后端日志应出现完整的异常堆栈
- [ ] Embedding 模型使用正确配置测试，日志无异常，前端返回成功