### PR TITLE
fix(llm): use query param for modelId in provider model delete/test endpoints

### DIFF
--- a/mateclaw-server/src/main/java/vip/mate/llm/controller/ModelConfigController.java
+++ b/mateclaw-server/src/main/java/vip/mate/llm/controller/ModelConfigController.java
@@ -154,10 +154,10 @@ public class ModelConfigController {
     }
 
     @Operation(summary = "从 Provider 删除模型")
-    @DeleteMapping("/{providerId}/models/{modelId}")
+    @DeleteMapping("/{providerId}/models")
     @RequireWorkspaceRole("admin")
     public R<ProviderInfoDTO> removeProviderModel(@PathVariable String providerId,
-                                                  @PathVariable String modelId) {
+                                                  @RequestParam String modelId) {
         return R.ok(modelProviderService.removeModel(providerId, modelId));
     }
 
@@ -224,10 +224,10 @@ public class ModelConfigController {
     }
 
     @Operation(summary = "测试单个模型可用性")
-    @PostMapping("/{providerId}/models/{modelId}/test")
+    @PostMapping("/{providerId}/models/test")
     @RequireWorkspaceRole("admin")
     public R<TestResult> testModel(@PathVariable String providerId,
-                                    @PathVariable String modelId) {
+                                   @RequestParam String modelId) {
         return R.ok(modelDiscoveryService.testModel(providerId, modelId));
     }
 

--- a/mateclaw-ui/src/api/index.ts
+++ b/mateclaw-ui/src/api/index.ts
@@ -494,7 +494,7 @@ export const modelApi = {
   addProviderModel: (providerId: string, data: any) =>
     http.post(`/models/${providerId}/models`, data),
   removeProviderModel: (providerId: string, modelId: string) =>
-    http.delete(`/models/${providerId}/models/${encodeURIComponent(modelId)}`),
+    http.delete(`/models/${providerId}/models`, { params: { modelId } }),
   getActive: () => http.get('/models/active'),
   setActive: (data: { providerId: string; model: string }) =>
     http.put('/models/active', data),
@@ -506,7 +506,7 @@ export const modelApi = {
   testConnection: (providerId: string) =>
     http.post(`/models/${providerId}/test-connection`),
   testModel: (providerId: string, modelId: string) =>
-    http.post(`/models/${providerId}/models/${encodeURIComponent(modelId)}/test`),
+    http.post(`/models/${providerId}/models/test`, null, { params: { modelId } }),
 
   // ==================== RFC-074: enabled / catalog ====================
   /** Full provider catalog including enabled=false rows; powers the Add Provider drawer. */


### PR DESCRIPTION
## Summary

Fixes #174

含斜杠的模型 ID（如 `Qwen/Qwen3-Embedding-8B`、`Pro/deepseek-ai/DeepSeek-V3`）在通过 path variable 传递时，即使前端已做 `encodeURIComponent`，Spring MVC 仍将 `%2F` 视为路径分隔符，导致路由匹配失败返回 **404**。

涉及两个接口：

| 接口 | 修复前 | 修复后 |
|---|---|---|
| 删除模型 | `DELETE /{providerId}/models/{modelId}` | `DELETE /{providerId}/models?modelId=...` |
| 测试模型 | `POST /{providerId}/models/{modelId}/test` | `POST /{providerId}/models/test?modelId=...` |

前端 `api/index.ts` 的 `removeProviderModel` 和 `testModel` 同步更新。

## Test plan

- [ ] 对 `Qwen/Qwen3-Embedding-8B` 点击删除，应成功（不再 404）
- [ ] 对 `deepseek-ai/DeepSeek-V3` 点击「测试连通性」，应返回结果（不再 404）
- [ ] 无斜杠的模型 ID（如 `gpt-4o`）操作不受影响