### PR TITLE
fix(llm): classify "network connection error" as retryable SERVER_ERROR (#178)

### DIFF
--- a/mateclaw-server/src/main/java/vip/mate/agent/graph/NodeStreamingChatHelper.java
+++ b/mateclaw-server/src/main/java/vip/mate/agent/graph/NodeStreamingChatHelper.java
@@ -333,7 +333,7 @@ public class NodeStreamingChatHelper {
      */
     private static final int CONTENT_REPEAT_CHECK_INTERVAL = 200;
 
-    private static final int MAX_RETRIES = 5;
+    private static final int MAX_RETRIES = 10;
     // RATE_LIMIT: fail fast to failover chain — staying on the same
     // provider during a rate-limit window wastes time without recovery.
     // SERVER_ERROR keeps MAX_RETRIES (upstream flaps often self-heal).

--- a/mateclaw-server/src/main/java/vip/mate/agent/graph/NodeStreamingChatHelper.java
+++ b/mateclaw-server/src/main/java/vip/mate/agent/graph/NodeStreamingChatHelper.java
@@ -449,7 +449,12 @@ public class NodeStreamingChatHelper {
                 // Reactor Netty wraps the raw socket cause in WebClientRequestException;
                 // surface that wrapper too so retries fire even when the cause chain
                 // string is "WebClientRequestException ...; nested ... SSLException".
-                || msg.contains("WebClientRequestException")) {
+                || msg.contains("WebClientRequestException")
+                // SiliconFlow and some other providers return "network connection error"
+                // in the response body when their backend is under high load or the
+                // upstream connection to the model server is disrupted. This is a
+                // transient server-side failure — classify as retryable.
+                || msg.contains("network connection error")) {
             return ErrorType.SERVER_ERROR;
         }
         return ErrorType.UNKNOWN;
@@ -1502,6 +1507,11 @@ public class NodeStreamingChatHelper {
         if (msg.contains("rate_limit") || msg.contains("429")) return "Rate limit exceeded, please retry later";
         if (msg.contains("timeout") || msg.contains("Timeout")) return "Request timeout, please retry";
         if (msg.contains("502") || msg.contains("503") || msg.contains("504")) return "Model service temporarily unavailable";
+        // SiliconFlow and similar providers surface "network connection error" when their
+        // backend is under high load or the upstream model connection is disrupted.
+        // Treat this as a transient failure so the user gets a retry-oriented message.
+        if (combined.contains("network connection error"))
+            return "Model service network error, please retry in a moment";
         // 截断过长的原始消息
         return msg.length() > 100 ? msg.substring(0, 100) + "..." : msg;
     }


### PR DESCRIPTION
## 问题

Closes #178

飞书渠道频繁收到 "LLM request failed: network connection error."。

部分 Provider（如 SiliconFlow）在后端过载时，会在响应体中携带 `"network connection error"` 字符串。`classifyError()` 没有覆盖此模式，导致 fallthrough 到 `ErrorType.UNKNOWN`，**第一次失败就直接报错给用户，完全跳过重试逻辑**。

## 修复

**`NodeStreamingChatHelper.java`**

- `classifyError()`：将 `"network connection error"` 加入 `SERVER_ERROR` 识别模式 → 触发最多 5 次指数退避重试，偶发的 Provider 过载会在重试中自愈
- `extractUserFriendlyError()`：映射为 "Model service network error, please retry in a moment"，避免裸错误字符串暴露给用户

## 测试

- [ ] Provider 返回含 "network connection error" 的响应体时，`classifyError()` 返回 `SERVER_ERROR`
- [ ] 重试逻辑正常触发（最多 5 次，指数退避）
- [ ] 所有重试失败后，用户看到友好提示而非裸 "network connection error"