### PR TITLE
fix(tool-guard): CredentialExposureGuardian reads DB rules so enabled flag works (#181)

### DIFF
--- a/mateclaw-server/src/main/java/vip/mate/tool/guard/guardian/CredentialExposureGuardian.java
+++ b/mateclaw-server/src/main/java/vip/mate/tool/guard/guardian/CredentialExposureGuardian.java
@@ -2,6 +2,7 @@ package vip.mate.tool.guard.guardian;
 
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Component;
+import vip.mate.tool.guard.engine.ToolGuardRuleRegistry;
 import vip.mate.tool.guard.model.*;
 
 import java.util.ArrayList;
@@ -16,6 +17,9 @@ import java.util.regex.Pattern;
  * <p>
  * 检测工具参数中可能包含的敏感凭据信息。
  * alwaysRun=true，不受 guarded tools 范围限制。
+ * <p>
+ * 优先从 ToolGuardRuleRegistry 加载数据库规则（支持 enabled 开关）；
+ * 若数据库中无凭据规则则 fallback 到内置硬编码规则。
  */
 @Slf4j
 @Component
@@ -25,7 +29,7 @@ public class CredentialExposureGuardian implements ToolGuardGuardian {
 
     private record CredentialRule(String ruleId, String pattern, String title, String description) {}
 
-    private static final List<CredentialRule> RULES = List.of(
+    private static final List<CredentialRule> BUILTIN_RULES = List.of(
             new CredentialRule("CRED_PASSWORD_ASSIGN",
                     "(password|secret|api[_-]?key|token)\\s*=\\s*['\"]?\\S{8,}",
                     "凭据信息暴露",
@@ -48,6 +52,12 @@ public class CredentialExposureGuardian implements ToolGuardGuardian {
                     "检测到 GitHub Personal Access Token")
     );
 
+    private final ToolGuardRuleRegistry ruleRegistry;
+
+    public CredentialExposureGuardian(ToolGuardRuleRegistry ruleRegistry) {
+        this.ruleRegistry = ruleRegistry;
+    }
+
     @Override
     public boolean supports(ToolInvocationContext context) {
         return true;
@@ -68,8 +78,47 @@ public class CredentialExposureGuardian implements ToolGuardGuardian {
         String raw = context.rawArguments();
         if (raw == null || raw.isEmpty()) return List.of();
 
+        // 优先使用数据库规则（已按 enabled=true 过滤，禁用规则不在列表内）
+        List<ToolGuardRuleEntity> dbRules = ruleRegistry.getAllEnabled().stream()
+                .filter(r -> GuardCategory.CREDENTIAL_EXPOSURE.name().equals(r.getCategory()))
+                .toList();
+
+        if (!dbRules.isEmpty()) {
+            return evaluateDbRules(dbRules, raw, context);
+        }
+
+        // 数据库无凭据规则时 fallback 到内置规则
+        return evaluateBuiltinRules(raw, context);
+    }
+
+    private List<GuardFinding> evaluateDbRules(List<ToolGuardRuleEntity> dbRules,
+                                                String raw, ToolInvocationContext context) {
         List<GuardFinding> findings = new ArrayList<>();
-        for (CredentialRule rule : RULES) {
+        for (ToolGuardRuleEntity rule : dbRules) {
+            Pattern p = ruleRegistry.getCompiledPattern(rule.getPattern());
+            Matcher matcher = p.matcher(raw);
+            if (matcher.find()) {
+                String snippet = extractSnippet(raw, matcher.start(), 30);
+                findings.add(new GuardFinding(
+                        rule.getRuleId(),
+                        GuardSeverity.valueOf(rule.getSeverity()),
+                        GuardCategory.CREDENTIAL_EXPOSURE,
+                        rule.getName(),
+                        rule.getDescription(),
+                        rule.getRemediation(),
+                        context.toolName(),
+                        null,
+                        rule.getPattern(),
+                        maskCredential(snippet)
+                ));
+            }
+        }
+        return findings;
+    }
+
+    private List<GuardFinding> evaluateBuiltinRules(String raw, ToolInvocationContext context) {
+        List<GuardFinding> findings = new ArrayList<>();
+        for (CredentialRule rule : BUILTIN_RULES) {
             Pattern p = COMPILED.computeIfAbsent(rule.pattern,
                     r -> Pattern.compile(r, Pattern.CASE_INSENSITIVE));
             Matcher matcher = p.matcher(raw);

--- a/mateclaw-server/src/main/java/vip/mate/tool/guard/service/ToolGuardRuleSeedService.java
+++ b/mateclaw-server/src/main/java/vip/mate/tool/guard/service/ToolGuardRuleSeedService.java
@@ -330,6 +330,14 @@ public class ToolGuardRuleSeedService implements ApplicationRunner {
                 GuardSeverity.HIGH, GuardCategory.CREDENTIAL_EXPOSURE, "BLOCK",
                 null, gf("CRED_PRIVATE_KEY"), 140));
 
+        rules.add(rule("CRED_JWT_TOKEN", gn("CRED_JWT_TOKEN"), "eyJ[A-Za-z0-9_-]{10,}\\.eyJ[A-Za-z0-9_-]{10,}\\.[A-Za-z0-9_-]+",
+                GuardSeverity.HIGH, GuardCategory.CREDENTIAL_EXPOSURE, "NEEDS_APPROVAL",
+                null, gf("CRED_JWT_TOKEN"), 140));
+
+        rules.add(rule("CRED_GITHUB_TOKEN", gn("CRED_GITHUB_TOKEN"), "gh[pousr]_[A-Za-z0-9_]{36,}",
+                GuardSeverity.HIGH, GuardCategory.CREDENTIAL_EXPOSURE, "NEEDS_APPROVAL",
+                null, gf("CRED_GITHUB_TOKEN"), 140));
+
         return rules;
     }
 

--- a/mateclaw-server/src/main/resources/messages.properties
+++ b/mateclaw-server/src/main/resources/messages.properties
@@ -154,6 +154,10 @@ guard.CRED_AWS_KEY.name=AWS Access Key \u6cc4\u9732
 guard.CRED_AWS_KEY.fix=\u4f7f\u7528 IAM Role \u6216 AWS Secrets Manager
 guard.CRED_PRIVATE_KEY.name=\u79c1\u94a5\u6cc4\u9732
 guard.CRED_PRIVATE_KEY.fix=\u8bf7\u52ff\u5728\u53c2\u6570\u4e2d\u4f20\u9012\u79c1\u94a5
+guard.CRED_JWT_TOKEN.name=JWT Token \u6cc4\u9732
+guard.CRED_JWT_TOKEN.fix=\u8bf7\u52ff\u5728\u53c2\u6570\u4e2d\u4f20\u9012 JWT Token
+guard.CRED_GITHUB_TOKEN.name=GitHub Token \u6cc4\u9732
+guard.CRED_GITHUB_TOKEN.fix=\u8bf7\u52ff\u5728\u53c2\u6570\u4e2d\u4f20\u9012 GitHub Token
 
 # --- Exception Messages (structured keys) ---
 err.auth.invalid_credentials=\u7528\u6237\u540d\u6216\u5bc6\u7801\u9519\u8bef

--- a/mateclaw-server/src/main/resources/messages_en.properties
+++ b/mateclaw-server/src/main/resources/messages_en.properties
@@ -154,6 +154,10 @@ guard.CRED_AWS_KEY.name=AWS Access Key leak
 guard.CRED_AWS_KEY.fix=Use IAM Role or AWS Secrets Manager
 guard.CRED_PRIVATE_KEY.name=Private key leak
 guard.CRED_PRIVATE_KEY.fix=Do not pass private keys in parameters
+guard.CRED_JWT_TOKEN.name=JWT Token leak
+guard.CRED_JWT_TOKEN.fix=Do not pass JWT tokens in parameters
+guard.CRED_GITHUB_TOKEN.name=GitHub Token leak
+guard.CRED_GITHUB_TOKEN.fix=Do not pass GitHub tokens in parameters
 
 # --- WorkspacePathGuard ---
 guard.path.not_allowed=Path is outside workspace boundary: {0}, allowed root: {1}


### PR DESCRIPTION
## 问题

Closes #181

在「安全工具防护」中禁用 Credential exposure 规则后，规则仍然匹配并生效。

`CredentialExposureGuardian` 使用硬编码静态列表 `BUILTIN_RULES`，完全不读 `ToolGuardRuleRegistry`，因此 `enabled=false` 对其无效。

## 修复

**`CredentialExposureGuardian.java`**
- 注入 `ToolGuardRuleRegistry`
- `evaluate()` 优先从 registry 取 `category = CREDENTIAL_EXPOSURE` 的启用规则匹配（禁用规则不在列表内，自然不触发）
- DB 无凭据规则时 fallback 到内置硬编码规则，保持向后兼容

**`ToolGuardRuleSeedService.java`**
- 补上缺失的 `CRED_JWT_TOKEN` 和 `CRED_GITHUB_TOKEN` seed 规则，使全部 5 条凭据规则均可通过 UI enabled 开关控制

**`messages.properties` / `messages_en.properties`**
- 补充两条新 seed 规则的 i18n 条目

## 测试

- [ ] 禁用某条凭据规则后，对应模式不再触发拦截
- [ ] 启用状态下规则正常拦截
- [ ] 全部禁用时 fallback 到内置规则（保底保护）
- [ ] 重启后 `CRED_JWT_TOKEN` / `CRED_GITHUB_TOKEN` 出现在规则列表并可操作