### PR TITLE
fix(channel/feishu): register all IM event handlers to prevent WebSocket disconnect

### DIFF
--- a/mateclaw-server/src/main/java/vip/mate/channel/feishu/FeishuChannelAdapter.java
+++ b/mateclaw-server/src/main/java/vip/mate/channel/feishu/FeishuChannelAdapter.java
@@ -377,7 +377,11 @@ public class FeishuChannelAdapter extends AbstractChannelAdapter implements Stre
                         }
                     }
                 })
-                // Silently ignore message reaction events to avoid HandlerNotFoundException
+                // Silently ignore all other IM events to avoid HandlerNotFoundException.
+                // When the SDK receives an event without a registered handler, it throws
+                // HandlerNotFoundException → SDK catches it and sends a 500 response →
+                // the Feishu server may close the WebSocket connection. The exception is
+                // swallowed inside the SDK so it never appears in application logs.
                 .onP2MessageReactionCreatedV1(new ImService.P2MessageReactionCreatedV1Handler() {
                     @Override
                     public void handle(com.lark.oapi.service.im.v1.model.P2MessageReactionCreatedV1 event) {}
@@ -386,10 +390,45 @@ public class FeishuChannelAdapter extends AbstractChannelAdapter implements Stre
                     @Override
                     public void handle(com.lark.oapi.service.im.v1.model.P2MessageReactionDeletedV1 event) {}
                 })
-                // Silently ignore bot added to chat event to avoid HandlerNotFoundException (#153)
+                .onP2MessageReadV1(new ImService.P2MessageReadV1Handler() {
+                    @Override
+                    public void handle(com.lark.oapi.service.im.v1.model.P2MessageReadV1 event) {}
+                })
+                .onP2MessageRecalledV1(new ImService.P2MessageRecalledV1Handler() {
+                    @Override
+                    public void handle(com.lark.oapi.service.im.v1.model.P2MessageRecalledV1 event) {}
+                })
                 .onP2ChatMemberBotAddedV1(new ImService.P2ChatMemberBotAddedV1Handler() {
                     @Override
                     public void handle(com.lark.oapi.service.im.v1.model.P2ChatMemberBotAddedV1 event) {}
+                })
+                .onP2ChatMemberBotDeletedV1(new ImService.P2ChatMemberBotDeletedV1Handler() {
+                    @Override
+                    public void handle(com.lark.oapi.service.im.v1.model.P2ChatMemberBotDeletedV1 event) {}
+                })
+                .onP2ChatMemberUserAddedV1(new ImService.P2ChatMemberUserAddedV1Handler() {
+                    @Override
+                    public void handle(com.lark.oapi.service.im.v1.model.P2ChatMemberUserAddedV1 event) {}
+                })
+                .onP2ChatMemberUserDeletedV1(new ImService.P2ChatMemberUserDeletedV1Handler() {
+                    @Override
+                    public void handle(com.lark.oapi.service.im.v1.model.P2ChatMemberUserDeletedV1 event) {}
+                })
+                .onP2ChatMemberUserWithdrawnV1(new ImService.P2ChatMemberUserWithdrawnV1Handler() {
+                    @Override
+                    public void handle(com.lark.oapi.service.im.v1.model.P2ChatMemberUserWithdrawnV1 event) {}
+                })
+                .onP2ChatUpdatedV1(new ImService.P2ChatUpdatedV1Handler() {
+                    @Override
+                    public void handle(com.lark.oapi.service.im.v1.model.P2ChatUpdatedV1 event) {}
+                })
+                .onP2ChatDisbandedV1(new ImService.P2ChatDisbandedV1Handler() {
+                    @Override
+                    public void handle(com.lark.oapi.service.im.v1.model.P2ChatDisbandedV1 event) {}
+                })
+                .onP2ChatAccessEventBotP2pChatEnteredV1(new ImService.P2ChatAccessEventBotP2pChatEnteredV1Handler() {
+                    @Override
+                    public void handle(com.lark.oapi.service.im.v1.model.P2ChatAccessEventBotP2pChatEnteredV1 event) {}
                 })
                 // Interactive card button clicks (Schema 2.0) — routed through cardDispatcher.
                 // The returned P2CardActionTriggerResponse is how Schema-2.0

--- a/mateclaw-server/src/main/resources/logback-spring.xml
+++ b/mateclaw-server/src/main/resources/logback-spring.xml
@@ -114,6 +114,9 @@
     <logger name="com.zaxxer.hikari" level="INFO"/>
     <logger name="io.netty" level="WARN"/>
 
+    <!-- 飞书 SDK：确保事件处理异常不被过滤（SDK 内部 HandlerNotFoundException 等） -->
+    <logger name="com.lark.oapi" level="WARN"/>
+
     <!-- ======================== Root ======================== -->
     <root level="INFO">
         <appender-ref ref="CONSOLE"/>


### PR DESCRIPTION
## Summary

- 注册所有飞书 IM 事件的空 handler，防止 `HandlerNotFoundException` 导致 WebSocket 断连
- 添加 `com.lark.oapi` 的 logback 配置，确保 SDK 内部异常可被观测

## Problem

飞书 SDK 的 `EventDispatcher` 对未注册 handler 的事件类型抛出 `HandlerNotFoundException`。该异常在 SDK 的 `ws.Client.handleDataFrame` 内部被 catch，SDK 发送 500 响应给飞书服务端，可能导致服务端主动断开 WebSocket 连接。异常完全在 SDK 内部吞掉，应用层无感知。

## Changes

**FeishuChannelAdapter.java** — 在 `createWsClient()` 中注册以下缺失的 IM 事件空 handler：
- `P2MessageReadV1` — 消息已读回执
- `P2MessageRecalledV1` — 消息撤回
- `P2ChatMemberBotDeletedV1` — 机器人被移出群
- `P2ChatMemberUserAddedV1` / `UserDeletedV1` / `UserWithdrawnV1`
- `P2ChatUpdatedV1` — 群信息更新
- `P2ChatDisbandedV1` — 群解散
- `P2ChatAccessEventBotP2pChatEnteredV1` — 机器人进入单聊

**logback-spring.xml** — 添加 `com.lark.oapi` 的 WARN 级别 logger

## Related

- 上游 Issue: larksuite/oapi-sdk-java#185
- 飞书 SDK 版本: oapi-sdk 2.6.1

## Test plan

- [ ] 部署后观察飞书 WebSocket 连接是否稳定
- [ ] 搜索日志确认无 `HandlerNotFoundException` 或 `handle message failed` 错误
- [ ] 验证消息收发、已读回执、群成员变动等场景正常