### PR TITLE
fix(feishu): ChannelMessageEventBridge 阻塞 WebSocket 事件分发导致消息丢失

### DIFF
--- a/mateclaw-server/src/main/java/vip/mate/channel/feishu/FeishuChannelAdapter.java
+++ b/mateclaw-server/src/main/java/vip/mate/channel/feishu/FeishuChannelAdapter.java
@@ -794,6 +794,7 @@ public class FeishuChannelAdapter extends AbstractChannelAdapter implements Stre
             HttpRequest request = HttpRequest.newBuilder()
                     .uri(URI.create(apiBase + "/open-apis/auth/v3/tenant_access_token/internal"))
                     .header("Content-Type", "application/json; charset=utf-8")
+                    .timeout(Duration.ofSeconds(10))
                     .POST(HttpRequest.BodyPublishers.ofString(jsonBody))
                     .build();
 

--- a/mateclaw-server/src/main/java/vip/mate/trigger/dispatch/ChannelMessageEventBridge.java
+++ b/mateclaw-server/src/main/java/vip/mate/trigger/dispatch/ChannelMessageEventBridge.java
@@ -3,6 +3,7 @@ package vip.mate.trigger.dispatch;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.context.event.EventListener;
+import org.springframework.scheduling.annotation.Async;
 import org.springframework.stereotype.Component;
 import vip.mate.channel.event.ChannelMessageReceivedEvent;
 import vip.mate.trigger.ingest.TriggerEventEnvelope;
@@ -31,6 +32,7 @@ public class ChannelMessageEventBridge {
 
     private final TriggerEventIngestService ingestService;
 
+    @Async
     @EventListener
     public void onChannelMessage(ChannelMessageReceivedEvent event) {
         if (event == null) return;


### PR DESCRIPTION
## Summary

- `ChannelMessageEventBridge.onChannelMessage()` 是同步 `@EventListener`，运行在 Lark SDK WebSocket 事件分发线程上，调用 `TriggerEventIngestService.ingest()` 执行数据库查询。当 DB 连接池繁忙时，阻塞事件分发线程，导致后续消息静默丢失
- 添加 `@Async` 使 trigger 处理运行在独立线程
- 给 `refreshTenantAccessToken()` HTTP 请求添加 10s 超时（之前无超时）

## Test plan

1. 配置飞书 WebSocket 长连接渠道
2. 触发耗时后台任务（知识库向量化等）使 DB 连接池高负载
3. 此期间通过飞书发送消息，验证消息不再丢失
4. 验证 trigger 功能正常（channel_message / content_match 模式）

Closes #208