### PR TITLE
feat(agent): Agent 级别工作目录覆盖

### DIFF
--- a/mateclaw-server/src/main/java/vip/mate/agent/AgentGraphBuilder.java
+++ b/mateclaw-server/src/main/java/vip/mate/agent/AgentGraphBuilder.java
@@ -358,13 +358,16 @@ public class AgentGraphBuilder {
         agent.topP = runtimeModel.getTopP();
         agent.toolCallingEnabled = toolCallingEnabled;
 
-        // 查找工作区活动目录
-        if (entity.getWorkspaceId() != null) {
+        // Agent 级别覆盖优先，否则继承工作区
+        if (entity.getWorkspaceBasePath() != null && !entity.getWorkspaceBasePath().isBlank()) {
+            agent.workspaceBasePath = entity.getWorkspaceBasePath();
+            log.info("Agent {} using agent-level basePath: {}", entity.getName(), agent.workspaceBasePath);
+        } else if (entity.getWorkspaceId() != null) {
             try {
                 var workspace = workspaceService.getById(entity.getWorkspaceId());
                 if (workspace != null && workspace.getBasePath() != null && !workspace.getBasePath().isBlank()) {
                     agent.workspaceBasePath = workspace.getBasePath();
-                    log.info("Agent {} bound to workspace basePath: {}", entity.getName(), agent.workspaceBasePath);
+                    log.info("Agent {} inherited workspace basePath: {}", entity.getName(), agent.workspaceBasePath);
                 }
             } catch (Exception e) {
                 log.warn("Failed to lookup workspace basePath for agent {}: {}", entity.getName(), e.getMessage());

--- a/mateclaw-server/src/main/java/vip/mate/agent/model/AgentEntity.java
+++ b/mateclaw-server/src/main/java/vip/mate/agent/model/AgentEntity.java
@@ -78,6 +78,10 @@ public class AgentEntity {
     /** 默认思考深度：off / low / medium / high / max，null 表示跟随模型默认 */
     private String defaultThinkingLevel;
 
+    /** Agent 级别的工作目录覆盖，为 null 时继承工作区 basePath */
+    @TableField(value = "workspace_base_path", updateStrategy = FieldStrategy.ALWAYS)
+    private String workspaceBasePath;
+
     @TableField(fill = FieldFill.INSERT)
     private LocalDateTime createTime;
 

--- a/mateclaw-server/src/main/resources/db/migration/h2/V121__agent_workspace_base_path.sql
+++ b/mateclaw-server/src/main/resources/db/migration/h2/V121__agent_workspace_base_path.sql
@@ -1,0 +1,3 @@
+-- V100: Add workspace_base_path column to mate_agent for Agent-level directory override.
+-- When set, this overrides the workspace-level basePath for this Agent only.
+ALTER TABLE mate_agent ADD COLUMN IF NOT EXISTS workspace_base_path VARCHAR(512) DEFAULT NULL;

--- a/mateclaw-server/src/main/resources/db/migration/mysql/V121__agent_workspace_base_path.sql
+++ b/mateclaw-server/src/main/resources/db/migration/mysql/V121__agent_workspace_base_path.sql
@@ -1,0 +1,3 @@
+-- V100: Add workspace_base_path column to mate_agent for Agent-level directory override.
+-- When set, this overrides the workspace-level basePath for this Agent only.
+ALTER TABLE mate_agent ADD COLUMN workspace_base_path VARCHAR(512) DEFAULT NULL;

--- a/mateclaw-ui/src/i18n/locales/en-US.ts
+++ b/mateclaw-ui/src/i18n/locales/en-US.ts
@@ -1163,6 +1163,8 @@ export default {
       extraInstructionsHint: 'Optional. Use for output format, process checklists, or boundary rules.',
       maxIterations: 'Max Iterations',
       defaultThinkingLevel: 'Default Thinking Level',
+      workspaceBasePath: 'Working Directory',
+      workspaceBasePathHint: 'Optional. Set a dedicated working directory for this employee (relative to workspace root). Leave blank to inherit the workspace default.',
       modelName: 'Model',
       modelGlobalDefault: 'Use global default',
       modelHint: 'Override the global default model for this employee. Leave blank to follow Settings → Models.',
@@ -1198,6 +1200,7 @@ export default {
       backstory: 'e.g. Spent 10 years in data — believes in asking the right question before writing SQL...',
       extraInstructions: 'Optional: output format, process checklist, or boundary rules...',
       tags: 'tag1,tag2',
+      workspaceBasePath: 'e.g. projects/code-review',
     },
     messages: {
       noDescription: 'No description',

--- a/mateclaw-ui/src/i18n/locales/zh-CN.ts
+++ b/mateclaw-ui/src/i18n/locales/zh-CN.ts
@@ -1055,6 +1055,8 @@ export default {
       extraInstructionsHint: '可选。用于细化输出格式、流程清单或边界规则。',
       maxIterations: '最大迭代次数',
       defaultThinkingLevel: '默认思考深度',
+      workspaceBasePath: '工作目录',
+      workspaceBasePathHint: '可选。为该员工指定独立的工作目录（相对于工作区根目录）。留空则继承工作区默认目录。',
       modelName: '模型',
       modelGlobalDefault: '使用全局默认模型',
       modelHint: '为该员工单独指定模型，留空则跟随「设置 → 模型」中的全局默认。',
@@ -1090,6 +1092,7 @@ export default {
       backstory: '例：在数据里待了十年，相信先问对问题再写 SQL...',
       extraInstructions: '可选：补充输出格式、流程清单或边界规则...',
       tags: 'tag1,tag2',
+      workspaceBasePath: '例如：projects/code-review',
     },
     messages: {
       noDescription: '暂无描述',

--- a/mateclaw-ui/src/types/index.ts
+++ b/mateclaw-ui/src/types/index.ts
@@ -43,6 +43,7 @@ export interface Agent {
   enabled: boolean
   icon?: string
   tags?: string
+  workspaceBasePath?: string
   createTime?: string
   updateTime?: string
 }

--- a/mateclaw-ui/src/views/Agents.vue
+++ b/mateclaw-ui/src/views/Agents.vue
@@ -271,6 +271,11 @@
                 <option value="max">{{ t('agents.thinkingLevels.max') }}</option>
               </select>
             </div>
+            <div class="form-group full-width">
+              <label class="form-label">{{ t('agents.fields.workspaceBasePath') }}</label>
+              <input v-model="form.workspaceBasePath" class="form-input" :placeholder="t('agents.placeholders.workspaceBasePath')" />
+              <p class="form-hint">{{ t('agents.fields.workspaceBasePathHint') }}</p>
+            </div>
             <!--
               Identity triad: role + goal + backstory map to H2 sections in
               the stored systemPrompt. The card tagline is derived from
@@ -703,6 +708,7 @@ const defaultForm = (): Partial<Agent> & { name: string; defaultThinkingLevel: s
   tags: '',
   enabled: true,
   defaultThinkingLevel: null,
+  workspaceBasePath: null,
 })
 
 const form = ref(defaultForm())
@@ -890,6 +896,7 @@ async function openEditModal(agent: Agent) {
     tags: agent.tags || '',
     enabled: agent.enabled,
     defaultThinkingLevel: (agent as any).defaultThinkingLevel || null,
+    workspaceBasePath: agent.workspaceBasePath || null,
   }
   profileForm.value = parsePrompt(agent.systemPrompt)
   modalTab.value = 'basic'


### PR DESCRIPTION
## Summary

当前 `WorkspacePathGuard` 的目录限制是工作区级别的 — 同一工作区下所有 Agent 共享同一个 `basePath`。实际场景中，一个工作区下可能有多个 Agent（代码审查、文档整理、数据分析等），但它们都能读写工作区下的任何文件，缺少 Agent 级别的目录隔离。

本 PR 为每个 Agent 新增可选的 `workspaceBasePath` 字段：
- 设置时：Agent 只能访问该子目录下的文件
- 未设置时：继承工作区的 `basePath`（原有行为不变）

## Changes

- **AgentEntity**: 新增 `workspaceBasePath` 字段
- **AgentGraphBuilder**: basePath 绑定逻辑改为 Agent 级别优先，否则继承工作区
- **Flyway V121**: `mate_agent` 表新增 `workspace_base_path` 列（H2 + MySQL）
- **Frontend**: Agent 编辑表单新增工作目录输入框
- **i18n**: 中英文翻译

## Test plan

1. `mvn compile` 编译通过
2. 启动应用，检查 `mate_agent` 表有 `workspace_base_path` 列
3. UI 测试：编辑 Agent → 设置工作目录 → 验证 Agent 只能访问该子目录下的文件
4. 回归测试：不设置 Agent 工作目录的 Agent → 继承工作区 basePath（原有行为不变）