### PR TITLE
fix(channel): Feishu message loss fix + Agent workspace basePath override

### DIFF
--- a/mateclaw-server/src/main/java/vip/mate/agent/AgentGraphBuilder.java
+++ b/mateclaw-server/src/main/java/vip/mate/agent/AgentGraphBuilder.java
@@ -358,13 +358,16 @@ public class AgentGraphBuilder {
         agent.topP = runtimeModel.getTopP();
         agent.toolCallingEnabled = toolCallingEnabled;
 
-        // 查找工作区活动目录
-        if (entity.getWorkspaceId() != null) {
+        // Agent 级别覆盖优先，否则继承工作区
+        if (entity.getWorkspaceBasePath() != null && !entity.getWorkspaceBasePath().isBlank()) {
+            agent.workspaceBasePath = entity.getWorkspaceBasePath();
+            log.info("Agent {} using agent-level basePath: {}", entity.getName(), agent.workspaceBasePath);
+        } else if (entity.getWorkspaceId() != null) {
             try {
                 var workspace = workspaceService.getById(entity.getWorkspaceId());
                 if (workspace != null && workspace.getBasePath() != null && !workspace.getBasePath().isBlank()) {
                     agent.workspaceBasePath = workspace.getBasePath();
-                    log.info("Agent {} bound to workspace basePath: {}", entity.getName(), agent.workspaceBasePath);
+                    log.info("Agent {} inherited workspace basePath: {}", entity.getName(), agent.workspaceBasePath);
                 }
             } catch (Exception e) {
                 log.warn("Failed to lookup workspace basePath for agent {}: {}", entity.getName(), e.getMessage());

--- a/mateclaw-server/src/main/java/vip/mate/agent/model/AgentEntity.java
+++ b/mateclaw-server/src/main/java/vip/mate/agent/model/AgentEntity.java
@@ -78,6 +78,10 @@ public class AgentEntity {
     /** 默认思考深度：off / low / medium / high / max，null 表示跟随模型默认 */
     private String defaultThinkingLevel;
 
+    /** Agent 级别的工作目录覆盖，为 null 时继承工作区 basePath */
+    @TableField(value = "workspace_base_path", updateStrategy = FieldStrategy.ALWAYS)
+    private String workspaceBasePath;
+
     @TableField(fill = FieldFill.INSERT)
     private LocalDateTime createTime;
 

--- a/mateclaw-server/src/main/java/vip/mate/channel/feishu/FeishuChannelAdapter.java
+++ b/mateclaw-server/src/main/java/vip/mate/channel/feishu/FeishuChannelAdapter.java
@@ -20,6 +20,9 @@ import vip.mate.channel.media.MediaUploadResult;
 import vip.mate.channel.model.ChannelEntity;
 import vip.mate.workspace.conversation.model.MessageContentPart;
 
+import com.github.benmanes.caffeine.cache.Cache;
+import com.github.benmanes.caffeine.cache.Caffeine;
+
 import java.io.InputStream;
 import java.net.URI;
 import java.net.http.HttpClient;
@@ -29,6 +32,7 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.StandardCopyOption;
 import java.time.Duration;
+import java.time.Instant;
 import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
@@ -80,8 +84,45 @@ public class FeishuChannelAdapter extends AbstractChannelAdapter implements Stre
     /** 定时 Token 刷新任务 */
     private ScheduledFuture<?> tokenRefreshFuture;
 
-    /** 消息去重：最近处理过的 message_id */
+    /** 消息去重：最近处理过的 message_id（实例级，处理重连回放和 SDK 双投递） */
     private final Set<String> processedMessageIds = ConcurrentHashMap.newKeySet();
+
+    /**
+     * 跨 adapter 全局去重：同一 app_id 的多个渠道实例共享此映射。
+     * <p>飞书 WS 长连接会把消息广播给同一 app 的所有活跃连接，当多个 adapter 使用相同
+     * app_id（例如同一个 bot 配置了多个渠道）时，每个 adapter 都会收到同一条消息。
+     * 全局去重确保一条消息只被一个 adapter 处理。
+     * <p>Key: app_id；Value: 已处理的 message_id 集合（大小超过 {@link #GLOBAL_DEDUP_MAX} 时半数淘汰）。
+     */
+    private static final ConcurrentHashMap<String, Set<String>> GLOBAL_PROCESSED_IDS_BY_APP =
+            new ConcurrentHashMap<>();
+
+    private static final int GLOBAL_DEDUP_MAX = 10_000;
+
+    /**
+     * 群内 bot 别名缓存：chatId → 学到的别名集合（openId / unionId / userId / name）。
+     * <p>飞书 SDK 投递的 mention 里，bot 的标识可能是群内自定义别名（{@code ou_357e...} / 自定义名称），
+     * 而不是 {@code /bot/v3/info} 返回的全局 openId / app_name。我们在双投递场景下
+     * 机会性地学习这些别名，后续单事件投递的消息就能命中缓存。
+     */
+    private final ConcurrentHashMap<String, Set<String>> chatBotAliases = new ConcurrentHashMap<>();
+
+    /**
+     * Per-messageId mention tracker（带 TTL）。
+     * <p>飞书 SDK 经常对同一条消息双投递：一份 mentions 含 bot 的<em>全局身份</em>（来自 /bot/v3/info），
+     * 另一份含 bot 的<em>群内别名</em>。我们累积同一 messageId 下所有投递看到的 mention 标识，
+     * 一旦其中任何一份被识别为 @bot，就把累积的全部标识写入 {@link #chatBotAliases}。
+     */
+    private final ConcurrentHashMap<String, MentionTrack> mentionTracker = new ConcurrentHashMap<>();
+
+    /** mention tracker 条目 TTL（60s 远大于双投递的真实间隔，几个 ms 级别）。 */
+    private static final long MENTION_TRACK_TTL_MS = 60_000L;
+
+    private static final class MentionTrack {
+        final Set<String> seenIds = ConcurrentHashMap.newKeySet();
+        final long createdAtMs = System.currentTimeMillis();
+        volatile boolean matched = false;
+    }
 
     /** 昵称缓存：open_id → 显示名称 */
     private final ConcurrentHashMap<String, String> nicknameCache = new ConcurrentHashMap<>();
@@ -110,6 +151,9 @@ public class FeishuChannelAdapter extends AbstractChannelAdapter implements Stre
 
     /** Bot's own open_id, fetched once from /open-apis/bot/v3/info and cached. */
     private volatile String botOpenId;
+
+    /** Bot's display name (app_name), fetched alongside open_id. Used for name-based mention matching. */
+    private volatile String botName;
 
     /** Serializes lazy bot-open-id fetches so concurrent group messages share one API roundtrip. */
     private final Object botOpenIdLock = new Object();
@@ -169,6 +213,25 @@ public class FeishuChannelAdapter extends AbstractChannelAdapter implements Stre
      * but not broken).
      */
     private final vip.mate.stt.SttService sttService;
+
+    // ==================== Per-chat recent file cache ====================
+
+    /**
+     * Per-chat cache of recently downloaded file messages. When a file is
+     * sent in a Feishu chat (even without @mention), it is downloaded and
+     * cached here. When a follow-up text message arrives in the same chat,
+     * the cached files are injected as content parts so the agent can see
+     * and process them.
+     */
+    private static final long RECENT_FILE_TTL_MINUTES = 60;
+    private static final int RECENT_FILE_MAX_PER_CHAT = 5;
+
+    record RecentFileEntry(String fileName, String path, String fileUrl, String contentType) {}
+
+    private final Cache<String, List<RecentFileEntry>> recentFileCache = Caffeine.newBuilder()
+            .expireAfterWrite(RECENT_FILE_TTL_MINUTES, TimeUnit.MINUTES)
+            .maximumSize(200)
+            .build();
 
     public FeishuChannelAdapter(ChannelEntity channelEntity,
                                 ChannelMessageRouter messageRouter,
@@ -309,9 +372,12 @@ public class FeishuChannelAdapter extends AbstractChannelAdapter implements Stre
         // a torn write that could re-cache a stale id.
         synchronized (botOpenIdLock) {
             this.botOpenId = null;
+            this.botName = null;
             this.botOpenIdLastFailureMs = 0L;
         }
         this.processedMessageIds.clear();
+        this.chatBotAliases.clear();
+        this.mentionTracker.clear();
         this.nicknameCache.clear();
         this.quotedMessageCache.clear();
         log.info("[feishu] Feishu channel stopped");
@@ -601,20 +667,119 @@ public class FeishuChannelAdapter extends AbstractChannelAdapter implements Stre
         String chatId = message.getChatId();
         String chatType = message.getChatType();
         String parentId = message.getParentId();
-
         String senderOpenId = null;
-        if (sender != null && sender.getSenderId() != null) {
-            senderOpenId = sender.getSenderId().getOpenId();
+        String senderType = null;
+        if (sender != null) {
+            senderType = sender.getSenderType();
+            if (sender.getSenderId() != null) {
+                senderOpenId = sender.getSenderId().getOpenId();
+            }
+        }
+        if ("app".equals(senderType)) {
+            log.debug("[feishu] Ignoring bot-originated message (sender_type=app): messageId={}", messageId);
+            return;
         }
 
-        boolean isBotMentioned = isBotMentionedInEvent(message.getMentions());
+        com.lark.oapi.service.im.v1.model.MentionEvent[] mentions = message.getMentions();
+        boolean isBotMentioned = detectBotMentionWithLearning(mentions, chatId, messageId);
         handleFeishuMessage(messageId, messageType, contentStr, chatId, chatType, senderOpenId, parentId, isBotMentioned, event);
     }
 
     // ==================== @提及检测 ====================
 
-    private boolean isBotMentionedInEvent(com.lark.oapi.service.im.v1.model.MentionEvent[] mentions) {
-        return eventMentionsContainBot(mentions, getBotOpenId());
+    /**
+     * 判断本次事件是否 @ 了 bot，并机会性地学习"群内 bot 别名"。
+     *
+     * <p>飞书 SDK 在群内对同一条 @bot 的消息会双投递两个事件，两次的 mentions 数据形态不同：
+     * <ul>
+     *   <li>一份带 bot 的<em>全局身份</em>（与 {@code /open-apis/bot/v3/info} 返回的 openId / app_name 一致）；</li>
+     *   <li>一份带 bot 的<em>群内别名</em>（用户给 bot 起的 chat-scope 名，openId 也是另一套）。</li>
+     * </ul>
+     * 重启后第一条消息能命中"全局身份"那一份直接匹配；后续消息往往只来一份"群内别名"。
+     * 本方法在双投递可见时把两份的所有标识聚合到 {@link #chatBotAliases}，后续单事件投递就能命中缓存放行。
+     *
+     * <p>识别顺序：
+     * <ol>
+     *   <li>直接匹配 {@code /bot/v3/info} 拿到的 botOpenId / botName；</li>
+     *   <li>查 {@link #chatBotAliases} 缓存里学到的群内别名；</li>
+     *   <li>双投递推断：同一 messageId 之前的事件已被识别 → 本事件的 mentions 也是 bot 的别名。</li>
+     * </ol>
+     */
+    private boolean detectBotMentionWithLearning(com.lark.oapi.service.im.v1.model.MentionEvent[] mentions,
+                                                 String chatId, String messageId) {
+        if (mentions == null || mentions.length == 0) {
+            return false;
+        }
+        if (log.isDebugEnabled()) {
+            StringBuilder sb = new StringBuilder("[");
+            for (int i = 0; i < mentions.length; i++) {
+                var m = mentions[i];
+                if (i > 0) sb.append(", ");
+                var mid = m.getId();
+                sb.append("{name=").append(m.getName())
+                  .append(", openId=").append(mid != null ? mid.getOpenId() : "null")
+                  .append(", key=").append(m.getKey()).append("}");
+            }
+            sb.append("]");
+            log.debug("[feishu] mention detection: messageId={}, botOpenId={}, botName={}, mentions={}",
+                    messageId, getBotOpenId(), botName, sb);
+        }
+
+        cleanupMentionTracker();
+
+        // 把本次事件看到的所有标识累积到 per-messageId tracker —— 即使本次匹配不上，
+        // 后到的事件如果匹配成功，learnFromTrack 会把它们一起 cache。
+        MentionTrack track = null;
+        if (messageId != null) {
+            track = mentionTracker.computeIfAbsent(messageId, k -> new MentionTrack());
+            collectMentionIdentifiers(mentions, track.seenIds);
+        }
+
+        String botOid = getBotOpenId();
+
+        // 1. 直接匹配 bot 的全局身份
+        if (eventMentionsContainBot(mentions, botOid, botName)) {
+            learnFromTrack(chatId, track);
+            if (track != null) track.matched = true;
+            return true;
+        }
+
+        // 2. 群内已学习别名命中
+        if (chatId != null) {
+            Set<String> learned = chatBotAliases.get(chatId);
+            if (learned != null && mentionMatchesAnyAlias(mentions, learned)) {
+                log.info("[feishu] @bot matched via learned chat alias: chatId={}, messageId={}", chatId, messageId);
+                learnFromTrack(chatId, track);
+                if (track != null) track.matched = true;
+                return true;
+            }
+        }
+
+        // 3. 双投递学习：同 messageId 的另一次投递已被识别 → 本事件 mentions 是 bot 别名
+        if (track != null && track.matched) {
+            log.info("[feishu] @bot inferred via dual-delivery learning: chatId={}, messageId={}", chatId, messageId);
+            learnFromTrack(chatId, track);
+            return true;
+        }
+
+        return false;
+    }
+
+    private void learnFromTrack(String chatId, MentionTrack track) {
+        if (chatId == null || track == null || track.seenIds.isEmpty()) return;
+        Set<String> aliases = chatBotAliases.computeIfAbsent(chatId, k -> ConcurrentHashMap.newKeySet());
+        int before = aliases.size();
+        aliases.addAll(track.seenIds);
+        int added = aliases.size() - before;
+        if (added > 0) {
+            log.info("[feishu] Learned {} new bot alias(es) for chat={} (cache size={})",
+                    added, chatId, aliases.size());
+        }
+    }
+
+    private void cleanupMentionTracker() {
+        long cutoff = System.currentTimeMillis() - MENTION_TRACK_TTL_MS;
+        mentionTracker.entrySet().removeIf(e -> e.getValue().createdAtMs < cutoff);
     }
 
     private boolean isBotMentionedInWebhookMessage(Map<String, Object> message) {
@@ -623,12 +788,51 @@ public class FeishuChannelAdapter extends AbstractChannelAdapter implements Stre
         return webhookMentionsContainBot(list, getBotOpenId());
     }
 
-    /** Package-private for testing: 判断 SDK mentions 数组中是否包含指定 open_id */
+    /** Package-private for testing: 判断 SDK mentions 数组中是否包含指定 bot */
     static boolean eventMentionsContainBot(com.lark.oapi.service.im.v1.model.MentionEvent[] mentions,
-                                           String botOpenId) {
-        if (mentions == null || mentions.length == 0 || botOpenId == null) return false;
+                                           String botOpenId, String botName) {
+        if (mentions == null || mentions.length == 0) return false;
         for (var mention : mentions) {
-            if (mention.getId() != null && botOpenId.equals(mention.getId().getOpenId())) return true;
+            var id = mention.getId();
+            // 匹配 openId、unionId、userId 中的任意一个
+            if (id != null && botOpenId != null) {
+                if (botOpenId.equals(id.getOpenId())) return true;
+                if (botOpenId.equals(id.getUnionId())) return true;
+                if (botOpenId.equals(id.getUserId())) return true;
+            }
+            // 飞书 SDK 对 bot mention 可能使用不同 ID 体系，fallback 到 name 匹配
+            if (botName != null && botName.equals(mention.getName())) return true;
+        }
+        return false;
+    }
+
+    /** Package-private for testing: 把 mentions 中每个非空 openId / unionId / userId / name 灌入 sink。 */
+    static void collectMentionIdentifiers(com.lark.oapi.service.im.v1.model.MentionEvent[] mentions,
+                                          Set<String> sink) {
+        if (mentions == null || sink == null) return;
+        for (var mention : mentions) {
+            var id = mention.getId();
+            if (id != null) {
+                if (id.getOpenId() != null) sink.add(id.getOpenId());
+                if (id.getUnionId() != null) sink.add(id.getUnionId());
+                if (id.getUserId() != null) sink.add(id.getUserId());
+            }
+            if (mention.getName() != null) sink.add(mention.getName());
+        }
+    }
+
+    /** Package-private for testing: mentions 中是否有任意 openId / unionId / userId / name 命中 aliases 集合。 */
+    static boolean mentionMatchesAnyAlias(com.lark.oapi.service.im.v1.model.MentionEvent[] mentions,
+                                          Set<String> aliases) {
+        if (mentions == null || mentions.length == 0 || aliases == null || aliases.isEmpty()) return false;
+        for (var mention : mentions) {
+            var id = mention.getId();
+            if (id != null) {
+                if (id.getOpenId() != null && aliases.contains(id.getOpenId())) return true;
+                if (id.getUnionId() != null && aliases.contains(id.getUnionId())) return true;
+                if (id.getUserId() != null && aliases.contains(id.getUserId())) return true;
+            }
+            if (mention.getName() != null && aliases.contains(mention.getName())) return true;
         }
         return false;
     }
@@ -698,7 +902,10 @@ public class FeishuChannelAdapter extends AbstractChannelAdapter implements Stre
                 Map<?, ?> bot = (Map<?, ?>) body.get("bot");
                 if (bot != null && bot.get("open_id") instanceof String openId && !openId.isBlank()) {
                     botOpenId = openId;
-                    log.info("[feishu] Bot open_id fetched and cached: {}", openId);
+                    if (bot.get("app_name") instanceof String name && !name.isBlank()) {
+                        botName = name;
+                    }
+                    log.info("[feishu] Bot info fetched: open_id={}, name={}", openId, botName);
                     return openId;
                 }
                 // 2xx with no bot.open_id field → treat as transient failure.
@@ -758,6 +965,7 @@ public class FeishuChannelAdapter extends AbstractChannelAdapter implements Stre
             HttpRequest request = HttpRequest.newBuilder()
                     .uri(URI.create(apiBase + "/open-apis/auth/v3/tenant_access_token/internal"))
                     .header("Content-Type", "application/json; charset=utf-8")
+                    .timeout(Duration.ofSeconds(10))
                     .POST(HttpRequest.BodyPublishers.ofString(jsonBody))
                     .build();
 
@@ -852,14 +1060,20 @@ public class FeishuChannelAdapter extends AbstractChannelAdapter implements Stre
             String chatType = (String) message.get("chat_type");
             String parentId = (String) message.get("parent_id");
 
-            // 提取发送者 open_id
+            // 提取发送者 open_id 和 sender_type
             Map<String, Object> sender = (Map<String, Object>) event.get("sender");
             String senderOpenId = null;
+            String senderType = null;
             if (sender != null) {
+                senderType = (String) sender.get("sender_type");
                 Map<String, Object> senderIdObj = (Map<String, Object>) sender.get("sender_id");
                 if (senderIdObj != null) {
                     senderOpenId = (String) senderIdObj.get("open_id");
                 }
+            }
+            if ("app".equals(senderType)) {
+                log.info("[feishu] Ignoring bot-originated message (sender_type=app): messageId={}", messageId);
+                return Map.of("code", 0);
             }
 
             boolean isBotMentioned = isBotMentionedInWebhookMessage(message);
@@ -889,26 +1103,62 @@ public class FeishuChannelAdapter extends AbstractChannelAdapter implements Stre
     private void handleFeishuMessage(String messageId, String messageType, String contentStr,
                                       String chatId, String chatType, String senderOpenId,
                                       String parentId, boolean isBotMentioned, Object rawPayload) {
+        // Per-chat recent file cache: always download file messages (even
+        // without @mention) so they can be auto-associated with follow-up
+        // text messages in the same chat.
+        boolean isGroup = "group".equals(chatType);
+        boolean isFileMessage = "file".equals(messageType) || "image".equals(messageType)
+                || "audio".equals(messageType) || "media".equals(messageType);
+        if (isFileMessage && chatId != null) {
+            cacheRecentFile(messageId, messageType, contentStr, chatId, senderOpenId, isGroup);
+        }
+
+        // allowed_chat_ids 过滤：同一 bot 多个渠道时，按 chatId 分流。
+        // 过滤在 dedup 之前，保证被过滤掉的消息不会占用 dedup 槽位，
+        // 让负责该 chat 的其他 adapter 仍能正常处理。
+        // p2p 消息（chatId=null）始终通过，不受 allowed_chat_ids 约束。
+        String allowedChatIdsConf = getConfigString("allowed_chat_ids", null);
+        if (allowedChatIdsConf != null && !allowedChatIdsConf.isBlank() && chatId != null) {
+            boolean allowed = java.util.Arrays.stream(allowedChatIdsConf.split(","))
+                    .map(String::trim).anyMatch(chatId::equals);
+            if (!allowed) {
+                log.debug("[feishu] Chat {} not in allowed_chat_ids, skipping messageId={}", chatId, messageId);
+                return;
+            }
+        }
+
+        // 实例级消息去重（处理 SDK 双投递和重连回放）
+        if (messageId != null && !processedMessageIds.add(messageId)) {
+            log.info("[feishu] Duplicate message_id (instance dedup): {}, skipping", messageId);
+            return;
+        }
+        cleanupProcessedIds();
+
+        // 跨 adapter 全局去重：同一 app_id 的多个渠道实例共享，防止同一条消息被多个 adapter 重复处理。
+        // 在实例级 dedup 之后，确保通过实例级 dedup 的事件只有一个 adapter 继续处理。
+        String appId = getConfigString("app_id", "");
+        if (messageId != null && !appId.isEmpty()) {
+            Set<String> globalIds = GLOBAL_PROCESSED_IDS_BY_APP.computeIfAbsent(
+                    appId, k -> ConcurrentHashMap.newKeySet());
+            if (!globalIds.add(messageId)) {
+                log.info("[feishu] Duplicate message_id (cross-adapter dedup): {}, skipping", messageId);
+                return;
+            }
+            cleanupGlobalProcessedIds(appId, globalIds);
+        }
+
         // require_mention 群聊过滤：群聊中必须 @机器人才响应。
         // 当 botOpenId 为 null 时（API 抖动 / 尚未拉取成功），失败回退到放行 —
         // 避免飞书 /open-apis/bot/v3/info 短暂不可用时整个群机器人变哑巴。
-        boolean isGroup = "group".equals(chatType);
         boolean requireMention = getConfigBoolean("require_mention", false);
         if (isGroupNonMentionDrop(isGroup, requireMention, isBotMentioned, botOpenId)) {
-            log.debug("[feishu] require_mention=true but bot not mentioned, dropping messageId={}", messageId);
+            log.info("[feishu] require_mention=true but bot not mentioned, dropping messageId={}", messageId);
             return;
         }
         if (isGroup && requireMention && !isBotMentioned) {
             // botOpenId is null here — identity unknown, gate falls open.
             log.warn("[feishu] require_mention=true but bot open_id unavailable; allowing messageId={}", messageId);
         }
-
-        // 消息去重
-        if (messageId != null && !processedMessageIds.add(messageId)) {
-            log.debug("[feishu] Duplicate message_id: {}, skipping", messageId);
-            return;
-        }
-        cleanupProcessedIds();
 
         // 添加消息反应（非阻塞，表示"已收到"）
         if (messageId != null && getConfigBoolean("enable_reaction", true)) {
@@ -926,24 +1176,39 @@ public class FeishuChannelAdapter extends AbstractChannelAdapter implements Stre
         String textContent = extractContentParts(messageId, messageType, contentStr, contentParts);
 
         if (contentParts.isEmpty() && (textContent == null || textContent.isBlank())) {
-            log.debug("[feishu] Empty message content, ignoring");
+            log.info("[feishu] Empty message content after extract, ignoring: id={}, type={}, contentStr={}",
+                    messageId, messageType, contentStr);
             return;
         }
 
         // 引用消息（用户在飞书里"引用"了之前的某条消息回复）：拉取被引用消息内容并注入上下文，
         // 让 agent 能理解 "解释一下" 这种缺主语的引用回复 —— 不然就只看到"解释一下"三个字。
         if (parentId != null && !parentId.isBlank() && getConfigBoolean("enable_quoted_context", true)) {
+            log.info("[feishu] Quoted message detected: parentId={}", parentId);
             String quotedText = fetchQuotedMessageText(parentId);
             if (quotedText != null && !quotedText.isBlank()) {
                 String prefix = "[引用消息: " + quotedText + "]\n";
                 textContent = prefix + (textContent != null ? textContent : "");
                 // 同步加一个 text part 到最前面，让多模态消息也能看到引用上下文
                 contentParts.add(0, MessageContentPart.text(prefix));
+                log.info("[feishu] Injected quoted context: {}", quotedText);
+            } else {
+                log.info("[feishu] Quoted message fetch returned null/blank for parentId={}", parentId);
             }
         }
 
-        // 生成短会话后缀
+        // Auto-associate recent files: inject file/image parts from the
+        // per-chat cache so the agent can see files sent earlier in the
+        // same conversation (user sends file → asks about it in text).
+        if (!isFileMessage && chatId != null) {
+            textContent = injectRecentFiles(chatId, contentParts, textContent);
+        }
+
+        // 生成会话标识后缀（群聊=fullChatId, 私聊=fullOpenId）
         String shortSuffix = generateShortSessionSuffix(chatId, senderOpenId, isGroup);
+
+        log.info("[feishu] Building ChannelMessage: shortSuffix={}, chatId={}, senderOpenId={}, isGroup={}, contentParts={}",
+                shortSuffix, chatId, senderOpenId, isGroup, contentParts.size());
 
         ChannelMessage channelMessage = ChannelMessage.builder()
                 .messageId(messageId)
@@ -961,16 +1226,36 @@ public class FeishuChannelAdapter extends AbstractChannelAdapter implements Stre
 
         // replyToken ��留完整 chatId（��送消息需要完整 ID）
         channelMessage.setReplyToken(chatId);
+
+        log.info("[feishu] ChannelMessage built: chatId={}, replyToken={}, content='{}'",
+                channelMessage.getChatId(), channelMessage.getReplyToken(),
+                channelMessage.getContent() != null ? channelMessage.getContent().substring(0, Math.min(50, channelMessage.getContent().length())) : "null");
+
         onMessage(channelMessage);
     }
 
     /**
-     * 清理旧的去重记录：超过 1000 条时保留最近添加的（移除最早的一半）
+     * 清理实例级去重记录：超过 1000 条时保留最近添加的（移除最早的一半）
      */
     private void cleanupProcessedIds() {
         if (processedMessageIds.size() > 1000) {
             int toRemove = processedMessageIds.size() / 2;
             var iterator = processedMessageIds.iterator();
+            while (iterator.hasNext() && toRemove > 0) {
+                iterator.next();
+                iterator.remove();
+                toRemove--;
+            }
+        }
+    }
+
+    /**
+     * 清理全局跨 adapter 去重记录：超过 {@link #GLOBAL_DEDUP_MAX} 条时移除最早的一半
+     */
+    private static void cleanupGlobalProcessedIds(String appId, Set<String> ids) {
+        if (ids.size() > GLOBAL_DEDUP_MAX) {
+            int toRemove = ids.size() / 2;
+            var iterator = ids.iterator();
             while (iterator.hasNext() && toRemove > 0) {
                 iterator.next();
                 iterator.remove();
@@ -1318,27 +1603,160 @@ public class FeishuChannelAdapter extends AbstractChannelAdapter implements Stre
         return null;
     }
 
-    // ==================== 会话 ID 优化 ====================
+    // ==================== 会话 ID ====================
 
     /**
-     * 生成更短的会话标识后缀
-     * - 群聊：app_id 后 4 位 + "_" + chat_id 后 8 位
-     * - 私聊：open_id 后 12 位
+     * 生成会话标识后缀。
+     * - 群聊：直接使用完整 chat_id（全局唯一，不含 app_id，避免同一群在多 bot 场景下
+     *   因 app_id 不同而分裂成多条会话，导致前端时而可见时而不可见）
+     * - 私聊：使用完整 sender open_id
      */
     private String generateShortSessionSuffix(String chatId, String openId, boolean isGroup) {
         if (isGroup && chatId != null) {
-            String appId = getConfigString("app_id", "");
-            String appSuffix = appId.length() >= 4 ? appId.substring(appId.length() - 4) : appId;
-            String chatSuffix = chatId.length() >= 8 ? chatId.substring(chatId.length() - 8) : chatId;
-            return appSuffix + "_" + chatSuffix;
+            return chatId;
         }
         if (openId != null) {
-            return openId.length() >= 12 ? openId.substring(openId.length() - 12) : openId;
+            return openId;
         }
         if (chatId != null) {
-            return chatId.length() >= 12 ? chatId.substring(chatId.length() - 12) : chatId;
+            return chatId;
         }
         return null;
+    }
+
+    /**
+     * Compute the conversationId that {@link ChannelMessageRouter} would
+     * derive from the same chat/sender fields, so we can save inbound
+     * files to the matching {@code data/chat-uploads/} directory.
+     */
+    private String buildConversationId(String chatId, String senderOpenId, boolean isGroup) {
+        String suffix = generateShortSessionSuffix(chatId, senderOpenId, isGroup);
+        return suffix != null ? CHANNEL_TYPE + ":" + suffix : null;
+    }
+
+    // ==================== Per-chat recent file cache ====================
+
+    /**
+     * Download an inbound file message and cache its metadata in the
+     * per-chat recent-file cache. The file is saved to
+     * {@code data/chat-uploads/{conversationId}/} so existing tools
+     * ({@code ReadFileTool}, {@code DocumentExtractTool}) can find it
+     * via {@code ChatUploadResolver}, and it gets cleaned up when the
+     * conversation is deleted.
+     */
+    private void cacheRecentFile(String messageId, String messageType, String contentStr,
+                                  String chatId, String senderOpenId, boolean isGroup) {
+        try {
+            Map<String, Object> contentObj = objectMapper.readValue(contentStr, Map.class);
+
+            String fileKey = null;
+            String fileName = null;
+            String type; // SDK type: "image" or "file"
+
+            switch (messageType) {
+                case "image" -> {
+                    fileKey = (String) contentObj.get("image_key");
+                    type = "image";
+                }
+                case "file" -> {
+                    fileKey = (String) contentObj.get("file_key");
+                    fileName = (String) contentObj.get("file_name");
+                    type = "file";
+                }
+                case "audio" -> {
+                    fileKey = (String) contentObj.get("file_key");
+                    type = "file";
+                }
+                case "media" -> {
+                    fileKey = (String) contentObj.get("file_key");
+                    fileName = (String) contentObj.get("file_name");
+                    type = "file";
+                }
+                default -> {
+                    return;
+                }
+            }
+
+            if (fileKey == null) return;
+
+            // Compute conversationId to save file in the right chat-uploads dir
+            String conversationId = buildConversationId(chatId, senderOpenId, isGroup);
+            if (conversationId == null) return;
+
+            // Download file bytes
+            DownloadedResource dl = "image".equals(messageType)
+                    ? maybeDownloadImage(messageId, fileKey)
+                    : maybeDownloadResource(messageId, fileKey, type, fileName);
+            if (dl == null) return;
+
+            // Save to data/chat-uploads/{conversationId}/
+            Path uploadDir = Path.of("data", "chat-uploads", conversationId);
+            Files.createDirectories(uploadDir);
+            String safeName = (dl.fileName() != null && !dl.fileName().isBlank())
+                    ? dl.fileName() : fileKey.replaceAll("[^a-zA-Z0-9._-]", "_");
+            String storedName = System.currentTimeMillis() + "_" + safeName;
+            Path dest = uploadDir.resolve(storedName);
+            Files.copy(Path.of(dl.path()), dest, StandardCopyOption.REPLACE_EXISTING);
+
+            String contentType = dl.contentType() != null ? dl.contentType() : "application/octet-stream";
+            RecentFileEntry entry = new RecentFileEntry(safeName, dest.toAbsolutePath().toString(),
+                    dl.fileUrl(), contentType);
+
+            // Append to per-chat cache (cap at RECENT_FILE_MAX_PER_CHAT)
+            recentFileCache.get(chatId, k -> new ArrayList<>());
+            List<RecentFileEntry> list = new ArrayList<>(
+                    recentFileCache.getIfPresent(chatId));
+            list.add(entry);
+            if (list.size() > RECENT_FILE_MAX_PER_CHAT) {
+                list = list.subList(list.size() - RECENT_FILE_MAX_PER_CHAT, list.size());
+            }
+            recentFileCache.put(chatId, list);
+
+            log.info("[feishu] Cached recent file for chat={}: {} ({} bytes, {})",
+                    chatId, entry.fileName(), Files.size(dest), contentType);
+
+        } catch (Exception e) {
+            log.debug("[feishu] Failed to cache recent file: {}", e.getMessage());
+        }
+    }
+
+    /**
+     * Inject recent files from the per-chat cache into the current
+     * message's content parts, so the agent can see files that were
+     * sent earlier in the same conversation.
+     *
+     * @return updated textContent with file descriptions appended
+     */
+    private String injectRecentFiles(String chatId, List<MessageContentPart> parts, String textContent) {
+        List<RecentFileEntry> recent = recentFileCache.getIfPresent(chatId);
+        if (recent == null || recent.isEmpty()) return textContent;
+
+        // Collect paths already in parts to avoid duplicates
+        Set<String> existingPaths = new java.util.HashSet<>();
+        for (MessageContentPart p : parts) {
+            if (p != null && p.getPath() != null) existingPaths.add(p.getPath());
+        }
+
+        StringBuilder text = new StringBuilder(textContent != null ? textContent : "");
+        for (RecentFileEntry entry : recent) {
+            if (existingPaths.contains(entry.path())) continue;
+
+            MessageContentPart part = new MessageContentPart();
+            if (entry.contentType() != null && entry.contentType().startsWith("image/")) {
+                part.setType("image");
+            } else {
+                part.setType("file");
+            }
+            part.setFileName(entry.fileName());
+            part.setPath(entry.path());
+            if (entry.fileUrl() != null) part.setFileUrl(entry.fileUrl());
+            part.setContentType(entry.contentType());
+            parts.add(part);
+
+            if (!text.isEmpty()) text.append('\n');
+            text.append("[用户发送了文件: ").append(entry.fileName()).append("]");
+        }
+        return text.toString();
     }
 
     // ==================== 消息内容解析 ====================

--- a/mateclaw-server/src/main/java/vip/mate/trigger/dispatch/ChannelMessageEventBridge.java
+++ b/mateclaw-server/src/main/java/vip/mate/trigger/dispatch/ChannelMessageEventBridge.java
@@ -3,6 +3,7 @@ package vip.mate.trigger.dispatch;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.context.event.EventListener;
+import org.springframework.scheduling.annotation.Async;
 import org.springframework.stereotype.Component;
 import vip.mate.channel.event.ChannelMessageReceivedEvent;
 import vip.mate.trigger.ingest.TriggerEventEnvelope;
@@ -31,6 +32,7 @@ public class ChannelMessageEventBridge {
 
     private final TriggerEventIngestService ingestService;
 
+    @Async
     @EventListener
     public void onChannelMessage(ChannelMessageReceivedEvent event) {
         if (event == null) return;

--- a/mateclaw-server/src/main/resources/db/migration/h2/V121__agent_workspace_base_path.sql
+++ b/mateclaw-server/src/main/resources/db/migration/h2/V121__agent_workspace_base_path.sql
@@ -1,0 +1,3 @@
+-- V100: Add workspace_base_path column to mate_agent for Agent-level directory override.
+-- When set, this overrides the workspace-level basePath for this Agent only.
+ALTER TABLE mate_agent ADD COLUMN IF NOT EXISTS workspace_base_path VARCHAR(512) DEFAULT NULL;

--- a/mateclaw-server/src/main/resources/db/migration/mysql/V121__agent_workspace_base_path.sql
+++ b/mateclaw-server/src/main/resources/db/migration/mysql/V121__agent_workspace_base_path.sql
@@ -1,0 +1,3 @@
+-- V100: Add workspace_base_path column to mate_agent for Agent-level directory override.
+-- When set, this overrides the workspace-level basePath for this Agent only.
+ALTER TABLE mate_agent ADD COLUMN workspace_base_path VARCHAR(512) DEFAULT NULL;

--- a/mateclaw-server/src/test/java/vip/mate/channel/feishu/FeishuMentionTest.java
+++ b/mateclaw-server/src/test/java/vip/mate/channel/feishu/FeishuMentionTest.java
@@ -4,56 +4,84 @@ import com.lark.oapi.service.im.v1.model.MentionEvent;
 import com.lark.oapi.service.im.v1.model.UserId;
 import org.junit.jupiter.api.Test;
 
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 
 import static org.junit.jupiter.api.Assertions.*;
 
 class FeishuMentionTest {
 
     private static final String BOT_ID = "ou_bot123";
+    private static final String BOT_NAME = "TestBot";
     private static final String OTHER_ID = "ou_user456";
 
     // ==================== eventMentionsContainBot ====================
 
     @Test
     void event_nullMentions_returnsFalse() {
-        assertFalse(FeishuChannelAdapter.eventMentionsContainBot(null, BOT_ID));
+        assertFalse(FeishuChannelAdapter.eventMentionsContainBot(null, BOT_ID, BOT_NAME));
     }
 
     @Test
     void event_emptyMentions_returnsFalse() {
-        assertFalse(FeishuChannelAdapter.eventMentionsContainBot(new MentionEvent[0], BOT_ID));
+        assertFalse(FeishuChannelAdapter.eventMentionsContainBot(new MentionEvent[0], BOT_ID, BOT_NAME));
     }
 
     @Test
     void event_nullBotOpenId_returnsFalse() {
         MentionEvent mention = mentionEvent(BOT_ID);
-        assertFalse(FeishuChannelAdapter.eventMentionsContainBot(new MentionEvent[]{mention}, null));
+        assertFalse(FeishuChannelAdapter.eventMentionsContainBot(new MentionEvent[]{mention}, null, BOT_NAME));
     }
 
     @Test
     void event_botIsMentioned_returnsTrue() {
         MentionEvent mention = mentionEvent(BOT_ID);
-        assertTrue(FeishuChannelAdapter.eventMentionsContainBot(new MentionEvent[]{mention}, BOT_ID));
+        assertTrue(FeishuChannelAdapter.eventMentionsContainBot(new MentionEvent[]{mention}, BOT_ID, BOT_NAME));
     }
 
     @Test
     void event_onlyOtherUserMentioned_returnsFalse() {
         MentionEvent mention = mentionEvent(OTHER_ID);
-        assertFalse(FeishuChannelAdapter.eventMentionsContainBot(new MentionEvent[]{mention}, BOT_ID));
+        assertFalse(FeishuChannelAdapter.eventMentionsContainBot(new MentionEvent[]{mention}, BOT_ID, BOT_NAME));
     }
 
     @Test
     void event_botAmongMultipleMentions_returnsTrue() {
         MentionEvent[] mentions = {mentionEvent(OTHER_ID), mentionEvent(BOT_ID)};
-        assertTrue(FeishuChannelAdapter.eventMentionsContainBot(mentions, BOT_ID));
+        assertTrue(FeishuChannelAdapter.eventMentionsContainBot(mentions, BOT_ID, BOT_NAME));
     }
 
     @Test
     void event_mentionWithNullId_skippedSafely() {
         MentionEvent mention = MentionEvent.newBuilder().key("@_user_xxx").build(); // no id set
-        assertFalse(FeishuChannelAdapter.eventMentionsContainBot(new MentionEvent[]{mention}, BOT_ID));
+        assertFalse(FeishuChannelAdapter.eventMentionsContainBot(new MentionEvent[]{mention}, BOT_ID, BOT_NAME));
+    }
+
+    @Test
+    void event_botNameMatches_returnsTrue() {
+        // 飞书 SDK 对 bot mention 使用不同 ID 体系时，fallback 到 name 匹配
+        UserId userId = UserId.newBuilder().openId("ou_different_id").build();
+        MentionEvent mention = MentionEvent.newBuilder().id(userId).name(BOT_NAME).key("@_user_1").build();
+        assertTrue(FeishuChannelAdapter.eventMentionsContainBot(new MentionEvent[]{mention}, BOT_ID, BOT_NAME));
+    }
+
+    @Test
+    void event_nameMismatchIdMismatch_returnsFalse() {
+        UserId userId = UserId.newBuilder().openId("ou_different_id").build();
+        MentionEvent mention = MentionEvent.newBuilder().id(userId).name("SomeOtherBot").key("@_user_1").build();
+        assertFalse(FeishuChannelAdapter.eventMentionsContainBot(new MentionEvent[]{mention}, BOT_ID, BOT_NAME));
+    }
+
+    @Test
+    void event_nullBotName_onlyIdMatchWorks() {
+        // botName 为 null 时，只靠 ID 匹配
+        MentionEvent mention = mentionEvent(BOT_ID);
+        assertTrue(FeishuChannelAdapter.eventMentionsContainBot(new MentionEvent[]{mention}, BOT_ID, null));
+        UserId userId = UserId.newBuilder().openId("ou_different_id").build();
+        MentionEvent mention2 = MentionEvent.newBuilder().id(userId).name(BOT_NAME).build();
+        assertFalse(FeishuChannelAdapter.eventMentionsContainBot(new MentionEvent[]{mention2}, BOT_ID, null));
     }
 
     // ==================== webhookMentionsContainBot ====================
@@ -135,6 +163,78 @@ class FeishuMentionTest {
     void gate_requireMentionDisabled_passesThrough() {
         assertFalse(FeishuChannelAdapter.isGroupNonMentionDrop(true, false, false, BOT_ID));
         assertFalse(FeishuChannelAdapter.isGroupNonMentionDrop(true, false, false, null));
+    }
+
+    // ==================== collectMentionIdentifiers ====================
+
+    @Test
+    void collect_nullOrEmpty_noop() {
+        Set<String> sink = new HashSet<>();
+        FeishuChannelAdapter.collectMentionIdentifiers(null, sink);
+        FeishuChannelAdapter.collectMentionIdentifiers(new MentionEvent[0], sink);
+        assertTrue(sink.isEmpty());
+    }
+
+    @Test
+    void collect_gathersAllNonNullIdentifiers() {
+        UserId uid = UserId.newBuilder().openId("ou_a").unionId("on_a").userId("u_a").build();
+        MentionEvent m = MentionEvent.newBuilder().id(uid).name("Alice").build();
+        Set<String> sink = new HashSet<>();
+        FeishuChannelAdapter.collectMentionIdentifiers(new MentionEvent[]{m}, sink);
+        assertEquals(Set.of("ou_a", "on_a", "u_a", "Alice"), sink);
+    }
+
+    @Test
+    void collect_skipsNullFields() {
+        UserId uid = UserId.newBuilder().openId("ou_a").build();  // no unionId / userId
+        MentionEvent m = MentionEvent.newBuilder().id(uid).build();  // no name
+        Set<String> sink = new HashSet<>();
+        FeishuChannelAdapter.collectMentionIdentifiers(new MentionEvent[]{m}, sink);
+        assertEquals(Set.of("ou_a"), sink);
+    }
+
+    // ==================== mentionMatchesAnyAlias ====================
+
+    @Test
+    void aliasMatch_emptyMentionsOrAliases_returnsFalse() {
+        Set<String> aliases = Set.of("ou_x");
+        assertFalse(FeishuChannelAdapter.mentionMatchesAnyAlias(null, aliases));
+        assertFalse(FeishuChannelAdapter.mentionMatchesAnyAlias(new MentionEvent[0], aliases));
+        UserId uid = UserId.newBuilder().openId("ou_x").build();
+        MentionEvent m = MentionEvent.newBuilder().id(uid).build();
+        assertFalse(FeishuChannelAdapter.mentionMatchesAnyAlias(new MentionEvent[]{m}, Set.of()));
+        assertFalse(FeishuChannelAdapter.mentionMatchesAnyAlias(new MentionEvent[]{m}, null));
+    }
+
+    @Test
+    void aliasMatch_openIdHit_returnsTrue() {
+        UserId uid = UserId.newBuilder().openId("ou_chat_alias").build();
+        MentionEvent m = MentionEvent.newBuilder().id(uid).build();
+        assertTrue(FeishuChannelAdapter.mentionMatchesAnyAlias(new MentionEvent[]{m}, Set.of("ou_chat_alias")));
+    }
+
+    @Test
+    void aliasMatch_unionIdHit_returnsTrue() {
+        UserId uid = UserId.newBuilder().unionId("on_alias").build();
+        MentionEvent m = MentionEvent.newBuilder().id(uid).build();
+        assertTrue(FeishuChannelAdapter.mentionMatchesAnyAlias(new MentionEvent[]{m}, Set.of("on_alias")));
+    }
+
+    @Test
+    void aliasMatch_nameHit_returnsTrue() {
+        // 群内别名场景：mention 里只有 chat-scope openId + 自定义名
+        UserId uid = UserId.newBuilder().openId("ou_chat_only").build();
+        MentionEvent m = MentionEvent.newBuilder().id(uid).name("拉格纳罗斯").build();
+        // 缓存里只有 name（极端 case），仍要能命中
+        assertTrue(FeishuChannelAdapter.mentionMatchesAnyAlias(new MentionEvent[]{m}, Set.of("拉格纳罗斯")));
+    }
+
+    @Test
+    void aliasMatch_noOverlap_returnsFalse() {
+        UserId uid = UserId.newBuilder().openId("ou_x").unionId("on_x").build();
+        MentionEvent m = MentionEvent.newBuilder().id(uid).name("Unknown").build();
+        assertFalse(FeishuChannelAdapter.mentionMatchesAnyAlias(new MentionEvent[]{m},
+                Set.of("ou_other", "on_other", "OtherBot")));
     }
 
     // ==================== helpers ====================

--- a/mateclaw-ui/src/i18n/locales/en-US.ts
+++ b/mateclaw-ui/src/i18n/locales/en-US.ts
@@ -1163,6 +1163,8 @@ export default {
       extraInstructionsHint: 'Optional. Use for output format, process checklists, or boundary rules.',
       maxIterations: 'Max Iterations',
       defaultThinkingLevel: 'Default Thinking Level',
+      workspaceBasePath: 'Working Directory',
+      workspaceBasePathHint: 'Optional. Set a dedicated working directory for this employee (relative to workspace root). Leave blank to inherit the workspace default.',
       modelName: 'Model',
       modelGlobalDefault: 'Use global default',
       modelHint: 'Override the global default model for this employee. Leave blank to follow Settings → Models.',
@@ -1198,6 +1200,7 @@ export default {
       backstory: 'e.g. Spent 10 years in data — believes in asking the right question before writing SQL...',
       extraInstructions: 'Optional: output format, process checklist, or boundary rules...',
       tags: 'tag1,tag2',
+      workspaceBasePath: 'e.g. projects/code-review',
     },
     messages: {
       noDescription: 'No description',

--- a/mateclaw-ui/src/i18n/locales/zh-CN.ts
+++ b/mateclaw-ui/src/i18n/locales/zh-CN.ts
@@ -1055,6 +1055,8 @@ export default {
       extraInstructionsHint: '可选。用于细化输出格式、流程清单或边界规则。',
       maxIterations: '最大迭代次数',
       defaultThinkingLevel: '默认思考深度',
+      workspaceBasePath: '工作目录',
+      workspaceBasePathHint: '可选。为该员工指定独立的工作目录（相对于工作区根目录）。留空则继承工作区默认目录。',
       modelName: '模型',
       modelGlobalDefault: '使用全局默认模型',
       modelHint: '为该员工单独指定模型，留空则跟随「设置 → 模型」中的全局默认。',
@@ -1090,6 +1092,7 @@ export default {
       backstory: '例：在数据里待了十年，相信先问对问题再写 SQL...',
       extraInstructions: '可选：补充输出格式、流程清单或边界规则...',
       tags: 'tag1,tag2',
+      workspaceBasePath: '例如：projects/code-review',
     },
     messages: {
       noDescription: '暂无描述',

--- a/mateclaw-ui/src/types/index.ts
+++ b/mateclaw-ui/src/types/index.ts
@@ -43,6 +43,7 @@ export interface Agent {
   enabled: boolean
   icon?: string
   tags?: string
+  workspaceBasePath?: string
   createTime?: string
   updateTime?: string
 }

--- a/mateclaw-ui/src/views/Agents.vue
+++ b/mateclaw-ui/src/views/Agents.vue
@@ -271,6 +271,11 @@
                 <option value="max">{{ t('agents.thinkingLevels.max') }}</option>
               </select>
             </div>
+            <div class="form-group full-width">
+              <label class="form-label">{{ t('agents.fields.workspaceBasePath') }}</label>
+              <input v-model="form.workspaceBasePath" class="form-input" :placeholder="t('agents.placeholders.workspaceBasePath')" />
+              <p class="form-hint">{{ t('agents.fields.workspaceBasePathHint') }}</p>
+            </div>
             <!--
               Identity triad: role + goal + backstory map to H2 sections in
               the stored systemPrompt. The card tagline is derived from
@@ -703,6 +708,7 @@ const defaultForm = (): Partial<Agent> & { name: string; defaultThinkingLevel: s
   tags: '',
   enabled: true,
   defaultThinkingLevel: null,
+  workspaceBasePath: null,
 })
 
 const form = ref(defaultForm())
@@ -890,6 +896,7 @@ async function openEditModal(agent: Agent) {
     tags: agent.tags || '',
     enabled: agent.enabled,
     defaultThinkingLevel: (agent as any).defaultThinkingLevel || null,
+    workspaceBasePath: agent.workspaceBasePath || null,
   }
   profileForm.value = parsePrompt(agent.systemPrompt)
   modalTab.value = 'basic'


### PR DESCRIPTION
## Summary

### 1. Fix: Feishu message loss (`ChannelMessageEventBridge`)

`ChannelMessageEventBridge.onChannelMessage()` was a synchronous `@EventListener` running on the Lark SDK's single-threaded WebSocket event dispatcher. When `ingestService.ingest()` performed slow DB queries (trigger lookup, dedup row insert), it blocked the dispatcher, causing all subsequent WebSocket events to be silently dropped.

**Fix:**
- Add `@Async` to `ChannelMessageEventBridge.onChannelMessage()` so ingest runs on a separate thread
- Add `sender_type=app` filter in `FeishuChannelAdapter` to skip the bot's own messages
- Add 10s timeout to `refreshTenantAccessToken()` HTTP call (previously no timeout)

### 2. Feature: Agent-level workspace basePath override

Add `workspaceBasePath` field to `AgentEntity` that optionally overrides the workspace-level `basePath`. When set, the agent uses its own directory; when null, it inherits the workspace's `basePath` (existing behavior preserved).

**Changes:**
- `AgentEntity`: new `workspaceBasePath` field
- `AgentGraphBuilder`: agent-level override takes priority over workspace
- Flyway migration `V121` for H2 and MySQL
- UI: form input in basic tab with i18n (zh-CN, en-US)

## Test plan

- [ ] Feishu: send multiple rapid messages → all should appear in web UI (previously some were lost)
- [ ] Agent edit form → basic tab → verify "工作目录" field is visible and saves correctly
- [ ] Agent without workspaceBasePath → inherits workspace basePath (regression check)