### PR TITLE
fix(conversation): IM渠道和WebChat消息记录token usage

### DIFF
--- a/mateclaw-server/src/main/java/vip/mate/channel/ChannelMessageRouter.java
+++ b/mateclaw-server/src/main/java/vip/mate/channel/ChannelMessageRouter.java
@@ -732,10 +732,17 @@ public class ChannelMessageRouter {
                     // for any Web SSE viewer of the same conversationId.
                     StringBuilder replyAccumulator = new StringBuilder();
                     final String channelType = adapter.getChannelType();
+                    // Token usage: capture _usage_final event emitted at stream end
+                    final int[] usage = {0, 0}; // [promptTokens, completionTokens]
                     agentService.chatStructuredStream(agentId, promptText, conversationId,
                                     message.getSenderId(), chatOrigin)
                             .doOnNext(delta -> {
                                 if (delta.isEvent()) {
+                                    if ("_usage_final".equals(delta.eventType())) {
+                                        Map<String, Object> data = delta.eventData();
+                                        usage[0] = ((Number) data.getOrDefault("promptTokens", 0)).intValue();
+                                        usage[1] = ((Number) data.getOrDefault("completionTokens", 0)).intValue();
+                                    }
                                     mirrorPlanEventToTracker(conversationId, delta, channelType);
                                 } else if (delta.content() != null) {
                                     // Match the legacy agentService.chat() behavior: include
@@ -770,7 +777,8 @@ public class ChannelMessageRouter {
                         boolean isError = errorClassifier.isErrorReply(reply);
                         String status = isError ? "error" : "completed";
                         MessageEntity saved = conversationService.saveMessage(
-                                conversationId, "assistant", reply, null, status);
+                                conversationId, "assistant", reply, null, status,
+                                usage[0], usage[1], null, null);
                         savedAssistantId = saved != null ? saved.getId() : null;
                         if (!isError) {
                             publishConversationCompletedEvent(agentId, conversationId, message.getContent(), reply);
@@ -884,8 +892,16 @@ public class ChannelMessageRouter {
             // only reads `delta.content()` and would otherwise eat plan_created /
             // plan_step_* events, leaving the Web Console mirror with no
             // PlanStepsPanel for IM-routed conversations.
-            Flux<AgentService.StreamDelta> mirroredStream = stream.doOnNext(delta ->
-                    mirrorPlanEventToTracker(conversationId, delta, channelType));
+            // Token usage: capture _usage_final event emitted at stream end
+            final int[] usage = {0, 0}; // [promptTokens, completionTokens]
+            Flux<AgentService.StreamDelta> mirroredStream = stream.doOnNext(delta -> {
+                if (delta.isEvent() && "_usage_final".equals(delta.eventType())) {
+                    Map<String, Object> data = delta.eventData();
+                    usage[0] = ((Number) data.getOrDefault("promptTokens", 0)).intValue();
+                    usage[1] = ((Number) data.getOrDefault("completionTokens", 0)).intValue();
+                }
+                mirrorPlanEventToTracker(conversationId, delta, channelType);
+            });
 
             // Step 2: 委托渠道渲染（渠道内部消费 Flux 并处理 UI 更新）
             String finalContent = streamingAdapter.processStream(mirroredStream, message, conversationId);
@@ -905,7 +921,8 @@ public class ChannelMessageRouter {
                 boolean isError = errorClassifier.isErrorReply(finalContent);
                 String status = isError ? "error" : "completed";
                 MessageEntity saved = conversationService.saveMessage(
-                        conversationId, "assistant", finalContent, null, status);
+                        conversationId, "assistant", finalContent, null, status,
+                        usage[0], usage[1], null, null);
                 if (!isError) {
                     publishConversationCompletedEvent(agentId, conversationId, promptText, finalContent);
                 }

--- a/mateclaw-server/src/main/java/vip/mate/channel/webchat/WebChatController.java
+++ b/mateclaw-server/src/main/java/vip/mate/channel/webchat/WebChatController.java
@@ -118,9 +118,16 @@ public class WebChatController {
                 // Pattern mirrors ChatController: always accumulate, only broadcast when the
                 // delta is not a persistence-only echo of content already streamed by inner nodes.
                 StringBuilder assistantReply = new StringBuilder();
+                // Token usage: capture _usage_final event emitted at stream end
+                final int[] usage = {0, 0}; // [promptTokens, completionTokens]
 
                 agentService.chatStructuredStream(agentId, message, conversationId, visitorId)
                         .doOnNext(delta -> {
+                            if (delta.isEvent() && "_usage_final".equals(delta.eventType())) {
+                                Map<String, Object> data = delta.eventData();
+                                usage[0] = ((Number) data.getOrDefault("promptTokens", 0)).intValue();
+                                usage[1] = ((Number) data.getOrDefault("completionTokens", 0)).intValue();
+                            }
                             if (delta.content() != null && !delta.content().isEmpty()) {
                                 assistantReply.append(delta.content());
                                 if (!delta.persistenceOnly()) {
@@ -139,7 +146,8 @@ public class WebChatController {
                             try {
                                 if (!reply.isBlank()) {
                                     conversationService.saveMessage(
-                                            conversationId, "assistant", reply, List.of());
+                                            conversationId, "assistant", reply, List.of(),
+                                            "completed", usage[0], usage[1], null, null);
                                 }
                                 completionPublisher.publish(
                                         agentId, conversationId, message, reply, "webchat");


### PR DESCRIPTION
## Summary

- IM 渠道（飞书/钉钉/企微/微信/Telegram 等）和 WebChat 小组件的 assistant 消息之前调用 `saveMessage` 时未传递 token usage，导致 `promptTokens` 和 `completionTokens` 默认为 0，Token 统计模块数据偏低
- 在 `ChannelMessageRouter`（同步路径 + 流式路径）和 `WebChatController` 的 `doOnNext` 中捕获 `_usage_final` 事件，传给 `saveMessage` 的完整参数重载

## Root Cause

`_usage_final` 事件（包含 promptTokens / completionTokens）由 agent graph 在流末尾发射，但只有 `ChatController` 的 `StreamAccumulator` 捕获了它。IM 渠道和 WebChat 的处理路径未捕获此事件。

## Changes

- `ChannelMessageRouter.java`: 同步路径和流式路径各增加 `usage` 数组，在 `doOnNext` 中提取 `_usage_final` 事件数据，传给 `saveMessage`
- `WebChatController.java`: 同理，在 SSE 流的 `doOnNext` 中捕获 token usage

## Test Plan

- [ ] 启动应用，通过 IM 渠道（如飞书）发送消息，检查 `mate_message` 表中 assistant 消息的 `prompt_tokens` 和 `completion_tokens` 不再为 0
- [ ] 通过 WebChat 小组件发送消息，验证 token 统计正确
- [ ] Token 统计模块数据应包含所有渠道的用量

Closes #214