### PR TITLE
fix(feishu): WebSocket 资源泄漏导致飞书渠道运行后失联

### DIFF
--- a/mateclaw-server/src/main/java/vip/mate/channel/feishu/FeishuChannelAdapter.java
+++ b/mateclaw-server/src/main/java/vip/mate/channel/feishu/FeishuChannelAdapter.java
@@ -549,7 +549,14 @@ public class FeishuChannelAdapter extends AbstractChannelAdapter implements Stre
 
     /**
      * 关闭 WebSocket 连接
-     * SDK 的 start() 在线程中阻塞运行，通过中断线程来触发停止
+     * <p>
+     * 必须主动关闭底层 WebSocket 连接并触发 SDK 的内部清理（停止 pingLoop、
+     * 释放 ExecutorService）。仅置空引用会导致旧连接的 pingLoop 和线程池
+     * 持续运行，造成文件描述符和线程泄漏，最终使新连接无法建立。
+     * <p>
+     * SDK 的 {@code disconnect()} 是 protected 的，无法直接调用。通过反射
+     * 获取内部 {@code conn} 字段并发送 close(1000) 触发 SDK 的
+     * {@code onClosed → disconnect()} 清理链路。
      */
     private void stopWebSocket() {
         cancelSilentDisconnectWatchdog();
@@ -557,6 +564,21 @@ public class FeishuChannelAdapter extends AbstractChannelAdapter implements Stre
         if (wsThread != null) {
             wsThread.interrupt();
             wsThread = null;
+        }
+        if (wsClient != null) {
+            try {
+                // 反射获取 protected conn 字段，发送 close(1000) 触发 SDK 清理
+                var connField = wsClient.getClass().getDeclaredField("conn");
+                connField.setAccessible(true);
+                Object conn = connField.get(wsClient);
+                if (conn != null) {
+                    // conn 是 OkHttp WebSocket，close(1000) 会触发 onClosed → disconnect()
+                    var closeMethod = conn.getClass().getMethod("close", int.class, String.class);
+                    closeMethod.invoke(conn, 1000, "client closed");
+                }
+            } catch (Exception e) {
+                log.debug("[feishu] Error during WebSocket disconnect: {}", e.getMessage());
+            }
         }
         wsClient = null;
     }


### PR DESCRIPTION
## Summary

- 修复 `stopWebSocket()` 未调用 SDK `disconnect()` 导致的 WebSocket 资源泄漏
- 每次重连都会泄漏旧连接的 pingLoop 线程、ExecutorService 和文件描述符
- 累积到一定程度后新连接无法建立，飞书消息完全无法接收，重启后恢复

## Root Cause

`FeishuChannelAdapter.stopWebSocket()` 只置空了 `wsClient` 引用，没有关闭底层 WebSocket 连接：

```java
// 修复前
private void stopWebSocket() {
    // ...
    wsClient = null;  // 旧连接未关闭！
}
```

SDK 的 `disconnect()` 是 `protected` 的，无法直接调用。旧连接的 `pingLoop`（在 `ExecutorService` 中）持续运行，每次重连泄漏一批资源。

## Fix

通过反射获取 SDK 内部 `conn` 字段（OkHttp WebSocket），调用 `close(1000, "client closed")` 触发 SDK 的 `onClosed → disconnect()` 清理链路。

## Follow-up: SDK Upgrade

oapi-sdk **2.7.1** 新增了 `public void close()` 方法，可以直接调用 `wsClient.close()` 而不需要反射。建议后续升级 SDK 版本（当前 2.6.1 → 2.7.1），届时可以移除反射代码，改为更干净的实现。

## Test plan

- [ ] 部署后观察飞书渠道长时间运行是否稳定
- [ ] 验证重连后消息正常收发
- [ ] 监控线程数和文件描述符是否持续增长

Closes #220