### PR TITLE
fix(cron): write tokenUsage to run row on completion

### DIFF
--- a/mateclaw-server/src/main/java/vip/mate/cron/service/CronJobLifecycleService.java
+++ b/mateclaw-server/src/main/java/vip/mate/cron/service/CronJobLifecycleService.java
@@ -196,10 +196,13 @@ public class CronJobLifecycleService {
         String convId = conversationId != null ? conversationId : run.getConversationId();
         String text = result != null && result.getText() != null ? result.getText() : "";
 
+        int totalTokens = chatResult != null
+                ? chatResult.promptTokens() + chatResult.completionTokens() : 0;
         runMapper.update(null, new LambdaUpdateWrapper<CronJobRunEntity>()
                 .eq(CronJobRunEntity::getId, run.getId())
                 .set(CronJobRunEntity::getStatus, "succeeded")
-                .set(CronJobRunEntity::getFinishedAt, LocalDateTime.now()));
+                .set(CronJobRunEntity::getFinishedAt, LocalDateTime.now())
+                .set(totalTokens > 0, CronJobRunEntity::getTokenUsage, totalTokens));
 
         if (silent) {
             // No-op run: persist a short marker so the tasks_<wsId>


### PR DESCRIPTION
## 问题

调度中心执行历史列表中，所有已完成 run 的 Token 用量始终显示为 0（即 `mate_cron_job_run.token_usage` 列永远是 `NULL`）。

Fixes #262

## 根本原因

`CronJobLifecycleService.finishRunAndPublish` 在 T2 阶段通过 `LambdaUpdateWrapper` 更新 run 记录时，只写入了 `status` 和 `finished_at`，遗漏了 `token_usage`：

```java
// 修复前
runMapper.update(null, new LambdaUpdateWrapper<CronJobRunEntity>()
        .eq(CronJobRunEntity::getId, run.getId())
        .set(CronJobRunEntity::getStatus, "succeeded")
        .set(CronJobRunEntity::getFinishedAt, LocalDateTime.now()));
        // ← token_usage 从未被写入
```

`AgentService.chatWithUsage` 返回的 `ChatResult` 携带了 `promptTokens` / `completionTokens`，这两个值已经正确写入会话消息层（`conversationService.saveMessage`），但在更新 cron run 行时被丢弃。

## 修复

在 `LambdaUpdateWrapper` 补充条件 `.set()`：

```java
int totalTokens = chatResult != null
        ? chatResult.promptTokens() + chatResult.completionTokens() : 0;
runMapper.update(null, new LambdaUpdateWrapper<CronJobRunEntity>()
        .eq(CronJobRunEntity::getId, run.getId())
        .set(CronJobRunEntity::getStatus, "succeeded")
        .set(CronJobRunEntity::getFinishedAt, LocalDateTime.now())
        .set(totalTokens > 0, CronJobRunEntity::getTokenUsage, totalTokens));
```

条件写法（`totalTokens > 0`）确保提醒类任务（`chatResult = null`，无 LLM 调用）不会将已有统计清零。

## 影响范围

- 仅改动 `CronJobLifecycleService.java` 一处，1 行变更
- 不影响会话消息、交付流水线、记忆提取
- 无数据库 schema 变更（`token_usage` 列已存在）

## 测试计划

- [ ] 触发一个 `agent` / `text` 类型定时任务，执行完成后确认调度中心执行历史的 Token 列显示正确数值
- [ ] 触发一个 `reminder` 类型任务，确认 Token 列仍显示 `-`（无 LLM 调用，正常）