### PR TITLE
fix(skill): 员工绑定技能后仍可访问未选技能 — 元工具运行时绑定校验

### DIFF
--- a/mateclaw-server/src/main/java/vip/mate/tool/builtin/SkillFileTool.java
+++ b/mateclaw-server/src/main/java/vip/mate/tool/builtin/SkillFileTool.java
@@ -6,10 +6,13 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.ai.chat.model.ToolContext;
 import org.springframework.ai.tool.annotation.Tool;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.Lazy;
 import org.springframework.lang.Nullable;
 import org.springframework.stereotype.Component;
 import vip.mate.agent.context.ChatOrigin;
 import vip.mate.agent.context.TokenEstimator;
+import vip.mate.llm.routing.AgentBindingResolver;
 import vip.mate.skill.runtime.SkillCatalogSort;
 import vip.mate.skill.runtime.SkillCatalogSorter;
 import vip.mate.skill.runtime.SkillFileAccessPolicy;
@@ -21,6 +24,7 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.stream.Collectors;
 
 /**
@@ -38,6 +42,10 @@ public class SkillFileTool {
     private final SkillRuntimeService runtimeService;
     private final SkillFileAccessPolicy accessPolicy;
     private final SkillUsageService usageService;
+
+    @Lazy
+    @Autowired
+    private AgentBindingResolver agentBindingResolver;
 
     @Tool(description = """
         Read a file from a skill's directory (SKILL.md, references/, scripts/, or templates/).
@@ -79,6 +87,9 @@ public class SkillFileTool {
         ResolvedSkill skill = runtimeService.findActiveSkill(skillName);
         if (skill == null) {
             return "Error: Skill '" + skillName + "' not found or not enabled";
+        }
+        if (!isSkillAllowedForAgent(skill, ctx)) {
+            return "Error: Skill '" + skillName + "' is not available for this agent.";
         }
 
         // 特殊处理：读取 SKILL.md
@@ -228,13 +239,18 @@ public class SkillFileTool {
     public String listSkillFiles(
         @JsonProperty(required = true)
         @JsonPropertyDescription("Skill name")
-        String skillName
+        String skillName,
+
+        @Nullable ToolContext ctx
     ) {
         log.info("Listing skill files: skill={}", skillName);
 
         ResolvedSkill skill = runtimeService.findActiveSkill(skillName);
         if (skill == null) {
             return "Error: Skill '" + skillName + "' not found or not enabled";
+        }
+        if (!isSkillAllowedForAgent(skill, ctx)) {
+            return "Error: Skill '" + skillName + "' is not available for this agent.";
         }
 
         StringBuilder sb = new StringBuilder();
@@ -305,10 +321,13 @@ public class SkillFileTool {
 
         @JsonProperty(required = false)
         @JsonPropertyDescription("Maximum number of skills to return, default 20, max 50")
-        Integer limit
+        Integer limit,
+
+        @Nullable ToolContext ctx
     ) {
         log.info("Listing available skills");
 
+        Set<Long> boundSkillIds = boundSkillIdsFromCtx(ctx);
         int safeLimit = limit == null || limit <= 0 ? 20 : Math.min(limit, 50);
         String kw = keyword == null ? "" : keyword.trim().toLowerCase();
         // Push freshly installed skills to the top of the truncated page so
@@ -325,6 +344,8 @@ public class SkillFileTool {
                 runtimeService.getActiveSkills().stream()
                         .filter(s -> SkillCatalogSorter.sourceMatches(s, source))
                         .filter(s -> SkillCatalogSorter.runtimeMatches(s, status))
+                        .filter(s -> boundSkillIds == null
+                                || (s.getId() != null && boundSkillIds.contains(s.getId())))
                         .filter(s -> kw.isEmpty()
                                 || containsIgnoreCase(s.getName(), kw)
                                 || containsIgnoreCase(s.getDescription(), kw))
@@ -379,6 +400,28 @@ public class SkillFileTool {
 
     private static boolean containsIgnoreCase(String value, String lowerCaseNeedle) {
         return value != null && value.toLowerCase().contains(lowerCaseNeedle);
+    }
+
+    /**
+     * Returns the agent's bound skill IDs from the tool context, or {@code null}
+     * when no binding restriction applies (agentId missing or agent has no explicit bindings).
+     */
+    @Nullable
+    private Set<Long> boundSkillIdsFromCtx(@Nullable ToolContext ctx) {
+        Long agentId = ChatOrigin.from(ctx).agentId();
+        if (agentId == null) return null;
+        return agentBindingResolver.getBoundSkillIds(agentId);
+    }
+
+    /**
+     * Returns {@code true} when the agent (identified via {@code ctx}) is allowed
+     * to access {@code skill}: either no explicit binding restriction, or the skill
+     * id is in the agent's bound set.
+     */
+    private boolean isSkillAllowedForAgent(ResolvedSkill skill, @Nullable ToolContext ctx) {
+        Set<Long> boundSkillIds = boundSkillIdsFromCtx(ctx);
+        if (boundSkillIds == null) return true;
+        return skill.getId() != null && boundSkillIds.contains(skill.getId());
     }
 
     private static String statusToken(ResolvedSkill skill) {

--- a/mateclaw-server/src/main/java/vip/mate/tool/builtin/SkillLoadTool.java
+++ b/mateclaw-server/src/main/java/vip/mate/tool/builtin/SkillLoadTool.java
@@ -5,10 +5,16 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.ai.chat.model.ToolContext;
 import org.springframework.ai.tool.annotation.Tool;
 import org.springframework.ai.tool.annotation.ToolParam;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.Lazy;
 import org.springframework.lang.Nullable;
 import org.springframework.stereotype.Component;
+import vip.mate.agent.context.ChatOrigin;
+import vip.mate.llm.routing.AgentBindingResolver;
 import vip.mate.skill.runtime.SkillRuntimeService;
 import vip.mate.skill.runtime.model.ResolvedSkill;
+
+import java.util.Set;
 
 /**
  * Explicit skill-load entry point.
@@ -31,6 +37,10 @@ public class SkillLoadTool {
 
     private final SkillRuntimeService runtimeService;
     private final SkillFileTool skillFileTool;
+
+    @Lazy
+    @Autowired
+    private AgentBindingResolver agentBindingResolver;
 
     @Tool(name = "load_skill", description = """
         Load a skill package's SKILL.md into the conversation.
@@ -64,6 +74,14 @@ public class SkillLoadTool {
             log.info("load_skill: skill '{}' not found or not enabled", skillName);
             return "Error: Skill '" + skillName + "' not found or not enabled. "
                     + "Call listAvailableSkills(keyword=\"" + skillName + "\") to find the correct name.";
+        }
+        Long agentId = ChatOrigin.from(ctx).agentId();
+        if (agentId != null) {
+            Set<Long> boundSkillIds = agentBindingResolver.getBoundSkillIds(agentId);
+            if (boundSkillIds != null && (skill.getId() == null || !boundSkillIds.contains(skill.getId()))) {
+                log.info("load_skill: agent {} is not allowed to load skill '{}'", agentId, skillName);
+                return "Error: Skill '" + skillName + "' is not available for this agent.";
+            }
         }
         String path = (filePath == null || filePath.isBlank()) ? "SKILL.md" : filePath;
         log.info("load_skill: loading skill='{}', path='{}'", skillName, path);

--- a/mateclaw-server/src/main/java/vip/mate/tool/builtin/SkillScriptTool.java
+++ b/mateclaw-server/src/main/java/vip/mate/tool/builtin/SkillScriptTool.java
@@ -7,8 +7,14 @@ import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.ai.chat.model.ToolContext;
 import org.springframework.ai.tool.annotation.Tool;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.Lazy;
+import org.springframework.lang.Nullable;
 import org.springframework.stereotype.Component;
+import vip.mate.agent.context.ChatOrigin;
+import vip.mate.llm.routing.AgentBindingResolver;
 import vip.mate.skill.runtime.SkillFileAccessPolicy;
 import vip.mate.skill.runtime.SkillRuntimeService;
 import vip.mate.skill.runtime.SkillScriptExecutionService;
@@ -20,6 +26,7 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 
 /**
  * 技能脚本执行工具
@@ -35,6 +42,10 @@ public class SkillScriptTool {
     private final SkillScriptExecutionService executionService;
     private final SkillSecretService skillSecretService;
     private final ObjectMapper objectMapper;
+
+    @Lazy
+    @Autowired
+    private AgentBindingResolver agentBindingResolver;
 
     @vip.mate.tool.ConcurrencyUnsafe("script execution can have arbitrary side effects on the host process and filesystem")
     @Tool(description = """
@@ -67,7 +78,9 @@ public class SkillScriptTool {
 
         @JsonProperty(required = false)
         @JsonPropertyDescription("Optional script arguments as ONE JSON-encoded string: a JSON array for multiple positional args, a JSON object for a single JSON payload, or plain text for one literal argument.")
-        String args
+        String args,
+
+        @Nullable ToolContext ctx
     ) {
         log.info("Executing skill script: skill={}, script={}, args={}", skillName, scriptPath, args);
 
@@ -75,6 +88,13 @@ public class SkillScriptTool {
         ResolvedSkill skill = runtimeService.findActiveSkill(skillName);
         if (skill == null) {
             return formatError("Skill '" + skillName + "' not found or not enabled");
+        }
+        Long agentId = ChatOrigin.from(ctx).agentId();
+        if (agentId != null) {
+            Set<Long> boundSkillIds = agentBindingResolver.getBoundSkillIds(agentId);
+            if (boundSkillIds != null && (skill.getId() == null || !boundSkillIds.contains(skill.getId()))) {
+                return formatError("Skill '" + skillName + "' is not available for this agent.");
+            }
         }
 
         // Must be a directory-backed skill.


### PR DESCRIPTION
## 关联 Issue

closes #264

## 问题描述

当员工（Agent）配置了**显式技能绑定**后，系统提示词（SKILL.md 目录）会正确地只展示已绑定的技能。但五个技能元工具在运行时没有执行绑定校验，导致 LLM 仍然可以通过工具调用访问任何未绑定的技能。

**复现路径：**
1. 创建员工，仅绑定技能 A，不绑定技能 B
2. 调用 `listAvailableSkills()` → 返回结果仍包含技能 B
3. 调用 `load_skill(skillName="B")` 或 `runSkillScript(skillName="B", ...)` → 均可成功

## 根本原因

以下五个工具直接查询全量技能目录，未从 `ToolContext` 取 `agentId` 做绑定校验：

| 工具方法 | 所在文件 |
|---|---|
| `listAvailableSkills` | `SkillFileTool.java` |
| `readSkillFile` | `SkillFileTool.java` |
| `listSkillFiles` | `SkillFileTool.java` |
| `loadSkill`（`load_skill`）| `SkillLoadTool.java` |
| `runSkillScript` | `SkillScriptTool.java` |

这些工具都在 `SYSTEM_LEVEL_TOOLS` 白名单中（有绑定的员工均可调用），但内部没有按绑定过滤实际可访问的技能范围。

## 修复方案

在三个工具 Bean 中注入 `AgentBindingResolver`（`@Lazy` 防止循环依赖），执行时调用 `getBoundSkillIds(agentId)`：

- 返回 `null` → 无绑定限制，放行（旧版/未配置员工向后兼容）
- 返回非 `null`（含空集合）→ 只允许 ID 在绑定集合内的技能通过

| 文件 | 修改内容 |
|---|---|
| `SkillFileTool.java` | `listAvailableSkills` 新增 `ToolContext` 参数，stream 过滤链加入绑定 ID 过滤；`readSkillFile` / `listSkillFiles` 在查到技能后调用 `isSkillAllowedForAgent` 校验 |
| `SkillLoadTool.java` | `load_skill` 在委托 `readSkillFile` 之前先做绑定校验 |
| `SkillScriptTool.java` | `runSkillScript` 新增 `ToolContext` 参数，执行脚本前做绑定校验 |

## 测试点

- [ ] 员工无绑定时，五个工具行为与修复前完全一致
- [ ] 员工有显式技能绑定时，`listAvailableSkills` 只返回已绑定技能
- [ ] 员工有显式技能绑定时，`load_skill` / `readSkillFile` / `listSkillFiles` / `runSkillScript` 对未绑定技能返回 `"Error: Skill '...' is not available for this agent."`
- [ ] `skills_disabled=true` 的员工行为不变（元工具已在上游被 `withDeniedToolsFiltered` 拦截）