### PR TITLE
test(skill): 修复 SkillFileToolTest 签名漂移，恢复 test 模块编译

### DIFF
--- a/mateclaw-server/src/test/java/vip/mate/tool/builtin/SkillFileToolTest.java
+++ b/mateclaw-server/src/test/java/vip/mate/tool/builtin/SkillFileToolTest.java
@@ -30,7 +30,7 @@ class SkillFileToolTest {
                 skill("ckjia-shopping", "mcp", false),
                 skill("claude-code", "acp", false)));
 
-        String result = tool.listAvailableSkills("code", "acp", "ready", 1);
+        String result = tool.listAvailableSkills("code", "acp", "ready", 1, null);
 
         assertTrue(result.contains("claude-code"));
         assertFalse(result.contains("ckjia-shopping"));


### PR DESCRIPTION
## 背景

`SkillFileTool.listAvailableSkills(...)` 增加了尾部 `@Nullable ToolContext ctx` 参数后，`SkillFileToolTest` 仍以旧的 4 参数签名调用，导致 **test 模块整体无法编译**，`mvn test` 在编译阶段即失败。

## 改动

为 `SkillFileToolTest.java:33` 的 `listAvailableSkills(...)` 调用补上尾部 `ToolContext` 实参（传 `null`，方法已 `@Nullable`），与现有 `readSkillFile(..., null)` 调用风格一致。约 1 行改动。

## 测试

```
mvn -pl mateclaw-server -am test -Dtest=SkillFileToolTest
Tests run: 5, Failures: 0, Errors: 0, Skipped: 0
```

test 模块恢复编译，`SkillFileToolTest` 全绿。

Closes #276