### PR TITLE
fix(channel): 飞书当前消息图片/文件工具读取失败 — part 路径指向沙箱外 media 目录

### DIFF
--- a/mateclaw-server/src/main/java/vip/mate/channel/feishu/FeishuChannelAdapter.java
+++ b/mateclaw-server/src/main/java/vip/mate/channel/feishu/FeishuChannelAdapter.java
@@ -942,8 +942,9 @@ public class FeishuChannelAdapter extends AbstractChannelAdapter implements Stre
         String shortSuffix = generateShortSessionSuffix(chatId, senderOpenId, isGroup);
         String conversationId = buildConversationId(shortSuffix, senderOpenId, isGroup);
 
+        String stagedUploadPath = null;
         if (isFileMessage) {
-            cacheRecentFile(messageId, messageType, contentStr, conversationId);
+            stagedUploadPath = cacheRecentFile(messageId, messageType, contentStr, conversationId);
         }
 
         // require_mention 群聊过滤：群聊中必须 @机器人才响应。
@@ -979,7 +980,7 @@ public class FeishuChannelAdapter extends AbstractChannelAdapter implements Stre
 
         // 解析消息内容
         List<MessageContentPart> contentParts = new ArrayList<>();
-        String textContent = extractContentParts(messageId, messageType, contentStr, contentParts);
+        String textContent = extractContentParts(messageId, messageType, contentStr, contentParts, stagedUploadPath);
 
         if (contentParts.isEmpty() && (textContent == null || textContent.isBlank())) {
             log.debug("[feishu] Empty message content, ignoring");
@@ -1431,8 +1432,14 @@ public class FeishuChannelAdapter extends AbstractChannelAdapter implements Stre
      * ({@code ReadFileTool}, {@code DocumentExtractTool}) can find it
      * via {@code ChatUploadResolver}, and it gets cleaned up when the
      * conversation is deleted.
+     *
+     * @return absolute path of the staged {@code data/chat-uploads/} copy, or
+     *         {@code null} when nothing was cached (unsupported type, missing
+     *         file key, download failure). Callers stamp this path onto the
+     *         current-message content part so the path surfaced to the LLM is
+     *         resolver-reachable instead of the sandbox-external media path.
      */
-    private void cacheRecentFile(String messageId, String messageType, String contentStr,
+    private String cacheRecentFile(String messageId, String messageType, String contentStr,
                                   String conversationId) {
         try {
             Map<String, Object> contentObj = objectMapper.readValue(contentStr, Map.class);
@@ -1461,17 +1468,17 @@ public class FeishuChannelAdapter extends AbstractChannelAdapter implements Stre
                     type = "file";
                 }
                 default -> {
-                    return;
+                    return null;
                 }
             }
 
-            if (fileKey == null) return;
+            if (fileKey == null) return null;
 
             // Download file bytes
             DownloadedResource dl = "image".equals(messageType)
                     ? maybeDownloadImage(messageId, fileKey)
                     : maybeDownloadResource(messageId, fileKey, type, fileName);
-            if (dl == null) return;
+            if (dl == null) return null;
 
             // Save to data/chat-uploads/{conversationId}/
             Path uploadDir = Path.of("data", "chat-uploads", conversationId);
@@ -1502,8 +1509,10 @@ public class FeishuChannelAdapter extends AbstractChannelAdapter implements Stre
             log.info("[feishu] Cached recent file for conversation={}: {} ({} bytes, {})",
                     conversationId, entry.fileName(), Files.size(dest), contentType);
 
+            return dest.toAbsolutePath().toString();
         } catch (Exception e) {
             log.debug("[feishu] Failed to cache recent file: {}", e.getMessage());
+            return null;
         }
     }
 
@@ -1551,15 +1560,19 @@ public class FeishuChannelAdapter extends AbstractChannelAdapter implements Stre
     /**
      * 解析飞书消息内容为 contentParts
      *
-     * @param messageId   消息 ID（用于媒体下载）
-     * @param messageType 消息类型
-     * @param contentStr  消息内容 JSON 字符串
-     * @param parts       输出的 content parts
+     * @param messageId        消息 ID（用于媒体下载）
+     * @param messageType      消息类型
+     * @param contentStr       消息内容 JSON 字符串
+     * @param parts            输出的 content parts
+     * @param stagedUploadPath {@code cacheRecentFile} 复制到 {@code data/chat-uploads/}
+     *                         的绝对路径（可空）。非空时覆盖各附件 part 的 path，使其指向
+     *                         沙箱可达（经 {@code ChatUploadResolver}）的那一份，而不是
+     *                         沙箱外的 {@code ~/.mateclaw/media/} 路径。
      * @return 纯文本摘要
      */
     @SuppressWarnings("unchecked")
     private String extractContentParts(String messageId, String messageType, String contentStr,
-                                        List<MessageContentPart> parts) {
+                                        List<MessageContentPart> parts, String stagedUploadPath) {
         if (contentStr == null) return null;
 
         try {
@@ -1588,6 +1601,7 @@ public class FeishuChannelAdapter extends AbstractChannelAdapter implements Stre
                         DownloadedResource dl = maybeDownloadImage(messageId, imageKey);
                         MessageContentPart part = MessageContentPart.image(imageKey, null);
                         applyDownload(part, dl);
+                        if (stagedUploadPath != null) part.setPath(stagedUploadPath);
                         parts.add(part);
                     }
                     yield "[图片]";
@@ -1599,6 +1613,7 @@ public class FeishuChannelAdapter extends AbstractChannelAdapter implements Stre
                         DownloadedResource dl = maybeDownloadResource(messageId, fileKey, "file", fileName);
                         MessageContentPart part = MessageContentPart.file(fileKey, fileName, null);
                         applyDownload(part, dl);
+                        if (stagedUploadPath != null) part.setPath(stagedUploadPath);
                         parts.add(part);
                     }
                     yield "[文件: " + (fileName != null ? fileName : "") + "]";
@@ -1612,6 +1627,7 @@ public class FeishuChannelAdapter extends AbstractChannelAdapter implements Stre
                         DownloadedResource dl = maybeDownloadResource(messageId, fileKey, "file", "voice.opus");
                         MessageContentPart part = MessageContentPart.audio(fileKey, null);
                         applyDownload(part, dl);
+                        if (stagedUploadPath != null) part.setPath(stagedUploadPath);
                         // STT hop: inject the transcript as a sibling text part BEFORE
                         // the audio part so ChannelMessageRouter.buildPromptFromParts
                         // sees real content instead of just "[音频]". WeCom / DingTalk
@@ -1632,6 +1648,7 @@ public class FeishuChannelAdapter extends AbstractChannelAdapter implements Stre
                         DownloadedResource dl = maybeDownloadResource(messageId, fileKey, "file", fileName);
                         MessageContentPart part = MessageContentPart.video(fileKey, fileName);
                         applyDownload(part, dl);
+                        if (stagedUploadPath != null) part.setPath(stagedUploadPath);
                         parts.add(part);
                     }
                     yield "[视频]";


### PR DESCRIPTION
关联 issue：closes #278

## 问题

通过飞书渠道上传图片/文件后，在**同一条消息**里让 Agent 读取该附件时报错「图片路径在工作区沙箱之外，我没办法直接读取这个文件」。视觉能看到图片，但任何走文件工具（`read_file` / `extract_document_text` / `detect_file_type`）的读取都失败。仅当前这条消息失败；先发文件、再用后续文本追问反而正常。

## 根因

1. 飞书媒体落盘在沙箱外的 `~/.mateclaw/media/feishu/{messageId}_{key}.ext`，`extractContentParts` 通过 `applyDownload` 把这个 media 路径写进 `MessageContentPart.path`。
2. `ConversationService#renderMediaPart` 把 `part.getPath()` 直接拼进 prompt：`[图片] 未命名（路径: /root/.mateclaw/media/feishu/...）`。
3. LLM 据此调 `read_file`：`WorkspacePathGuard` 因路径不在工作区沙箱内拒绝；`ReadFileTool` 兜底的 `ChatUploadResolver` 按 basename 在 `data/chat-uploads/{conversationId}/` 找，但 media 份命名 `{messageId}_{key}` 与 chat-uploads 份命名 `{millis}_{fileName}` 对不上 → 失配 → 返回沙箱越界错误。

**关键点**：`cacheRecentFile` 其实**已经**把附件复制了一份到 `data/chat-uploads/{conversationId}/`，只是 part 上挂的是 media 那份路径。后续追问走 `injectRecentFiles` 用的正是 chat-uploads 路径，所以追问能成功——唯独当前消息失败。

## 修复

让当前消息的 part 路径指向 `cacheRecentFile` 已经复制好的 chat-uploads 那一份：

1. `cacheRecentFile(...)` 返回类型 `void → String`，返回它复制出的 chat-uploads 绝对路径（失败/提前返回时 `null`）。
2. 消息处理处捕获返回值到 `stagedUploadPath`。
3. `extractContentParts(...)` 增加 `stagedUploadPath` 入参，在 image/file/audio/media 各分支 `applyDownload` 之后 `part.setPath(stagedUploadPath)` 覆盖 media 路径。

chat-uploads 绝对路径的 basename 就是磁盘真实文件名，`ChatUploadResolver` 的「直接 basename」分支即可命中；vision 经 `resolveImagePath` 读绝对路径照常工作。复用已有复制，无额外拷贝、无新增状态。

> 备选方案（更省事但隔离性更弱，未采用）：在 `WorkspacePathGuard` 把 `~/.mateclaw/media/` 注册成受信根。但 media 目录全局共享、不分会话，受信后任意会话理论上能读到他人上传的媒体，故不取。

## 影响范围

- 文件：`mateclaw-server/.../channel/feishu/FeishuChannelAdapter.java`（+28 / -11）
- 已知边界：富文本 `post` 多图不走 `cacheRecentFile`，本次不覆盖，保持现状，可作为后续 follow-up。
- 钉钉等同样使用 `~/.mateclaw/media/{channel}/` 的渠道可能有类似问题，本 PR 仅覆盖飞书。

## 测试

`mvn -pl mateclaw-server -am test -Dtest='Feishu*Test'`：134 个相关单元测试全过。