### PR TITLE
fix(channel): 修正飞书媒体下载权限 scope（im:message:readonly）

### DIFF
--- a/mateclaw-ui/src/components/channels/ChannelEditModal.vue
+++ b/mateclaw-ui/src/components/channels/ChannelEditModal.vue
@@ -667,7 +667,7 @@ const feishuRequiredPermissions = computed(() => {
     perms.push({ scope: 'contact:user.base:readonly', desc: t('channels.feishu.perm.contact'), reason: t('channels.feishu.perm.contactReason') })
   }
   if (channelConfig.value?.media_download_enabled) {
-    perms.push({ scope: 'im:message.resource', desc: t('channels.feishu.perm.media'), reason: t('channels.feishu.perm.mediaReason') })
+    perms.push({ scope: 'im:message:readonly', desc: t('channels.feishu.perm.media'), reason: t('channels.feishu.perm.mediaReason') })
   }
   return perms
 })


### PR DESCRIPTION
closes #268

## 问题

飞书渠道配置页「所需权限」中媒体下载显示的 scope 为 `im:message.resource`，该 scope 在飞书开放平台权限列表中不存在，导致用户无法按提示完成权限申请。

## 原因

飞书媒体资源下载所需权限为 `im:message:readonly`，媒体访问能力已包含在消息读取权限内，并非独立 scope。

## 变更

`mateclaw-ui/src/components/channels/ChannelEditModal.vue`：

```diff
-    perms.push({ scope: 'im:message.resource', ... })
+    perms.push({ scope: 'im:message:readonly', ... })
```

仅此一行改动（替代 #269 —— 那条分支误从本地 dev-local 切出夹带了大量无关提交）。

## 测试

- [ ] 飞书渠道配置页开启「媒体下载」后，权限面板显示 `im:message:readonly`
- [ ] 其他权限项展示不受影响