### PR TITLE
fix(cron): silent 运行的 Token 计入设置页总统计

### DIFF
--- a/mateclaw-server/src/main/java/vip/mate/cron/service/CronJobLifecycleService.java
+++ b/mateclaw-server/src/main/java/vip/mate/cron/service/CronJobLifecycleService.java
@@ -211,7 +211,17 @@ public class CronJobLifecycleService {
             // real content to deliver or to learn from.
             String marker = i18n != null ? i18n.msg("cron.run.silent")
                     : "（本次定时任务无新内容，已跳过）";
-            conversationService.saveMessage(convId, "assistant", marker);
+            // A silent run still made a full LLM call, so carry its token usage
+            // onto the marker message — otherwise the settings-page total (which
+            // aggregates MessageEntity token columns) under-counts cron spend.
+            if (chatResult != null
+                    && (chatResult.promptTokens() > 0 || chatResult.completionTokens() > 0)) {
+                conversationService.saveMessage(convId, "assistant", marker, null, "completed",
+                        chatResult.promptTokens(), chatResult.completionTokens(),
+                        chatResult.runtimeModel(), chatResult.runtimeProvider());
+            } else {
+                conversationService.saveMessage(convId, "assistant", marker);
+            }
             return;
         }
 


### PR DESCRIPTION
## Summary

修复 #284：定时任务的 silent(无新内容)运行虽已完整调用 LLM 消耗了 token，但占位 marker 消息用的是不带 token 的 `saveMessage` 重载，导致设置页"总 Token 统计"(聚合 `MessageEntity` 的 token 列)漏掉了这部分消耗。

本 PR 让 silent 分支的 marker 消息也带上 `chatResult` 的 prompt/completion token，与非 silent 分支口径对齐。

- 改动一处：`CronJobLifecycleService.finishRunAndPublish()` 的 silent 分支。
- 零数据迁移；非 silent 运行行为不变。
- token 为 0 时仍走原简易重载，不引入空 token 列。

## Test plan

- [x] `mvn -pl mateclaw-server compile` 通过。
- [ ] silent 定时任务运行后，设置页 Token 统计应包含该次运行的 token；调度中心运行记录 `tokenUsage` 与之一致。
- [ ] 非 silent 成功运行的统计行为保持不变（回归）。

Closes #284