### PR TITLE
docs(webchat): clarify agentId is pinned at conversation creation

### DIFF
--- a/mateclaw-server/src/main/java/vip/mate/channel/webchat/WebChatController.java
+++ b/mateclaw-server/src/main/java/vip/mate/channel/webchat/WebChatController.java
@@ -328,7 +328,10 @@ public class WebChatController {
         private String message;
         private String visitorId;
         /** Optional: route this call to a specific agent instead of the channel's bound agent.
-         *  Must belong to the channel's workspace. */
+         *  Must belong to the channel's workspace.
+         *  <p>Only applied when the (visitorId + sessionId) conversation is first created. Once that
+         *  conversation exists, its agent is fixed: a different agentId on later requests is silently
+         *  ignored. To talk to another agent, use a new sessionId (or a new visitorId). */
         private Long agentId;
         /** Optional: open a distinct conversation thread for the same visitor.
          *  Composed into the server-derived conversationId; never used as a raw conversationId. */


### PR DESCRIPTION
## 背景

承接 #296 的 review 提醒（@matevip）：WebChat stream 接口中，`agentId` 只在 `(visitorId + sessionId)` 会话**首次创建**时生效；会话建立后，后续请求即便传入不同的 `agentId` 也会沿用建会话时的 agent，新值被静默忽略。

维护者建议「要么把 agentId 纳入会话 key 支持同会话切 agent，要么在文档里说明这个行为」。考虑到把 agentId 纳入会话 key 属于改变会话标识生成方式的破坏性变更（影响存量会话），本 PR 选择**文档说明**这一无破坏性方案。

## 改动

仅在 `WebChatRequest.agentId` 字段的 Javadoc 补充行为说明，**零代码逻辑变更**：

- 说明 agentId 仅在会话首次创建时生效；
- 会话建立后 agent 固定，后续不同 agentId 被静默忽略；
- 如需对话另一个 agent，使用新的 sessionId（或新的 visitorId）。

## 测试

纯 Javadoc 改动，无需新增测试；不影响编译。