### PR TITLE
fix(feishu): recover recent files from disk when in-memory cache misses

### DIFF
--- a/mateclaw-server/src/main/java/vip/mate/channel/feishu/FeishuChannelAdapter.java
+++ b/mateclaw-server/src/main/java/vip/mate/channel/feishu/FeishuChannelAdapter.java
@@ -222,10 +222,14 @@ public class FeishuChannelAdapter extends AbstractChannelAdapter implements Stre
 
     record RecentFileEntry(String fileName, String path, String fileUrl, String contentType) {}
 
-    private final Cache<String, List<RecentFileEntry>> recentFileCache = Caffeine.newBuilder()
+    // Package-private for testing: seed the cache directly to verify injection paths.
+    final Cache<String, List<RecentFileEntry>> recentFileCache = Caffeine.newBuilder()
             .expireAfterWrite(RECENT_FILE_TTL_MINUTES, TimeUnit.MINUTES)
             .maximumSize(200)
             .build();
+
+    // Package-private for testing: redirect to a temp directory without touching real disk.
+    Path chatUploadsRoot = Path.of("data", "chat-uploads");
 
     public FeishuChannelAdapter(ChannelEntity channelEntity,
                                 ChannelMessageRouter messageRouter,
@@ -1709,7 +1713,7 @@ public class FeishuChannelAdapter extends AbstractChannelAdapter implements Stre
             if (dl == null) return null;
 
             // Save to data/chat-uploads/{conversationId}/
-            Path uploadDir = Path.of("data", "chat-uploads", conversationId);
+            Path uploadDir = chatUploadsRoot.resolve(conversationId);
             Files.createDirectories(uploadDir);
             String rawName = (dl.fileName() != null && !dl.fileName().isBlank())
                     ? dl.fileName() : fileKey;
@@ -1751,7 +1755,8 @@ public class FeishuChannelAdapter extends AbstractChannelAdapter implements Stre
      *
      * @return updated textContent with file descriptions appended
      */
-    private String injectRecentFiles(String conversationId, List<MessageContentPart> parts, String textContent) {
+    // Package-private for testing.
+    String injectRecentFiles(String conversationId, List<MessageContentPart> parts, String textContent) {
         List<RecentFileEntry> recent = recentFileCache.getIfPresent(conversationId);
         if (recent == null || recent.isEmpty()) {
             // Fallback: scan data/chat-uploads/{conversationId}/ on disk.
@@ -1798,11 +1803,27 @@ public class FeishuChannelAdapter extends AbstractChannelAdapter implements Stre
      * are still on disk.
      */
     private List<RecentFileEntry> loadRecentFilesFromDisk(String conversationId) {
-        Path dir = Path.of("data", "chat-uploads", conversationId);
+        long cutoff = System.currentTimeMillis() - RECENT_FILE_TTL_MINUTES * 60_000L;
+        return loadRecentFilesFromDisk(chatUploadsRoot.resolve(conversationId), cutoff);
+    }
+
+    /**
+     * Package-private for testing: explicit {@code dir} and {@code cutoffMs} make the
+     * test deterministic without temp-directory path construction or time mocking.
+     * Production callers go through {@link #loadRecentFilesFromDisk(String)}.
+     */
+    List<RecentFileEntry> loadRecentFilesFromDisk(Path dir, long cutoffMs) {
         if (!Files.isDirectory(dir)) return List.of();
         try (var stream = Files.list(dir)) {
             return stream
                     .filter(Files::isRegularFile)
+                    .filter(p -> {
+                        try {
+                            return Files.getLastModifiedTime(p).toMillis() >= cutoffMs;
+                        } catch (Exception e) {
+                            return true;
+                        }
+                    })
                     .sorted((a, b) -> {
                         try {
                             return Long.compare(

--- a/mateclaw-server/src/main/java/vip/mate/channel/feishu/FeishuChannelAdapter.java
+++ b/mateclaw-server/src/main/java/vip/mate/channel/feishu/FeishuChannelAdapter.java
@@ -1669,6 +1669,7 @@ public class FeishuChannelAdapter extends AbstractChannelAdapter implements Stre
     private String cacheRecentFile(String messageId, String messageType, String contentStr,
                                   String conversationId) {
         try {
+            log.info("[feishu] cacheRecentFile: type={}, conversationId={}, messageId={}", messageType, conversationId, messageId);
             Map<String, Object> contentObj = objectMapper.readValue(contentStr, Map.class);
 
             String fileKey = null;
@@ -1738,7 +1739,7 @@ public class FeishuChannelAdapter extends AbstractChannelAdapter implements Stre
 
             return dest.toAbsolutePath().toString();
         } catch (Exception e) {
-            log.debug("[feishu] Failed to cache recent file: {}", e.getMessage());
+            log.warn("[feishu] Failed to cache recent file for conversation={}: {}", conversationId, e.getMessage(), e);
             return null;
         }
     }
@@ -1752,7 +1753,14 @@ public class FeishuChannelAdapter extends AbstractChannelAdapter implements Stre
      */
     private String injectRecentFiles(String conversationId, List<MessageContentPart> parts, String textContent) {
         List<RecentFileEntry> recent = recentFileCache.getIfPresent(conversationId);
-        if (recent == null || recent.isEmpty()) return textContent;
+        if (recent == null || recent.isEmpty()) {
+            // Fallback: scan data/chat-uploads/{conversationId}/ on disk.
+            // Survives process restart / Caffeine TTL expiry / GC eviction.
+            recent = loadRecentFilesFromDisk(conversationId);
+            if (recent.isEmpty()) return textContent;
+            log.info("[feishu] injectRecentFiles: cache miss, recovered {} file(s) from disk for conversation={}",
+                    recent.size(), conversationId);
+        }
 
         // Collect paths already in parts to avoid duplicates
         Set<String> existingPaths = new java.util.HashSet<>();
@@ -1780,6 +1788,75 @@ public class FeishuChannelAdapter extends AbstractChannelAdapter implements Stre
             text.append("[用户发送了文件: ").append(entry.fileName()).append("]");
         }
         return text.toString();
+    }
+
+    /**
+     * Scan {@code data/chat-uploads/{conversationId}/} on disk and return
+     * the most recent files as {@link RecentFileEntry}s.  Used as a
+     * fallback when the in-memory Caffeine cache has been evicted
+     * (process restart, TTL expiry, GC pressure) but the staged copies
+     * are still on disk.
+     */
+    private List<RecentFileEntry> loadRecentFilesFromDisk(String conversationId) {
+        Path dir = Path.of("data", "chat-uploads", conversationId);
+        if (!Files.isDirectory(dir)) return List.of();
+        try (var stream = Files.list(dir)) {
+            return stream
+                    .filter(Files::isRegularFile)
+                    .sorted((a, b) -> {
+                        try {
+                            return Long.compare(
+                                    Files.getLastModifiedTime(b).toMillis(),
+                                    Files.getLastModifiedTime(a).toMillis());
+                        } catch (Exception e) {
+                            return 0;
+                        }
+                    })
+                    .limit(RECENT_FILE_MAX_PER_CHAT)
+                    .map(p -> {
+                        String fileName = p.getFileName().toString();
+                        // Strip timestamp prefix (e.g. "1777391026594_report.pdf" → "report.pdf")
+                        int sep = fileName.indexOf('_');
+                        String display = (sep > 0 && sep < 20) ? fileName.substring(sep + 1) : fileName;
+                        String contentType = guessContentType(p);
+                        return new RecentFileEntry(display, p.toAbsolutePath().toString(), null, contentType);
+                    })
+                    .toList();
+        } catch (Exception e) {
+            log.debug("[feishu] Failed to scan disk for recent files in {}: {}", dir, e.getMessage());
+            return List.of();
+        }
+    }
+
+    /** Best-effort content type from file extension. */
+    private static String guessContentType(Path p) {
+        String name = p.getFileName().toString().toLowerCase();
+        if (name.endsWith(".pdf")) return "application/pdf";
+        if (name.endsWith(".docx")) return "application/vnd.openxmlformats-officedocument.wordprocessingml.document";
+        if (name.endsWith(".xlsx")) return "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet";
+        if (name.endsWith(".pptx")) return "application/vnd.openxmlformats-officedocument.presentationml.presentation";
+        if (name.endsWith(".doc")) return "application/msword";
+        if (name.endsWith(".xls")) return "application/vnd.ms-excel";
+        if (name.endsWith(".ppt")) return "application/vnd.ms-powerpoint";
+        if (name.endsWith(".txt")) return "text/plain";
+        if (name.endsWith(".csv")) return "text/csv";
+        if (name.endsWith(".json")) return "application/json";
+        if (name.endsWith(".xml")) return "application/xml";
+        if (name.endsWith(".md")) return "text/markdown";
+        if (name.endsWith(".png")) return "image/png";
+        if (name.endsWith(".jpg") || name.endsWith(".jpeg")) return "image/jpeg";
+        if (name.endsWith(".gif")) return "image/gif";
+        if (name.endsWith(".webp")) return "image/webp";
+        if (name.endsWith(".mp3")) return "audio/mpeg";
+        if (name.endsWith(".ogg")) return "audio/ogg";
+        if (name.endsWith(".opus")) return "audio/opus";
+        if (name.endsWith(".wav")) return "audio/wav";
+        if (name.endsWith(".mp4")) return "video/mp4";
+        if (name.endsWith(".mov")) return "video/quicktime";
+        if (name.endsWith(".zip")) return "application/zip";
+        if (name.endsWith(".rar")) return "application/x-rar-compressed";
+        if (name.endsWith(".7z")) return "application/x-7z-compressed";
+        return "application/octet-stream";
     }
 
     // ==================== 消息内容解析 ====================

--- a/mateclaw-server/src/test/java/vip/mate/channel/feishu/FeishuRecentFileCacheTest.java
+++ b/mateclaw-server/src/test/java/vip/mate/channel/feishu/FeishuRecentFileCacheTest.java
@@ -1,0 +1,273 @@
+package vip.mate.channel.feishu;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+import vip.mate.channel.ChannelMessageRouter;
+import vip.mate.channel.model.ChannelEntity;
+import vip.mate.workspace.conversation.model.MessageContentPart;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.attribute.FileTime;
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.mock;
+
+/**
+ * Unit tests for the per-chat recent-file cache:
+ *
+ * <ul>
+ *   <li>{@link FeishuChannelAdapter#loadRecentFilesFromDisk(Path, long)} — disk scan with
+ *       explicit dir and TTL cutoff so tests never touch the real filesystem or depend on
+ *       wall-clock time.</li>
+ *   <li>{@link FeishuChannelAdapter#injectRecentFiles} — Caffeine cache-hit and cache-miss
+ *       (disk fallback) paths, duplicate dedup, image vs file part typing.</li>
+ * </ul>
+ */
+class FeishuRecentFileCacheTest {
+
+    // ==================== helpers ====================
+
+    private static FeishuChannelAdapter newAdapter() {
+        ChannelEntity e = new ChannelEntity();
+        e.setId(1L);
+        e.setChannelType("feishu");
+        e.setConfigJson("{\"app_id\":\"cli_test\",\"app_secret\":\"x\"}");
+        return new FeishuChannelAdapter(
+                e, mock(ChannelMessageRouter.class), new ObjectMapper(),
+                null, null, null, null, null, null, null);
+    }
+
+    /** Write a tiny file and stamp its last-modified time. */
+    private static Path touch(Path dir, String name, long lastModifiedMs) throws IOException {
+        Path file = dir.resolve(name);
+        Files.writeString(file, "x");
+        Files.setLastModifiedTime(file, FileTime.fromMillis(lastModifiedMs));
+        return file;
+    }
+
+    private static final long NOW = System.currentTimeMillis();
+    private static final long FIVE_MIN_AGO = NOW - 5 * 60_000L;
+    private static final long TEN_MIN_AGO  = NOW - 10 * 60_000L;
+    private static final long OLD           = NOW - 90 * 60_000L; // > 60-min TTL
+
+    // ==================== loadRecentFilesFromDisk ====================
+
+    @Test
+    void loadFromDisk_nonExistentDir_returnsEmpty(@TempDir Path tmp) {
+        FeishuChannelAdapter a = newAdapter();
+        List<FeishuChannelAdapter.RecentFileEntry> result =
+                a.loadRecentFilesFromDisk(tmp.resolve("no-such"), NOW - 60 * 60_000L);
+        assertTrue(result.isEmpty());
+    }
+
+    @Test
+    void loadFromDisk_emptyDir_returnsEmpty(@TempDir Path tmp) throws IOException {
+        Path dir = tmp.resolve("chat"); Files.createDirectories(dir);
+        FeishuChannelAdapter a = newAdapter();
+        assertTrue(a.loadRecentFilesFromDisk(dir, NOW - 60 * 60_000L).isEmpty());
+    }
+
+    @Test
+    void loadFromDisk_freshFiles_returnedSortedNewestFirst(@TempDir Path tmp) throws IOException {
+        Path dir = tmp.resolve("chat"); Files.createDirectories(dir);
+        touch(dir, "1000000000001_a.txt", TEN_MIN_AGO);
+        touch(dir, "1000000000002_b.txt", FIVE_MIN_AGO);
+
+        FeishuChannelAdapter a = newAdapter();
+        long cutoff = NOW - 60 * 60_000L;
+        List<FeishuChannelAdapter.RecentFileEntry> result = a.loadRecentFilesFromDisk(dir, cutoff);
+
+        assertEquals(2, result.size());
+        // newest first
+        assertEquals("b.txt", result.get(0).fileName());
+        assertEquals("a.txt", result.get(1).fileName());
+    }
+
+    @Test
+    void loadFromDisk_staleFiles_excluded(@TempDir Path tmp) throws IOException {
+        Path dir = tmp.resolve("chat"); Files.createDirectories(dir);
+        touch(dir, "1000000000001_old.txt", OLD);
+
+        FeishuChannelAdapter a = newAdapter();
+        long cutoff = NOW - 60 * 60_000L;
+        assertTrue(a.loadRecentFilesFromDisk(dir, cutoff).isEmpty());
+    }
+
+    @Test
+    void loadFromDisk_mixFreshAndStale_onlyFreshReturned(@TempDir Path tmp) throws IOException {
+        Path dir = tmp.resolve("chat"); Files.createDirectories(dir);
+        touch(dir, "1000000000001_fresh.pdf", FIVE_MIN_AGO);
+        touch(dir, "1000000000002_stale.pdf", OLD);
+
+        FeishuChannelAdapter a = newAdapter();
+        long cutoff = NOW - 60 * 60_000L;
+        List<FeishuChannelAdapter.RecentFileEntry> result = a.loadRecentFilesFromDisk(dir, cutoff);
+
+        assertEquals(1, result.size());
+        assertEquals("fresh.pdf", result.get(0).fileName());
+    }
+
+    @Test
+    void loadFromDisk_moreThan5FreshFiles_cappedAtMax(@TempDir Path tmp) throws IOException {
+        Path dir = tmp.resolve("chat"); Files.createDirectories(dir);
+        for (int i = 1; i <= 7; i++) {
+            touch(dir, "100000000000" + i + "_f" + i + ".txt", FIVE_MIN_AGO - i * 1000L);
+        }
+
+        FeishuChannelAdapter a = newAdapter();
+        long cutoff = NOW - 60 * 60_000L;
+        List<FeishuChannelAdapter.RecentFileEntry> result = a.loadRecentFilesFromDisk(dir, cutoff);
+
+        assertEquals(5, result.size()); // RECENT_FILE_MAX_PER_CHAT
+    }
+
+    @Test
+    void loadFromDisk_timestampPrefixStripped(@TempDir Path tmp) throws IOException {
+        Path dir = tmp.resolve("chat"); Files.createDirectories(dir);
+        touch(dir, "1777391026594_report.pdf", FIVE_MIN_AGO);
+        // No-underscore name: no stripping
+        touch(dir, "plain.pdf", TEN_MIN_AGO);
+
+        FeishuChannelAdapter a = newAdapter();
+        long cutoff = NOW - 60 * 60_000L;
+        List<FeishuChannelAdapter.RecentFileEntry> result = a.loadRecentFilesFromDisk(dir, cutoff);
+
+        assertEquals(2, result.size());
+        // newest first is the one with timestamp prefix
+        assertEquals("report.pdf", result.get(0).fileName());
+        assertEquals("plain.pdf", result.get(1).fileName());
+    }
+
+    @Test
+    void loadFromDisk_contentTypeGuessingByExtension(@TempDir Path tmp) throws IOException {
+        Path dir = tmp.resolve("chat"); Files.createDirectories(dir);
+        touch(dir, "1000000000001_doc.pdf", FIVE_MIN_AGO);
+        touch(dir, "1000000000002_img.png", TEN_MIN_AGO);
+        touch(dir, "1000000000003_mystery.xyz", OLD - 1); // stale, should be excluded
+
+        FeishuChannelAdapter a = newAdapter();
+        long cutoff = NOW - 60 * 60_000L;
+        List<FeishuChannelAdapter.RecentFileEntry> result = a.loadRecentFilesFromDisk(dir, cutoff);
+
+        assertEquals(2, result.size());
+        assertEquals("application/pdf", result.get(0).contentType());
+        assertEquals("image/png", result.get(1).contentType());
+    }
+
+    // ==================== injectRecentFiles ====================
+
+    @Test
+    void injectRecentFiles_cacheHit_injectsFromCache(@TempDir Path tmp) {
+        FeishuChannelAdapter a = newAdapter();
+        a.chatUploadsRoot = tmp; // no disk files — only cache should be hit
+
+        String convId = "feishu:oc_test123";
+        a.recentFileCache.put(convId, List.of(
+                new FeishuChannelAdapter.RecentFileEntry("report.pdf", "/tmp/report.pdf",
+                        null, "application/pdf")
+        ));
+
+        List<MessageContentPart> parts = new ArrayList<>();
+        String text = a.injectRecentFiles(convId, parts, "请分析");
+
+        assertEquals(1, parts.size());
+        assertEquals("file", parts.get(0).getType());
+        assertEquals("report.pdf", parts.get(0).getFileName());
+        assertTrue(text.contains("[用户发送了文件: report.pdf]"));
+    }
+
+    @Test
+    void injectRecentFiles_cacheMiss_diskHasFreshFile_fallsBackToDisk(@TempDir Path tmp) throws IOException {
+        FeishuChannelAdapter a = newAdapter();
+        a.chatUploadsRoot = tmp;
+
+        String convId = "feishu:oc_groupX";
+        Path convDir = tmp.resolve(convId);
+        Files.createDirectories(convDir);
+        Files.writeString(convDir.resolve("1000000000001_summary.txt"), "content");
+
+        List<MessageContentPart> parts = new ArrayList<>();
+        String text = a.injectRecentFiles(convId, parts, "帮我看看");
+
+        assertEquals(1, parts.size(), "disk fallback should inject the file");
+        assertEquals("summary.txt", parts.get(0).getFileName());
+        assertTrue(text.contains("[用户发送了文件: summary.txt]"));
+    }
+
+    @Test
+    void injectRecentFiles_cacheMiss_diskEmpty_noChange(@TempDir Path tmp) {
+        FeishuChannelAdapter a = newAdapter();
+        a.chatUploadsRoot = tmp;
+
+        List<MessageContentPart> parts = new ArrayList<>();
+        String original = "帮我看看";
+        String text = a.injectRecentFiles("feishu:oc_empty", parts, original);
+
+        assertTrue(parts.isEmpty());
+        assertEquals(original, text);
+    }
+
+    @Test
+    void injectRecentFiles_duplicatePathSkipped(@TempDir Path tmp) {
+        FeishuChannelAdapter a = newAdapter();
+        a.chatUploadsRoot = tmp;
+
+        String convId = "feishu:oc_dedup";
+        String existingPath = "/some/path/file.pdf";
+        a.recentFileCache.put(convId, List.of(
+                new FeishuChannelAdapter.RecentFileEntry("file.pdf", existingPath,
+                        null, "application/pdf")
+        ));
+
+        // part already carrying the same path
+        MessageContentPart existing = MessageContentPart.file("key", "file.pdf", null);
+        existing.setPath(existingPath);
+        List<MessageContentPart> parts = new ArrayList<>(List.of(existing));
+
+        a.injectRecentFiles(convId, parts, "");
+
+        // size unchanged — duplicate suppressed
+        assertEquals(1, parts.size());
+    }
+
+    @Test
+    void injectRecentFiles_imageEntry_setsTypeImage(@TempDir Path tmp) {
+        FeishuChannelAdapter a = newAdapter();
+        a.chatUploadsRoot = tmp;
+
+        String convId = "feishu:oc_img";
+        a.recentFileCache.put(convId, List.of(
+                new FeishuChannelAdapter.RecentFileEntry("photo.png", "/tmp/photo.png",
+                        null, "image/png")
+        ));
+
+        List<MessageContentPart> parts = new ArrayList<>();
+        a.injectRecentFiles(convId, parts, "");
+
+        assertEquals(1, parts.size());
+        assertEquals("image", parts.get(0).getType());
+    }
+
+    @Test
+    void injectRecentFiles_nullTextContent_handledGracefully(@TempDir Path tmp) {
+        FeishuChannelAdapter a = newAdapter();
+        a.chatUploadsRoot = tmp;
+
+        String convId = "feishu:oc_nulltext";
+        a.recentFileCache.put(convId, List.of(
+                new FeishuChannelAdapter.RecentFileEntry("data.csv", "/tmp/data.csv",
+                        null, "text/csv")
+        ));
+
+        List<MessageContentPart> parts = new ArrayList<>();
+        String text = a.injectRecentFiles(convId, parts, null);
+
+        assertFalse(text.isBlank());
+        assertTrue(text.contains("data.csv"));
+    }
+}


### PR DESCRIPTION
## Problem

When a Feishu group member sends a file and then follows up with a text message asking the bot to process it, the bot replied "I cannot receive the file."

Two related root causes:

**Root cause 1 — In-memory cache lost on restart / TTL expiry**
The per-chat recent-file cache (Caffeine, 60-min TTL) is purely in-memory. After a process restart or TTL expiry, the cache is empty, but the staged copies under `data/chat-uploads/` survive on disk. A follow-up text message found nothing and the bot replied as if no file was ever sent.

**Root cause 2 — Disk fallback had no TTL filter**
The disk fallback scanned _all_ files in `data/chat-uploads/{conversationId}/` regardless of age. This would inject files from hours or days ago into unrelated future conversations, bypassing the 60-min TTL that the Caffeine cache enforces.

## Changes

**`FeishuChannelAdapter.java`**
- `injectRecentFiles()`: fall back to scanning `data/chat-uploads/{conversationId}/` when the Caffeine cache misses (survives restart / TTL expiry / GC eviction)
- `loadRecentFilesFromDisk()`: filter out files older than `RECENT_FILE_TTL_MINUTES` (60 min) so the disk fallback honours the same TTL as the Caffeine cache
- Testability refactoring (no behaviour change):
  - `recentFileCache`: `private` → package-private (tests seed the cache directly)
  - `chatUploadsRoot`: new package-private `Path` field (tests redirect to `@TempDir`)
  - `loadRecentFilesFromDisk(Path dir, long cutoffMs)`: package-private overload for deterministic unit tests without wall-clock or filesystem coupling
  - `injectRecentFiles`: `private` → package-private
- `cacheRecentFile()`: catch log promoted from `debug` → `warn` with full stack trace

**`FeishuRecentFileCacheTest.java`** (new, 14 cases)
- `loadRecentFilesFromDisk`: non-existent dir, empty dir, fresh files sorted newest-first, stale files excluded by TTL, mixed fresh + stale, >5 files capped at max, timestamp-prefix stripping, MIME guessing from extension
- `injectRecentFiles`: Caffeine cache hit, cache-miss disk fallback, empty disk, duplicate-path dedup, image vs file part typing, null textContent guard

## Test plan

- [ ] All 14 new unit tests pass (`mvn test -Dtest=FeishuRecentFileCacheTest`)
- [ ] Existing Feishu tests unaffected (`FeishuInboundResourceTest`, `FeishuSessionIdTest`, `FeishuConversationIdAlignmentTest`, `FeishuMentionTest`)
- [ ] Manual: send a file in a Feishu group → restart the server → send a follow-up text → bot correctly injects the cached file
- [ ] Manual: file older than 60 min is **not** injected into new messages

Closes #325