### PR TITLE
fix: reuse shared HttpClient to prevent thread-leak OOM on model test

### DIFF
--- a/mateclaw-server/src/main/java/vip/mate/llm/service/ModelDiscoveryService.java
+++ b/mateclaw-server/src/main/java/vip/mate/llm/service/ModelDiscoveryService.java
@@ -66,6 +66,13 @@ public class ModelDiscoveryService {
 
     private static final Duration TIMEOUT = Duration.ofSeconds(10);
 
+    // Shared HttpClient for OpenAI-compatible providers — avoids creating a new
+    // native thread + connection pool per request (was causing thread-leak OOM).
+    private static final HttpClient SHARED_HTTP_CLIENT = HttpClient.newBuilder()
+            .version(HttpClient.Version.HTTP_1_1)
+            .connectTimeout(Duration.ofSeconds(30))
+            .build();
+
     // Virtual-thread executor for parallel model probing (lightweight, short-lived)
     private static final ExecutorService PROBE_EXECUTOR = Executors.newVirtualThreadPerTaskExecutor();
 
@@ -962,10 +969,7 @@ public class ModelDiscoveryService {
      * the upgrade negotiation.
      */
     private RestClient.Builder openAiCompatibleClientBuilder() {
-        HttpClient httpClient = HttpClient.newBuilder()
-                .version(HttpClient.Version.HTTP_1_1)
-                .build();
-        return RestClient.builder().requestFactory(new JdkClientHttpRequestFactory(httpClient));
+        return RestClient.builder().requestFactory(new JdkClientHttpRequestFactory(SHARED_HTTP_CLIENT));
     }
 
     @SuppressWarnings("unchecked")


### PR DESCRIPTION
## Summary

- `openAiCompatibleClientBuilder()` 每次调用都创建新的 `java.net.http.HttpClient`，其内部 selector 线程和连接池从不回收，频繁测试模型时耗尽系统线程上限导致 `OutOfMemoryError: unable to create native thread`
- 将 `HttpClient` 提升为 `static final` 单例，所有 OpenAI 兼容 provider 共享同一组线程和连接池

## Test plan

- [x] 运行 `ModelDiscoveryEmbeddingDetectionTest` 和 `ModelDiscoveryServiceChatGPTOAuthTest` 通过
- [ ] 部署后手动测试 DeepSeek 模型可用性检查，确认不再出现线程泄漏

Closes matevip/mateclaw#328