### PR TITLE
fix(channels): don't gate webchat creation on auto-generated API Key

### DIFF
--- a/mateclaw-ui/src/components/channels/ChannelOnboardingWizard.vue
+++ b/mateclaw-ui/src/components/channels/ChannelOnboardingWizard.vue
@@ -393,8 +393,13 @@ const subtitle = computed(() =>
 )
 
 const allFields = computed<ChannelFieldDef[]>(() => CHANNEL_FIELD_DEFS[channelType.value] || [])
-const requiredFields = computed(() => allFields.value.filter((f) => f.required))
-const optionalFields = computed(() => allFields.value.filter((f) => !f.required))
+// readOnly fields are platform-generated on save (e.g. webchat's api_key) — the
+// user can't enter them during creation, so they must never gate "Continue" nor
+// render as fillable inputs here. They show up (required, readOnly) in the edit
+// modal once a value exists.
+const editableFields = computed(() => allFields.value.filter((f) => !f.readOnly))
+const requiredFields = computed(() => editableFields.value.filter((f) => f.required))
+const optionalFields = computed(() => editableFields.value.filter((f) => !f.required))
 
 const hasVerifier = computed(() => VERIFIABLE_TYPES.has(channelType.value))
 const isOAuthStyle = computed(() => OAUTH_STYLE_TYPES.has(channelType.value))


### PR DESCRIPTION
## 问题

在「渠道 → 新建 → Web / API 接入（webchat）」创建向导第 1 步，`api_key` 字段被标记为必填（`*`）且只读，占位符为「保存后由平台自动生成」。由于该字段在创建阶段为空、又是只读无法输入，`canSubmitConfig` 永远无法通过，导致「继续」按钮始终禁用，无法完成 webchat 渠道创建。

Fixes #338

## 改动

`ChannelOnboardingWizard.vue`：将 `readOnly`（平台自动生成）字段排除出向导的 `requiredFields` / `optionalFields`。这类字段用户在创建阶段无法填写，因此既不应作为「继续」的必填校验门槛，也不应渲染为可输入项。

- **创建时**：webchat 第 1 步仅展示说明文案，`api_key` 由后端在保存时生成，「继续」可正常点击。
- **编辑时**：`ChannelEditModal` 不受影响 —— `api_key` 仍以必填（`*`）+ 只读形式展示已生成的值。

该修改对其他渠道类型无影响（webchat 的 `api_key` 是唯一标记 `readOnly` 的字段）。

## 测试

- `npx vue-tsc --noEmit` 通过，无类型错误。
- 该改动为只读字段的派生过滤（presentational），未新增单元测试。