### PR TITLE
docs(security): correct generated-file TTL comment (7 days, not 10 min)

### DIFF
--- a/mateclaw-server/src/main/java/vip/mate/config/SecurityConfig.java
+++ b/mateclaw-server/src/main/java/vip/mate/config/SecurityConfig.java
@@ -62,7 +62,9 @@ public class SecurityConfig {
                     "/api/v1/channels/webhook/**",
                     "/api/v1/channels/webchat/**",
                     "/api/v1/talk/ws",
-                    // RFC-045: tool-generated files served via unguessable UUID + 10-min TTL
+                    // RFC-045: tool-generated files served via unguessable UUID; entries
+                    // expire after GeneratedFileCache.TTL (7 days) — delayed access (e.g. an
+                    // IM-delivered link opened later) is intentional, the UUID is the guard.
                     "/api/v1/files/generated/**"
                 ).permitAll()
                 // 所有其他 API 接口需要认证


### PR DESCRIPTION
## 改动

`SecurityConfig` 中 `/api/v1/files/generated/**` 的放行注释写的是「10-min TTL」,但实际 `GeneratedFileCache.TTL = Duration.ofDays(7)`。仅修正注释使其与代码一致。

7 天是有意设计(生成链接常经 IM 推送、延迟点开),不是 bug;安全防线始终是不可猜测的 UUID。过时注释的风险在于误导后续安全判断(例如以为"这种 URL 进日志无所谓,10 分钟就失效")。

纯注释,无行为变更。

Refs #344