### PR TITLE
feat(webchat): stop an in-flight session stream (POST /sessions/stop)

### DIFF
--- a/mateclaw-server/src/main/java/vip/mate/channel/webchat/WebChatController.java
+++ b/mateclaw-server/src/main/java/vip/mate/channel/webchat/WebChatController.java
@@ -7,15 +7,24 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.core.io.FileSystemResource;
+import org.springframework.core.io.Resource;
+import org.springframework.http.HttpHeaders;
 import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
+import org.springframework.web.multipart.MultipartFile;
 import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
 
 import javax.crypto.Mac;
 import javax.crypto.spec.SecretKeySpec;
+import java.net.URLEncoder;
 import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.security.GeneralSecurityException;
 import java.security.MessageDigest;
+import java.util.ArrayList;
 import java.util.Base64;
 import vip.mate.channel.web.Utf8SseEmitter;
 import vip.mate.agent.AgentService;
@@ -63,6 +72,7 @@ public class WebChatController {
     private final ObjectMapper objectMapper;
     private final ConversationCompletionPublisher completionPublisher;
     private final vip.mate.memory.identity.MemoryOwnerResolver memoryOwnerResolver;
+    private final WebChatFileService fileService;
 
     /**
      * Server-only secret used to sign per-visitor tokens. Reuses the JWT secret so no extra
@@ -158,8 +168,10 @@ public class WebChatController {
                 Long webWsId = webAgent != null ? webAgent.getWorkspaceId() : 1L;
                 var conv = conversationService.getOrCreateConversation(conversationId, resolvedAgentId, webchatUsername(visitorId), webWsId);
 
-                // 保存用户消息
-                conversationService.saveMessage(conversationId, "user", message, List.of());
+                // 保存用户消息（含访客本轮引用的附件）。附件元数据一律服务端按 fileId 回查，
+                // 不信客户端传入；path 用于 Agent 侧工具读取，对外消息视图会被剥离。
+                List<MessageContentPart> userParts = buildUserParts(conversationId, message, request.getAttachmentIds());
+                conversationService.saveMessage(conversationId, "user", message, userParts);
 
                 // 初始化 SSE 流跟踪
                 streamTracker.register(conversationId);
@@ -337,7 +349,8 @@ public class WebChatController {
         if (!ownsConversation(conversationId, visitorId)) {
             return R.fail(404, "Session not found");
         }
-        return R.ok(conversationService.listMessageViews(conversationId));
+        // External view: strip server-side file paths before handing messages to the visitor.
+        return R.ok(conversationService.listMessageViewsExternal(conversationId));
     }
 
     /**
@@ -369,6 +382,155 @@ public class WebChatController {
         }
         conversationService.deleteConversation(conversationId);
         return R.ok();
+    }
+
+    /**
+     * 上传文件（入站）。访客先上传拿到 fileId，再在 /stream 的 attachmentIds 中引用。
+     * <p>鉴权同会话接口：API Key + visitor token；conversationId 服务端派生。
+     */
+    @Operation(summary = "WebChat 上传文件")
+    @PostMapping(value = "/upload", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
+    public R<Map<String, Object>> uploadFile(
+            @RequestHeader("X-MC-Key") String apiKey,
+            @RequestHeader(value = "X-MC-Visitor-Token", required = false) String visitorToken,
+            @RequestParam String visitorId,
+            @RequestParam(required = false) String sessionId,
+            @RequestPart("file") MultipartFile file) {
+        ChannelEntity channel = resolveChannel(apiKey);
+        if (channel == null) {
+            return R.fail(401, "Invalid API Key");
+        }
+        if (!verifyVisitorToken(visitorTokenSecret, channel.getId(), visitorId, visitorToken)) {
+            return R.fail(401, "Invalid or missing visitor token");
+        }
+        // Upload requires an established visitor identity (the token is bound to it);
+        // unlike /stream we never mint a fresh visitorId here.
+        String vid;
+        String sid;
+        try {
+            if (visitorId == null || visitorId.trim().isEmpty()) {
+                return R.fail(400, "visitorId is required");
+            }
+            vid = normalizeVisitorId(visitorId);
+            sid = normalizeSessionId(sessionId);
+        } catch (IllegalArgumentException ex) {
+            return R.fail(400, ex.getMessage());
+        }
+        String conversationId = deriveConversationId(apiKey, vid, sid);
+        try {
+            WebChatFileService.StagedFile stored = fileService.store(conversationId, file);
+            return R.ok(Map.of(
+                    "fileId", stored.storedName(),
+                    "fileName", stored.originalName(),
+                    "contentType", stored.contentType() != null ? stored.contentType() : "application/octet-stream",
+                    "size", stored.size()
+            ));
+        } catch (WebChatFileService.UploadRejectedException ex) {
+            return R.fail(400, ex.getMessage());
+        } catch (IOException ex) {
+            log.error("[WebChat] Upload failed conv={}: {}", conversationId, ex.getMessage());
+            return R.fail(500, "Upload failed");
+        }
+    }
+
+    /**
+     * 下载文件（出站）。serves both visitor-uploaded files and agent-produced files
+     * written under the conversation dir. 鉴权同上，路径在服务端派生目录内防穿越。
+     */
+    @Operation(summary = "WebChat 下载文件")
+    @GetMapping("/files")
+    public ResponseEntity<Resource> downloadFile(
+            @RequestHeader("X-MC-Key") String apiKey,
+            @RequestHeader(value = "X-MC-Visitor-Token", required = false) String visitorToken,
+            @RequestParam String visitorId,
+            @RequestParam(required = false) String sessionId,
+            @RequestParam String storedName) {
+        ChannelEntity channel = resolveChannel(apiKey);
+        if (channel == null) {
+            return ResponseEntity.status(401).build();
+        }
+        if (!verifyVisitorToken(visitorTokenSecret, channel.getId(), visitorId, visitorToken)) {
+            return ResponseEntity.status(401).build();
+        }
+        String sid;
+        try {
+            sid = normalizeSessionId(sessionId);
+        } catch (IllegalArgumentException ex) {
+            return ResponseEntity.badRequest().build();
+        }
+        String conversationId = deriveConversationId(apiKey, visitorId, sid);
+        if (!ownsConversation(conversationId, visitorId)) {
+            return ResponseEntity.status(404).build();
+        }
+        Path file = fileService.resolve(conversationId, storedName).orElse(null);
+        if (file == null) {
+            return ResponseEntity.notFound().build();
+        }
+
+        String contentType;
+        try {
+            contentType = Files.probeContentType(file);
+        } catch (IOException e) {
+            contentType = null;
+        }
+        MediaType mediaType = MediaType.APPLICATION_OCTET_STREAM;
+        if (contentType != null) {
+            try {
+                mediaType = MediaType.parseMediaType(contentType);
+            } catch (Exception ignored) {
+                // fall back to octet-stream
+            }
+        }
+        // Only inline images; everything else downloads as an attachment. nosniff
+        // stops the browser from re-interpreting the bytes as active content.
+        boolean inlineImage = contentType != null && contentType.startsWith("image/");
+        String encodedName = URLEncoder.encode(file.getFileName().toString(), StandardCharsets.UTF_8)
+                .replace("+", "%20");
+        return ResponseEntity.ok()
+                .contentType(mediaType)
+                .header("X-Content-Type-Options", "nosniff")
+                .header(HttpHeaders.CONTENT_DISPOSITION,
+                        (inlineImage ? "inline" : "attachment") + "; filename*=UTF-8''" + encodedName)
+                .body(new FileSystemResource(file));
+    }
+
+    /**
+     * Build the user message's content parts: a text part for the message plus a
+     * file/media part for each referenced attachment. Attachment metadata is
+     * resolved server-side from the staging registry (the client only sends opaque
+     * ids); an id that is unknown, expired, or belongs to another conversation is
+     * silently dropped.
+     */
+    private List<MessageContentPart> buildUserParts(String conversationId, String message,
+                                                    List<String> attachmentIds) {
+        List<MessageContentPart> parts = new ArrayList<>();
+        if (message != null && !message.isBlank()) {
+            MessageContentPart text = new MessageContentPart();
+            text.setType("text");
+            text.setText(message);
+            parts.add(text);
+        }
+        if (attachmentIds != null) {
+            for (String fileId : attachmentIds) {
+                fileService.consume(conversationId, fileId).ifPresent(sf -> {
+                    MessageContentPart p = new MessageContentPart();
+                    p.setType(WebChatFileService.partTypeFor(sf.contentType()));
+                    p.setFileName(sf.originalName());
+                    p.setContentType(sf.contentType());
+                    p.setStoredName(sf.storedName());
+                    p.setFileSize(sf.size());
+                    // Relative download ref (caller adds auth headers + visitorId/sessionId).
+                    p.setFileUrl("/api/v1/channels/webchat/files?storedName="
+                            + URLEncoder.encode(sf.storedName(), StandardCharsets.UTF_8));
+                    // Server path lets the agent's file tools read the upload; stripped from
+                    // the external message view (listMessageViewsExternal).
+                    fileService.resolve(conversationId, sf.storedName())
+                            .ifPresent(path -> p.setPath(path.toString()));
+                    parts.add(p);
+                });
+            }
+        }
+        return parts;
     }
 
     // ==================== 内部方法 ====================
@@ -566,6 +728,10 @@ public class WebChatController {
         /** Optional: open a distinct conversation thread for the same visitor.
          *  Composed into the server-derived conversationId; never used as a raw conversationId. */
         private String sessionId;
+        /** Optional: ids returned by POST /upload, referencing files this visitor uploaded
+         *  for this conversation. Metadata is resolved server-side; unknown / foreign / expired
+         *  ids are dropped. */
+        private List<String> attachmentIds;
     }
 
     /** Compact view of one of a visitor's conversation threads. */

--- a/mateclaw-server/src/main/java/vip/mate/channel/webchat/WebChatController.java
+++ b/mateclaw-server/src/main/java/vip/mate/channel/webchat/WebChatController.java
@@ -203,7 +203,7 @@ public class WebChatController {
                                 .withSender(null, "api", null);
                 String webchatOwnerKey = memoryOwnerResolver.resolve(webchatOrigin);
 
-                agentService.chatStructuredStream(resolvedAgentId, message, conversationId, visitorId, null, webchatOrigin)
+                reactor.core.Disposable disposable = agentService.chatStructuredStream(resolvedAgentId, message, conversationId, visitorId, null, webchatOrigin)
                         .doOnNext(delta -> {
                             if (delta.isEvent() && "_usage_final".equals(delta.eventType())) {
                                 Map<String, Object> data = delta.eventData();
@@ -251,6 +251,12 @@ public class WebChatController {
                             streamTracker.complete(conversationId);
                         })
                         .subscribe();
+                // Bind the subscription's Disposable so requestStop() (invoked by
+                // POST /sessions/stop) can actually dispose the Flux and interrupt
+                // the LLM stream. Without this, stopRequested is set but the underlying
+                // HTTP call keeps running — token burn + side-effect tools still fire.
+                // Mirrors ChatController#chatStream line 495.
+                streamTracker.setDisposable(conversationId, disposable);
 
             } catch (Exception e) {
                 log.error("[WebChat] Error: {}", e.getMessage(), e);
@@ -635,6 +641,51 @@ public class WebChatController {
         }
         conversationService.deleteConversation(conversationId);
         return R.ok();
+    }
+
+    /**
+     * 停止访客某线程正在进行中的 SSE 流。
+     * <p>
+     * 鉴权同其他会话管理端点(API Key + visitorToken + 会话归属)。内部调
+     * {@link ChatStreamTracker#requestStop(String)}——靠 chatStream 注册时绑定的
+     * Disposable 实际中断 Flux;返回 {@code stopped=false} 表示当前没有活跃流
+     * (幂等,不报错)。
+     * <p>
+     * 不做 approval sweep:webchat 渠道目前不暴露 approval UI,且无 MateClaw
+     * username 可传给 {@code denyAllByConversation}。若未来 webchat 接入审批流,
+     * 再单独评估是否补这层。
+     */
+    @Operation(summary = "停止访客会话线程的进行中流")
+    @PostMapping("/sessions/stop")
+    public R<Map<String, Object>> stopSession(
+            @RequestHeader("X-MC-Key") String apiKey,
+            @RequestHeader(value = "X-MC-Visitor-Token", required = false) String visitorToken,
+            @RequestParam String visitorId,
+            @RequestParam(required = false) String sessionId) {
+        ChannelEntity channel = resolveChannel(apiKey);
+        if (channel == null) {
+            return R.fail(401, "Invalid API Key");
+        }
+        if (!verifyVisitorToken(visitorTokenSecret, channel.getId(), visitorId, visitorToken)) {
+            return R.fail(401, "Invalid or missing visitor token");
+        }
+        String sid;
+        try {
+            sid = normalizeSessionId(sessionId);
+        } catch (IllegalArgumentException ex) {
+            return R.fail(400, ex.getMessage());
+        }
+        String conversationId = deriveConversationId(apiKey, visitorId, sid);
+        // ownsConversation is the existence + ownership guard: an unknown sessionId
+        // maps to a conversationId that either doesn't exist or belongs to someone
+        // else — both return 404 so the caller can't probe the namespace.
+        if (!ownsConversation(conversationId, visitorId)) {
+            return R.fail(404, "Session not found");
+        }
+        boolean stopped = streamTracker.requestStop(conversationId);
+        log.info("[WebChat] Stop requested: conversationId={}, visitor={}, stopped={}",
+                conversationId, visitorId, stopped);
+        return R.ok(Map.of("stopped", stopped));
     }
 
     /**

--- a/mateclaw-server/src/main/java/vip/mate/channel/webchat/WebChatController.java
+++ b/mateclaw-server/src/main/java/vip/mate/channel/webchat/WebChatController.java
@@ -405,9 +405,12 @@ public class WebChatController {
         String base = deriveConversationId(apiKey, visitorId, null);
         String channelPrefix = "webchat:" + apiKey.substring(0, Math.min(8, apiKey.length())) + ":";
         String owner = webchatUsername(visitorId);
-        return conversationService.listConversations(owner).stream()
+        // Query is scoped to this visitor's own rows only (no system rows), so
+        // listing a visitor's threads doesn't load every IM/cron conversation.
+        // The channel prefix is matched in-memory with a literal startsWith so a
+        // '_' / '%' in the api key's first 8 chars can't act as a LIKE wildcard.
+        return conversationService.listWebchatConversations(owner).stream()
                 .filter(c -> c.getConversationId() != null
-                        && owner.equals(c.getUsername())
                         && c.getConversationId().startsWith(channelPrefix))
                 .map(c -> {
                     String sid = recoverSessionId(c, base);
@@ -422,7 +425,7 @@ public class WebChatController {
      * Returns null for the default (no-session) thread and for legacy hashed rows
      * whose sessionId can no longer be reconstructed.
      */
-    private String recoverSessionId(vip.mate.workspace.conversation.vo.ConversationVO c, String base) {
+    private String recoverSessionId(vip.mate.workspace.conversation.model.ConversationEntity c, String base) {
         if (c.getWebchatSessionId() != null) {
             return c.getWebchatSessionId();
         }

--- a/mateclaw-server/src/main/java/vip/mate/channel/webchat/WebChatController.java
+++ b/mateclaw-server/src/main/java/vip/mate/channel/webchat/WebChatController.java
@@ -288,6 +288,114 @@ public class WebChatController {
         ));
     }
 
+    /** Cap on how many empty (message_count = 0) threads one visitor may hold on a
+     *  channel at once. Guards against pathologic clients churning placeholder
+     *  sessions without ever sending a message. */
+    private static final int MAX_EMPTY_SESSIONS_PER_VISITOR = 5;
+
+    /**
+     * 显式创建一条访客会话线程（空会话）。
+     * <p>
+     * 与 {@code POST /stream} 的隐式 getOrCreate 互补：本端点先建一条 message_count=0
+     * 的占位线程，调用方拿到 {@code sessionId/conversationId/visitorToken} 之后，再决定
+     * 何时通过 {@code /stream} 发首条消息。鉴权为访客的<b>首次接触</b>：仅校验
+     * {@code X-MC-Key}，不要求 {@code X-MC-Visitor-Token}，后端会签发并回传 token，
+     * 调用方在后续 GET/PUT/DELETE 上必须回带。
+     * <p>
+     * 行为：
+     * <ul>
+     *   <li>幂等：{@code sessionId} 与该 visitor 已有线程冲突 → 直接返回现有线程，
+     *       不报错、不覆盖 title。</li>
+     *   <li>配额：单 (渠道, visitor) 未活跃空线程 ≤ {@value MAX_EMPTY_SESSIONS_PER_VISITOR}，
+     *       超出返回 409。已存在的线程走幂等路径不受配额限制。</li>
+     *   <li>title 非空时写入；为空时落默认 "新对话"，首条 user 消息仍会按现有规则截取。</li>
+     * </ul>
+     */
+    @Operation(summary = "显式创建访客会话线程（空会话）")
+    @PostMapping("/sessions")
+    public R<Map<String, Object>> createSession(
+            @RequestHeader("X-MC-Key") String apiKey,
+            @RequestBody(required = false) WebChatCreateSessionRequest request) {
+
+        ChannelEntity channel = resolveChannel(apiKey);
+        if (channel == null) {
+            return R.fail(401, "Invalid API Key");
+        }
+
+        // Resolve agent: explicit request.agentId overrides channel's bound agent,
+        // but must belong to channel's workspace (mirrors /stream).
+        final Long agentId;
+        if (request != null && request.getAgentId() != null) {
+            var requested = agentService.getAgent(request.getAgentId());
+            if (requested == null) {
+                return R.fail(400, "Requested agent not found");
+            }
+            if (channel.getWorkspaceId() != null && requested.getWorkspaceId() != null
+                    && !channel.getWorkspaceId().equals(requested.getWorkspaceId())) {
+                return R.fail(400, "Requested agent does not belong to this channel's workspace");
+            }
+            agentId = request.getAgentId();
+        } else {
+            agentId = channel.getAgentId();
+            if (agentId == null) {
+                return R.fail(400, "No agent configured for this WebChat channel");
+            }
+        }
+
+        final String visitorId;
+        final String sessionId;
+        try {
+            visitorId = normalizeVisitorId(request != null ? request.getVisitorId() : null);
+            sessionId = normalizeSessionId(request != null ? request.getSessionId() : null);
+        } catch (IllegalArgumentException ex) {
+            return R.fail(400, ex.getMessage());
+        }
+
+        String title = (request != null && request.getTitle() != null) ? request.getTitle().trim() : null;
+        if (title != null && (title.isEmpty() || title.length() > 100)) {
+            return R.fail(400, "title 不合法（1-100 字）");
+        }
+
+        String conversationId = deriveConversationId(apiKey, visitorId, sessionId);
+        String owner = webchatUsername(visitorId);
+
+        // Idempotency: existing thread is returned as-is. Title and every other
+        // field are left untouched — a re-create call must not clobber a previously
+        // set title. Existing rows are exempt from the empty-session quota.
+        ConversationEntity existing = conversationService.findByConversationId(conversationId);
+        if (existing != null && owner.equals(existing.getUsername())) {
+            return R.ok(buildCreateSessionResponse(existing, sessionId, channel.getId(), visitorId));
+        }
+
+        // Quota: count empty threads this visitor already holds on this channel.
+        // loadVisitorSessions already scopes to (channel prefix ∩ visitor owner).
+        long emptyCount = loadVisitorSessions(apiKey, visitorId).stream()
+                .filter(s -> s.getMessageCount() == null || s.getMessageCount() == 0)
+                .count();
+        if (emptyCount >= MAX_EMPTY_SESSIONS_PER_VISITOR) {
+            return R.fail(409, "未活跃会话数已达上限（" + MAX_EMPTY_SESSIONS_PER_VISITOR
+                    + "），请先发送消息或删除旧会话");
+        }
+
+        ConversationEntity conv = conversationService.getOrCreateWebchatConversation(
+                conversationId, agentId, owner, channel.getWorkspaceId(), sessionId, title);
+        return R.ok(buildCreateSessionResponse(conv, sessionId, channel.getId(), visitorId));
+    }
+
+    private Map<String, Object> buildCreateSessionResponse(ConversationEntity conv, String sessionId,
+                                                           Long channelId, String visitorId) {
+        String visitorToken = computeVisitorToken(visitorTokenSecret, channelId, visitorId);
+        // LinkedHashMap (not Map.of) because Map.of rejects null and we want a
+        // stable key order for the response payload.
+        Map<String, Object> m = new java.util.LinkedHashMap<>();
+        m.put("sessionId", sessionId != null ? sessionId : "");
+        m.put("conversationId", conv.getConversationId());
+        m.put("visitorToken", visitorToken);
+        m.put("title", conv.getTitle() != null ? conv.getTitle() : "");
+        m.put("createTime", conv.getCreateTime());
+        return m;
+    }
+
     /**
      * 列出某访客的会话线程
      * <p>
@@ -888,5 +996,21 @@ public class WebChatController {
         private String title;
         private LocalDateTime lastActiveTime;
         private Integer messageCount;
+    }
+
+    /** Body for {@code POST /sessions} — explicitly create an empty thread. */
+    @lombok.Data
+    public static class WebChatCreateSessionRequest {
+        /** Optional; server mints a UUID when absent (same convention as /stream). */
+        private String visitorId;
+        /** Optional; server generates one when absent. Whitelisted charset, ≤ 64 chars. */
+        private String sessionId;
+        /** Optional; 1–100 chars when non-blank, otherwise left null so the first
+         *  /stream message still derives the title (mirrors PUT /sessions/title rules). */
+        private String title;
+        /** Optional; override the channel's bound agent. Must belong to the channel's
+         *  workspace. Only applied on first creation — once the thread exists, a
+         *  different agentId is ignored. */
+        private Long agentId;
     }
 }

--- a/mateclaw-server/src/main/java/vip/mate/channel/webchat/WebChatController.java
+++ b/mateclaw-server/src/main/java/vip/mate/channel/webchat/WebChatController.java
@@ -36,7 +36,7 @@ import vip.mate.memory.event.ConversationCompletionPublisher;
 import vip.mate.workspace.conversation.ConversationService;
 import vip.mate.workspace.conversation.model.ConversationEntity;
 import vip.mate.workspace.conversation.model.MessageContentPart;
-import vip.mate.workspace.conversation.vo.MessageVO;
+import vip.mate.workspace.conversation.model.MessageEntity;
 
 import java.io.IOException;
 import java.time.LocalDateTime;
@@ -306,32 +306,63 @@ public class WebChatController {
         if (!verifyVisitorToken(visitorTokenSecret, channel.getId(), visitorId, visitorToken)) {
             return R.fail(401, "Invalid or missing visitor token");
         }
-        String base = deriveConversationId(apiKey, visitorId, null);
-        String prefix = base + ":";
-        String owner = webchatUsername(visitorId);
-        List<WebChatSessionView> sessions = conversationService.listConversations(owner).stream()
-                .filter(c -> c.getConversationId() != null
-                        && owner.equals(c.getUsername())
-                        && (c.getConversationId().equals(base) || c.getConversationId().startsWith(prefix)))
-                .map(c -> {
-                    String cid = c.getConversationId();
-                    String sid = cid.equals(base) ? null : cid.substring(prefix.length());
-                    return new WebChatSessionView(sid, c.getTitle(), c.getLastActiveTime(), c.getMessageCount());
-                })
-                .collect(Collectors.toList());
-        return R.ok(sessions);
+        return R.ok(loadVisitorSessions(apiKey, visitorId));
     }
 
     /**
-     * 获取某会话线程的消息列表
+     * 分页 + 关键词搜索某访客的会话线程。
+     * <p>访客的会话集是按 visitor 命名空间限定的（数量有界），故在内存里做关键词过滤与分页。
+     * keyword 不区分大小写、匹配标题子串。
      */
-    @Operation(summary = "获取会话消息")
-    @GetMapping("/sessions/messages")
-    public R<List<MessageVO>> sessionMessages(
+    @Operation(summary = "分页查询访客会话线程")
+    @GetMapping("/sessions/page")
+    public R<Map<String, Object>> pageSessions(
             @RequestHeader("X-MC-Key") String apiKey,
             @RequestHeader(value = "X-MC-Visitor-Token", required = false) String visitorToken,
             @RequestParam String visitorId,
-            @RequestParam(required = false) String sessionId) {
+            @RequestParam(defaultValue = "1") int page,
+            @RequestParam(defaultValue = "20") int size,
+            @RequestParam(required = false) String keyword) {
+        ChannelEntity channel = resolveChannel(apiKey);
+        if (channel == null) {
+            return R.fail(401, "Invalid API Key");
+        }
+        if (!verifyVisitorToken(visitorTokenSecret, channel.getId(), visitorId, visitorToken)) {
+            return R.fail(401, "Invalid or missing visitor token");
+        }
+        if (page < 1) page = 1;
+        if (size < 1 || size > 200) size = 20;
+
+        List<WebChatSessionView> all = loadVisitorSessions(apiKey, visitorId);
+        if (keyword != null && !keyword.isBlank()) {
+            String kw = keyword.trim().toLowerCase(java.util.Locale.ROOT);
+            all = all.stream()
+                    .filter(s -> s.getTitle() != null && s.getTitle().toLowerCase(java.util.Locale.ROOT).contains(kw))
+                    .collect(Collectors.toList());
+        }
+        long total = all.size();
+        int from = Math.min((page - 1) * size, all.size());
+        int to = Math.min(from + size, all.size());
+        List<WebChatSessionView> pageItems = all.subList(from, to);
+        return R.ok(Map.of(
+                "items", pageItems,
+                "total", total,
+                "page", page,
+                "size", size
+        ));
+    }
+
+    /**
+     * 重命名某会话线程。标题非空、长度 ≤ 100。
+     */
+    @Operation(summary = "重命名会话线程")
+    @PutMapping("/sessions/title")
+    public R<Void> renameSession(
+            @RequestHeader("X-MC-Key") String apiKey,
+            @RequestHeader(value = "X-MC-Visitor-Token", required = false) String visitorToken,
+            @RequestParam String visitorId,
+            @RequestParam(required = false) String sessionId,
+            @RequestBody Map<String, String> body) {
         ChannelEntity channel = resolveChannel(apiKey);
         if (channel == null) {
             return R.fail(401, "Invalid API Key");
@@ -349,8 +380,91 @@ public class WebChatController {
         if (!ownsConversation(conversationId, visitorId)) {
             return R.fail(404, "Session not found");
         }
-        // External view: strip server-side file paths before handing messages to the visitor.
-        return R.ok(conversationService.listMessageViewsExternal(conversationId));
+        String title = body != null && body.get("title") != null ? body.get("title").trim() : "";
+        if (title.isEmpty() || title.length() > 100) {
+            return R.fail(400, "标题不合法（1-100 字）");
+        }
+        conversationService.renameConversation(conversationId, title);
+        return R.ok();
+    }
+
+    /**
+     * Load this visitor's session threads (own namespace only), mapped to the
+     * compact view. Sorted as {@code listConversations} returns them (pinned
+     * desc, last-active desc). Shared by the list and paginated endpoints.
+     */
+    private List<WebChatSessionView> loadVisitorSessions(String apiKey, String visitorId) {
+        String base = deriveConversationId(apiKey, visitorId, null);
+        String prefix = base + ":";
+        String owner = webchatUsername(visitorId);
+        return conversationService.listConversations(owner).stream()
+                .filter(c -> c.getConversationId() != null
+                        && owner.equals(c.getUsername())
+                        && (c.getConversationId().equals(base) || c.getConversationId().startsWith(prefix)))
+                .map(c -> {
+                    String cid = c.getConversationId();
+                    String sid = cid.equals(base) ? null : cid.substring(prefix.length());
+                    return new WebChatSessionView(sid, c.getTitle(), c.getLastActiveTime(), c.getMessageCount());
+                })
+                .collect(Collectors.toList());
+    }
+
+    /**
+     * 获取某会话线程的消息列表（支持分页）。
+     * <p>不传 limit 时返回全部消息（向后兼容）；传 limit 返回最新 limit 条 + hasMore；
+     * 传 beforeId + limit 时返回该 ID 之前的 limit 条（上拉加载更早消息）。
+     */
+    @Operation(summary = "获取会话消息（支持分页）")
+    @GetMapping("/sessions/messages")
+    public R<?> sessionMessages(
+            @RequestHeader("X-MC-Key") String apiKey,
+            @RequestHeader(value = "X-MC-Visitor-Token", required = false) String visitorToken,
+            @RequestParam String visitorId,
+            @RequestParam(required = false) String sessionId,
+            @RequestParam(required = false) Long beforeId,
+            @RequestParam(required = false) Integer limit) {
+        ChannelEntity channel = resolveChannel(apiKey);
+        if (channel == null) {
+            return R.fail(401, "Invalid API Key");
+        }
+        if (!verifyVisitorToken(visitorTokenSecret, channel.getId(), visitorId, visitorToken)) {
+            return R.fail(401, "Invalid or missing visitor token");
+        }
+        String sid;
+        try {
+            sid = normalizeSessionId(sessionId);
+        } catch (IllegalArgumentException ex) {
+            return R.fail(400, ex.getMessage());
+        }
+        String conversationId = deriveConversationId(apiKey, visitorId, sid);
+        if (!ownsConversation(conversationId, visitorId)) {
+            return R.fail(404, "Session not found");
+        }
+
+        // Backward-compatible: no limit → full external (path-stripped) list.
+        if (limit == null || limit <= 0) {
+            return R.ok(conversationService.listMessageViewsExternal(conversationId));
+        }
+
+        // Paginated: mirror ConversationController#listMessages but with the
+        // external view so visitors never see server-side file paths.
+        List<MessageEntity> messages;
+        boolean hasMore;
+        if (beforeId != null) {
+            messages = conversationService.listMessagesBefore(conversationId, beforeId, limit + 1);
+            hasMore = messages.size() > limit;
+            if (hasMore) {
+                messages = messages.subList(messages.size() - limit, messages.size());
+            }
+        } else {
+            long total = conversationService.countMessages(conversationId);
+            messages = conversationService.listRecentMessages(conversationId, limit);
+            hasMore = total > limit;
+        }
+        return R.ok(Map.of(
+                "messages", conversationService.toExternalMessageViews(messages),
+                "hasMore", hasMore
+        ));
     }
 
     /**

--- a/mateclaw-server/src/main/java/vip/mate/channel/webchat/WebChatController.java
+++ b/mateclaw-server/src/main/java/vip/mate/channel/webchat/WebChatController.java
@@ -166,7 +166,8 @@ public class WebChatController {
                 // 创建或获取会话（workspace 从 agent 获取）
                 var webAgent = agentService.getAgent(resolvedAgentId);
                 Long webWsId = webAgent != null ? webAgent.getWorkspaceId() : 1L;
-                var conv = conversationService.getOrCreateConversation(conversationId, resolvedAgentId, webchatUsername(visitorId), webWsId);
+                var conv = conversationService.getOrCreateWebchatConversation(
+                        conversationId, resolvedAgentId, webchatUsername(visitorId), webWsId, effectiveSessionId);
 
                 // 保存用户消息（含访客本轮引用的附件）。附件元数据一律服务端按 fileId 回查，
                 // 不信客户端传入；path 用于 Agent 侧工具读取，对外消息视图会被剥离。
@@ -392,21 +393,48 @@ public class WebChatController {
      * Load this visitor's session threads (own namespace only), mapped to the
      * compact view. Sorted as {@code listConversations} returns them (pinned
      * desc, last-active desc). Shared by the list and paginated endpoints.
+     * <p>
+     * Enumeration is keyed by the visitor's username plus the channel prefix
+     * ({@code webchat:<key8>:}) rather than the full conversationId prefix, so it
+     * still catches threads whose conversationId hashed (long visitorId +
+     * sessionId). The sessionId is read from the persisted {@code webchatSessionId}
+     * column (set on creation) and only falls back to parsing the conversationId
+     * for legacy rows created before that column existed.
      */
     private List<WebChatSessionView> loadVisitorSessions(String apiKey, String visitorId) {
         String base = deriveConversationId(apiKey, visitorId, null);
-        String prefix = base + ":";
+        String channelPrefix = "webchat:" + apiKey.substring(0, Math.min(8, apiKey.length())) + ":";
         String owner = webchatUsername(visitorId);
         return conversationService.listConversations(owner).stream()
                 .filter(c -> c.getConversationId() != null
                         && owner.equals(c.getUsername())
-                        && (c.getConversationId().equals(base) || c.getConversationId().startsWith(prefix)))
+                        && c.getConversationId().startsWith(channelPrefix))
                 .map(c -> {
-                    String cid = c.getConversationId();
-                    String sid = cid.equals(base) ? null : cid.substring(prefix.length());
+                    String sid = recoverSessionId(c, base);
                     return new WebChatSessionView(sid, c.getTitle(), c.getLastActiveTime(), c.getMessageCount());
                 })
                 .collect(Collectors.toList());
+    }
+
+    /**
+     * Recover a thread's sessionId. Prefers the persisted column; for legacy
+     * rows (column null) falls back to parsing the non-hashed conversationId.
+     * Returns null for the default (no-session) thread and for legacy hashed rows
+     * whose sessionId can no longer be reconstructed.
+     */
+    private String recoverSessionId(vip.mate.workspace.conversation.vo.ConversationVO c, String base) {
+        if (c.getWebchatSessionId() != null) {
+            return c.getWebchatSessionId();
+        }
+        String cid = c.getConversationId();
+        if (cid.equals(base)) {
+            return null;
+        }
+        String prefix = base + ":";
+        if (cid.startsWith(prefix)) {
+            return cid.substring(prefix.length());
+        }
+        return null;
     }
 
     /**

--- a/mateclaw-server/src/main/java/vip/mate/channel/webchat/WebChatFileService.java
+++ b/mateclaw-server/src/main/java/vip/mate/channel/webchat/WebChatFileService.java
@@ -17,6 +17,7 @@ import java.util.Set;
 import java.util.UUID;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 /**
  * Storage + validation for files exchanged over the WebChat channel.
@@ -47,6 +48,8 @@ public class WebChatFileService {
     private final boolean enabled;
     private final long maxSizeBytes;
     private final Set<String> allowedExtensions;
+    private final int maxFilesPerConversation;
+    private final long maxTotalBytesPerConversation;
 
     /** fileId (== storedName) -> staged metadata, pending a /stream reference. */
     private final ConcurrentHashMap<String, StagedFile> staged = new ConcurrentHashMap<>();
@@ -56,13 +59,17 @@ public class WebChatFileService {
             @Value("${mateclaw.webchat.upload.max-size-mb:20}") long maxSizeMb,
             @Value("${mateclaw.webchat.upload.allowed-extensions:"
                     + "png,jpg,jpeg,gif,webp,bmp,pdf,txt,md,csv,json,log,"
-                    + "doc,docx,xls,xlsx,ppt,pptx,zip,mp3,wav,m4a,mp4,mov,webm}") String allowedExtensionsCsv) {
+                    + "doc,docx,xls,xlsx,ppt,pptx,zip,mp3,wav,m4a,mp4,mov,webm}") String allowedExtensionsCsv,
+            @Value("${mateclaw.webchat.upload.max-files-per-conversation:50}") int maxFilesPerConversation,
+            @Value("${mateclaw.webchat.upload.max-total-mb-per-conversation:200}") long maxTotalMbPerConversation) {
         this.enabled = enabled;
         this.maxSizeBytes = maxSizeMb * 1024 * 1024;
         this.allowedExtensions = Arrays.stream(allowedExtensionsCsv.split(","))
                 .map(s -> s.trim().toLowerCase(Locale.ROOT))
                 .filter(s -> !s.isEmpty())
                 .collect(Collectors.toUnmodifiableSet());
+        this.maxFilesPerConversation = maxFilesPerConversation;
+        this.maxTotalBytesPerConversation = maxTotalMbPerConversation * 1024 * 1024;
     }
 
     /** Metadata for a staged upload. */
@@ -118,6 +125,7 @@ public class WebChatFileService {
             throw new UploadRejectedException("Invalid conversation");
         }
         Files.createDirectories(dir);
+        enforceConversationQuota(dir, file.getSize());
         Path target = dir.resolve(storedName);
         file.transferTo(target.toAbsolutePath());
 
@@ -198,6 +206,34 @@ public class WebChatFileService {
             });
             return true;
         });
+    }
+
+    /**
+     * Bound a conversation's disk footprint: reject when the dir already holds
+     * the max file count, or when adding {@code incomingSize} would push the
+     * total over the cap. Cheap dir scan (these dirs hold at most a few dozen
+     * files); pairs with the staging TTL sweep that reclaims unreferenced files.
+     */
+    private void enforceConversationQuota(Path dir, long incomingSize) throws IOException {
+        int count = 0;
+        long total = 0;
+        try (Stream<Path> files = Files.list(dir)) {
+            for (Path p : (Iterable<Path>) files::iterator) {
+                if (Files.isRegularFile(p)) {
+                    count++;
+                    total += Files.size(p);
+                }
+            }
+        }
+        if (count >= maxFilesPerConversation) {
+            throw new UploadRejectedException(
+                    "Too many files in this conversation (max " + maxFilesPerConversation + ")");
+        }
+        if (total + incomingSize > maxTotalBytesPerConversation) {
+            throw new UploadRejectedException(
+                    "Conversation upload quota exceeded (max "
+                            + (maxTotalBytesPerConversation / 1024 / 1024) + " MB)");
+        }
     }
 
     private static String extensionOf(String name) {

--- a/mateclaw-server/src/main/java/vip/mate/channel/webchat/WebChatFileService.java
+++ b/mateclaw-server/src/main/java/vip/mate/channel/webchat/WebChatFileService.java
@@ -1,0 +1,219 @@
+package vip.mate.channel.webchat;
+
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Service;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.Arrays;
+import java.util.Locale;
+import java.util.Optional;
+import java.util.Set;
+import java.util.UUID;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.stream.Collectors;
+
+/**
+ * Storage + validation for files exchanged over the WebChat channel.
+ *
+ * <p>WebChat is reached by untrusted external visitors (API key + visitor
+ * token, no JWT), so uploads are hardened here: size cap, extension allow-list,
+ * filename sanitization, and a server-issued stored name. Every path is derived
+ * from the server-computed {@code conversationId} — never from a client-supplied
+ * path — and download resolution is traversal-guarded.
+ *
+ * <p>Uploads are staged in an in-memory registry keyed by an opaque file id.
+ * Only when the visitor references that id on the next {@code /stream} call does
+ * the file become a real conversation attachment (the bytes already live under
+ * the conversation's upload dir, so cleanup rides the existing
+ * {@code cleanAttachmentFiles} cascade). Unreferenced staged files are swept
+ * after {@link #STAGING_TTL_MS}.
+ */
+@Slf4j
+@Service
+public class WebChatFileService {
+
+    /** Shared with the JWT chat upload dir so deleteConversation cleanup applies. */
+    private static final Path UPLOAD_ROOT = Paths.get("data", "chat-uploads");
+
+    /** How long an uploaded-but-unreferenced file lingers before the sweep removes it. */
+    private static final long STAGING_TTL_MS = 60 * 60 * 1000L; // 1 hour
+
+    private final boolean enabled;
+    private final long maxSizeBytes;
+    private final Set<String> allowedExtensions;
+
+    /** fileId (== storedName) -> staged metadata, pending a /stream reference. */
+    private final ConcurrentHashMap<String, StagedFile> staged = new ConcurrentHashMap<>();
+
+    public WebChatFileService(
+            @Value("${mateclaw.webchat.upload.enabled:true}") boolean enabled,
+            @Value("${mateclaw.webchat.upload.max-size-mb:20}") long maxSizeMb,
+            @Value("${mateclaw.webchat.upload.allowed-extensions:"
+                    + "png,jpg,jpeg,gif,webp,bmp,pdf,txt,md,csv,json,log,"
+                    + "doc,docx,xls,xlsx,ppt,pptx,zip,mp3,wav,m4a,mp4,mov,webm}") String allowedExtensionsCsv) {
+        this.enabled = enabled;
+        this.maxSizeBytes = maxSizeMb * 1024 * 1024;
+        this.allowedExtensions = Arrays.stream(allowedExtensionsCsv.split(","))
+                .map(s -> s.trim().toLowerCase(Locale.ROOT))
+                .filter(s -> !s.isEmpty())
+                .collect(Collectors.toUnmodifiableSet());
+    }
+
+    /** Metadata for a staged upload. */
+    public record StagedFile(String conversationId, String storedName, String originalName,
+                             String contentType, long size, long expireAt) {
+        boolean expired() {
+            return System.currentTimeMillis() > expireAt;
+        }
+    }
+
+    /** Thrown on any validation failure; the controller maps it to a 4xx. */
+    public static class UploadRejectedException extends RuntimeException {
+        public UploadRejectedException(String message) {
+            super(message);
+        }
+    }
+
+    public boolean isEnabled() {
+        return enabled;
+    }
+
+    /**
+     * Validate and store an uploaded file under the conversation's upload dir,
+     * returning a staged record whose {@code storedName} doubles as the opaque
+     * file id the visitor references on the next /stream call.
+     *
+     * @param conversationId server-derived conversation id (never client-supplied)
+     */
+    public StagedFile store(String conversationId, MultipartFile file) throws IOException {
+        if (!enabled) {
+            throw new UploadRejectedException("WebChat file upload is disabled");
+        }
+        if (file == null || file.isEmpty()) {
+            throw new UploadRejectedException("Empty file");
+        }
+        if (file.getSize() > maxSizeBytes) {
+            throw new UploadRejectedException("File too large (max " + (maxSizeBytes / 1024 / 1024) + " MB)");
+        }
+
+        String originalName = file.getOriginalFilename() != null ? file.getOriginalFilename() : "file";
+        // Strip any directory components, then collapse to a safe charset.
+        String baseName = Paths.get(originalName).getFileName().toString();
+        String ext = extensionOf(baseName);
+        if (ext.isEmpty() || !allowedExtensions.contains(ext)) {
+            throw new UploadRejectedException("File type not allowed: ." + ext);
+        }
+        String safeName = baseName.replaceAll("[^a-zA-Z0-9._-]", "_");
+
+        String storedName = UUID.randomUUID() + "_" + safeName;
+        Path dir = UPLOAD_ROOT.resolve(conversationId).normalize();
+        if (!dir.startsWith(UPLOAD_ROOT.normalize())) {
+            // conversationId is server-derived, so this should never happen; fail closed if it does.
+            throw new UploadRejectedException("Invalid conversation");
+        }
+        Files.createDirectories(dir);
+        Path target = dir.resolve(storedName);
+        file.transferTo(target.toAbsolutePath());
+
+        String contentType = Optional.ofNullable(file.getContentType())
+                .filter(ct -> !ct.isBlank())
+                .orElseGet(() -> probe(target));
+
+        StagedFile entry = new StagedFile(conversationId, storedName, baseName, contentType,
+                file.getSize(), System.currentTimeMillis() + STAGING_TTL_MS);
+        staged.put(storedName, entry);
+        log.info("[webchat-file] Stored upload conv={} stored={} type={} size={}",
+                conversationId, storedName, contentType, file.getSize());
+        return entry;
+    }
+
+    /**
+     * Resolve a staged file id into its metadata, asserting it belongs to this
+     * conversation and has not expired. Consuming it removes the staging entry
+     * (the bytes remain as a committed conversation attachment). Returns empty
+     * if the id is unknown, expired, or belongs to another conversation.
+     */
+    public Optional<StagedFile> consume(String conversationId, String fileId) {
+        if (fileId == null) {
+            return Optional.empty();
+        }
+        StagedFile entry = staged.get(fileId);
+        if (entry == null || entry.expired() || !entry.conversationId().equals(conversationId)) {
+            return Optional.empty();
+        }
+        staged.remove(fileId);
+        return Optional.of(entry);
+    }
+
+    /**
+     * Traversal-safe resolution of a stored file under the conversation's dir.
+     * Both the dir and the final path are derived from the server-computed
+     * conversationId; the client-supplied {@code storedName} is confined by the
+     * {@code startsWith} guard. Returns empty if missing or escaping the dir.
+     */
+    public Optional<Path> resolve(String conversationId, String storedName) {
+        if (storedName == null || storedName.isBlank()) {
+            return Optional.empty();
+        }
+        Path base = UPLOAD_ROOT.resolve(conversationId).normalize();
+        Path file = base.resolve(storedName).normalize();
+        if (!file.startsWith(base) || !Files.exists(file) || !Files.isRegularFile(file)) {
+            return Optional.empty();
+        }
+        return Optional.of(file);
+    }
+
+    /** Map a content type to the MessageContentPart type the agent/UI understands. */
+    public static String partTypeFor(String contentType) {
+        if (contentType == null) {
+            return "file";
+        }
+        String ct = contentType.toLowerCase(Locale.ROOT);
+        if (ct.startsWith("image/")) return "image";
+        if (ct.startsWith("video/")) return "video";
+        if (ct.startsWith("audio/")) return "audio";
+        return "file";
+    }
+
+    /** Periodically drop staged files the visitor never referenced. */
+    @Scheduled(fixedDelay = 15 * 60 * 1000L)
+    public void sweepExpired() {
+        staged.values().removeIf(entry -> {
+            if (!entry.expired()) {
+                return false;
+            }
+            resolve(entry.conversationId(), entry.storedName()).ifPresent(p -> {
+                try {
+                    Files.deleteIfExists(p);
+                } catch (IOException e) {
+                    log.warn("[webchat-file] Failed to delete expired staged file {}: {}",
+                            p, e.getMessage());
+                }
+            });
+            return true;
+        });
+    }
+
+    private static String extensionOf(String name) {
+        int dot = name.lastIndexOf('.');
+        if (dot < 0 || dot == name.length() - 1) {
+            return "";
+        }
+        return name.substring(dot + 1).toLowerCase(Locale.ROOT);
+    }
+
+    private static String probe(Path path) {
+        try {
+            String ct = Files.probeContentType(path);
+            return ct != null ? ct : "application/octet-stream";
+        } catch (IOException e) {
+            return "application/octet-stream";
+        }
+    }
+}

--- a/mateclaw-server/src/main/java/vip/mate/workspace/conversation/ConversationService.java
+++ b/mateclaw-server/src/main/java/vip/mate/workspace/conversation/ConversationService.java
@@ -808,6 +808,27 @@ public class ConversationService {
     }
 
     /**
+     * External-facing message views for untrusted callers (webchat visitors).
+     * Strips the server-side absolute file path from both the structured parts
+     * ({@code path} nulled) and the rendered text, so the server filesystem
+     * layout is never disclosed. Visitors still get {@code fileUrl} / {@code
+     * fileName} / {@code contentType} to render and download attachments.
+     */
+    public List<MessageVO> listMessageViewsExternal(String conversationId) {
+        return listMessages(conversationId).stream()
+                .map(message -> {
+                    List<MessageContentPart> parts = parseMessageParts(message);
+                    parts.forEach(p -> {
+                        if (p != null) {
+                            p.setPath(null);
+                        }
+                    });
+                    return MessageVO.from(message, parts, renderMessageContent(message, false));
+                })
+                .toList();
+    }
+
+    /**
      * Delete a conversation and cascade-clean every row that referenced it.
      * <p>
      * Tables cleaned in the same transaction:
@@ -936,6 +957,16 @@ public class ConversationService {
     }
 
     public String renderMessageContent(MessageEntity message) {
+        return renderMessageContent(message, true);
+    }
+
+    /**
+     * Render variant whose {@code includePath} controls whether the server-side
+     * file path is embedded in the text. Internal/LLM rendering keeps it (tools
+     * resolve files by path); external rendering (webchat visitors) drops it so
+     * the server filesystem layout is not disclosed to untrusted callers.
+     */
+    public String renderMessageContent(MessageEntity message, boolean includePath) {
         List<MessageContentPart> parts = parseMessageParts(message);
         if (parts.isEmpty()) {
             return message.getContent() != null ? message.getContent() : "";
@@ -949,8 +980,8 @@ public class ConversationService {
             switch (part.getType()) {
                 case "text" -> appendSegment(text, part.getText());
                 case "thinking", "tool_call", "parse_error" -> { /* skip — frontend reads these from contentParts directly */ }
-                case "file" -> appendSegment(text, renderFilePart(part));
-                case "image", "video", "audio", "model3d" -> appendSegment(text, renderMediaPart(part));
+                case "file" -> appendSegment(text, renderFilePart(part, includePath));
+                case "image", "video", "audio", "model3d" -> appendSegment(text, renderMediaPart(part, includePath));
                 default -> appendSegment(text, part.getText());
             }
         }
@@ -1000,10 +1031,10 @@ public class ConversationService {
      * picks (read_file / extract_document_text / detect_file_type / …) can be called
      * with a path that resolves directly, instead of relying on per-tool fallbacks.
      */
-    private String renderFilePart(MessageContentPart part) {
+    private String renderFilePart(MessageContentPart part, boolean includePath) {
         String name = safe(part.getFileName());
         String path = safe(part.getPath());
-        if (path.isBlank()) {
+        if (!includePath || path.isBlank()) {
             return "[附件] " + name;
         }
         return "[附件] " + name + "（路径: " + path + "）";
@@ -1020,7 +1051,7 @@ public class ConversationService {
      * already uploaded. The path lets file-reading tools ({@code read_file},
      * {@code extract_document_text}, {@code detect_file_type}) work as a fallback.
      */
-    private String renderMediaPart(MessageContentPart part) {
+    private String renderMediaPart(MessageContentPart part, boolean includePath) {
         String label = switch (part.getType()) {
             case "image" -> "[图片]";
             case "video" -> "[视频]";
@@ -1034,7 +1065,7 @@ public class ConversationService {
         }
         String path = safe(part.getPath());
         StringBuilder rendered = new StringBuilder(label).append(' ').append(name);
-        if (!path.isBlank()) {
+        if (includePath && !path.isBlank()) {
             rendered.append("（路径: ").append(path).append("）");
         }
         // A persisted caption (vision sidecar output) carries the image content

--- a/mateclaw-server/src/main/java/vip/mate/workspace/conversation/ConversationService.java
+++ b/mateclaw-server/src/main/java/vip/mate/workspace/conversation/ConversationService.java
@@ -815,7 +815,16 @@ public class ConversationService {
      * fileName} / {@code contentType} to render and download attachments.
      */
     public List<MessageVO> listMessageViewsExternal(String conversationId) {
-        return listMessages(conversationId).stream()
+        return toExternalMessageViews(listMessages(conversationId));
+    }
+
+    /**
+     * Map already-loaded message entities to external (path-stripped) views.
+     * Shared by the full-list and paginated webchat paths so sanitization stays
+     * in one place.
+     */
+    public List<MessageVO> toExternalMessageViews(List<MessageEntity> messages) {
+        return messages.stream()
                 .map(message -> {
                     List<MessageContentPart> parts = parseMessageParts(message);
                     parts.forEach(p -> {

--- a/mateclaw-server/src/main/java/vip/mate/workspace/conversation/ConversationService.java
+++ b/mateclaw-server/src/main/java/vip/mate/workspace/conversation/ConversationService.java
@@ -254,6 +254,26 @@ public class ConversationService {
     }
 
     /**
+     * WebChat get-or-create that also records the thread's {@code sessionId} on
+     * insert, so the visitor's /sessions listing can recover it even when the
+     * conversationId hashes (long visitorId + sessionId). The session id is
+     * written only when the row is first created; an existing row is left as-is.
+     */
+    @Transactional
+    public ConversationEntity getOrCreateWebchatConversation(String conversationId, Long agentId,
+                                                             String username, Long workspaceId,
+                                                             String sessionId) {
+        boolean existed = conversationMapper.selectOne(new LambdaQueryWrapper<ConversationEntity>()
+                .eq(ConversationEntity::getConversationId, conversationId)) != null;
+        ConversationEntity conv = getOrCreateConversation(conversationId, agentId, username, workspaceId);
+        if (!existed && sessionId != null && !sessionId.isBlank() && conv.getWebchatSessionId() == null) {
+            conv.setWebchatSessionId(sessionId);
+            conversationMapper.updateById(conv);
+        }
+        return conv;
+    }
+
+    /**
      * Create a child conversation (delegation scenario), linking it back to
      * its parent via {@code parentConversationId}.
      *

--- a/mateclaw-server/src/main/java/vip/mate/workspace/conversation/ConversationService.java
+++ b/mateclaw-server/src/main/java/vip/mate/workspace/conversation/ConversationService.java
@@ -263,12 +263,40 @@ public class ConversationService {
     public ConversationEntity getOrCreateWebchatConversation(String conversationId, Long agentId,
                                                              String username, Long workspaceId,
                                                              String sessionId) {
+        return getOrCreateWebchatConversation(conversationId, agentId, username, workspaceId, sessionId, null);
+    }
+
+    /**
+     * WebChat get-or-create with an optional caller-supplied title.
+     * <p>
+     * When the row is freshly inserted and {@code title} is non-blank, it
+     * overrides the default {@code "新对话"}; otherwise the default is kept and
+     * {@link #saveMessage} will still derive a title from the first user
+     * message. An existing row is never rewritten — neither {@code sessionId}
+     * nor {@code title} are clobbered, so a session created via
+     * {@code POST /sessions} with a caller-supplied title keeps that title
+     * when the first {@code /stream} message later lands.
+     */
+    @Transactional
+    public ConversationEntity getOrCreateWebchatConversation(String conversationId, Long agentId,
+                                                             String username, Long workspaceId,
+                                                             String sessionId, String title) {
         boolean existed = conversationMapper.selectOne(new LambdaQueryWrapper<ConversationEntity>()
                 .eq(ConversationEntity::getConversationId, conversationId)) != null;
         ConversationEntity conv = getOrCreateConversation(conversationId, agentId, username, workspaceId);
-        if (!existed && sessionId != null && !sessionId.isBlank() && conv.getWebchatSessionId() == null) {
-            conv.setWebchatSessionId(sessionId);
-            conversationMapper.updateById(conv);
+        if (!existed) {
+            boolean dirty = false;
+            if (sessionId != null && !sessionId.isBlank() && conv.getWebchatSessionId() == null) {
+                conv.setWebchatSessionId(sessionId);
+                dirty = true;
+            }
+            if (title != null && !title.isBlank()) {
+                conv.setTitle(title.trim());
+                dirty = true;
+            }
+            if (dirty) {
+                conversationMapper.updateById(conv);
+            }
         }
         return conv;
     }

--- a/mateclaw-server/src/main/java/vip/mate/workspace/conversation/ConversationService.java
+++ b/mateclaw-server/src/main/java/vip/mate/workspace/conversation/ConversationService.java
@@ -274,6 +274,24 @@ public class ConversationService {
     }
 
     /**
+     * List a webchat visitor's own conversations (top-level threads), ordered
+     * pinned-desc then last-active-desc.
+     * <p>
+     * Scoped to {@code username = owner} only — unlike {@link #listConversations}
+     * it does <b>not</b> pull in {@code system} rows, so a visitor's /sessions
+     * call doesn't load every IM/cron conversation in the database just to list
+     * its own handful of threads. The caller still applies the channel-prefix
+     * filter (literal {@code startsWith}, wildcard-safe) to isolate the channel.
+     */
+    public List<ConversationEntity> listWebchatConversations(String username) {
+        return conversationMapper.selectList(new LambdaQueryWrapper<ConversationEntity>()
+                .eq(ConversationEntity::getUsername, username)
+                .isNull(ConversationEntity::getParentConversationId)
+                .orderByDesc(ConversationEntity::getPinned)
+                .orderByDesc(ConversationEntity::getLastActiveTime));
+    }
+
+    /**
      * Create a child conversation (delegation scenario), linking it back to
      * its parent via {@code parentConversationId}.
      *

--- a/mateclaw-server/src/main/java/vip/mate/workspace/conversation/model/ConversationEntity.java
+++ b/mateclaw-server/src/main/java/vip/mate/workspace/conversation/model/ConversationEntity.java
@@ -62,6 +62,14 @@ public class ConversationEntity {
     private String modelName;
 
     /**
+     * WebChat per-thread sessionId (see V147 migration). Persisted so it can be
+     * recovered for the visitor's /sessions listing even when the conversationId
+     * hashes (long visitorId + sessionId folds into an unrecoverable hash). NULL
+     * for non-webchat rows and for a visitor's default (no-session) thread.
+     */
+    private String webchatSessionId;
+
+    /**
      * Per-conversation progress notebook JSON (see V100 migration).
      * <p>
      * Map of {@code stepKey -> {label, status, note, updatedAt}}, written by

--- a/mateclaw-server/src/main/java/vip/mate/workspace/conversation/vo/ConversationVO.java
+++ b/mateclaw-server/src/main/java/vip/mate/workspace/conversation/vo/ConversationVO.java
@@ -68,6 +68,7 @@ public class ConversationVO extends ConversationEntity {
         vo.setPinned(entity.getPinned() != null ? entity.getPinned() : 0);
         vo.setModelProvider(entity.getModelProvider());
         vo.setModelName(entity.getModelName());
+        vo.setWebchatSessionId(entity.getWebchatSessionId());
         vo.setCreateTime(entity.getCreateTime());
         vo.setUpdateTime(entity.getUpdateTime());
         // 补充关联字段

--- a/mateclaw-server/src/main/resources/db/migration/h2/V147__webchat_session_id.sql
+++ b/mateclaw-server/src/main/resources/db/migration/h2/V147__webchat_session_id.sql
@@ -1,0 +1,6 @@
+-- WebChat per-thread sessionId, persisted so it can be recovered even when the
+-- conversationId hashes (visitorId + sessionId > 64 chars folds into a hash,
+-- which is otherwise unrecoverable — making the thread invisible/unaddressable
+-- in the visitor's /sessions listing). NULL for non-webchat rows and for a
+-- visitor's default (no-session) thread.
+ALTER TABLE mate_conversation ADD COLUMN IF NOT EXISTS webchat_session_id VARCHAR(64);

--- a/mateclaw-server/src/main/resources/db/migration/kingbase/V147__webchat_session_id.sql
+++ b/mateclaw-server/src/main/resources/db/migration/kingbase/V147__webchat_session_id.sql
@@ -1,0 +1,3 @@
+-- See the H2 copy for context. KingbaseES (PostgreSQL) supports
+-- ADD COLUMN IF NOT EXISTS natively.
+ALTER TABLE mate_conversation ADD COLUMN IF NOT EXISTS webchat_session_id VARCHAR(64);

--- a/mateclaw-server/src/main/resources/db/migration/mysql/V147__webchat_session_id.sql
+++ b/mateclaw-server/src/main/resources/db/migration/mysql/V147__webchat_session_id.sql
@@ -1,0 +1,15 @@
+-- See the H2 file for context. MySQL 8.0 doesn't support
+-- `ADD COLUMN IF NOT EXISTS`, so the existence check goes through
+-- INFORMATION_SCHEMA + a prepared statement.
+SET @col_exists := (
+    SELECT COUNT(*) FROM information_schema.COLUMNS
+    WHERE TABLE_SCHEMA = DATABASE()
+      AND TABLE_NAME = 'mate_conversation'
+      AND COLUMN_NAME = 'webchat_session_id'
+);
+SET @ddl := IF(@col_exists = 0,
+    'ALTER TABLE mate_conversation ADD COLUMN webchat_session_id VARCHAR(64) NULL COMMENT ''WebChat per-thread sessionId (recoverable even when conversationId hashes)''',
+    'SELECT 1');
+PREPARE stmt FROM @ddl;
+EXECUTE stmt;
+DEALLOCATE PREPARE stmt;

--- a/mateclaw-server/src/test/java/vip/mate/channel/webchat/WebChatCreateSessionTest.java
+++ b/mateclaw-server/src/test/java/vip/mate/channel/webchat/WebChatCreateSessionTest.java
@@ -1,0 +1,204 @@
+package vip.mate.channel.webchat;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.test.context.TestPropertySource;
+import vip.mate.MateClawApplication;
+import vip.mate.channel.webchat.WebChatController.WebChatCreateSessionRequest;
+import vip.mate.common.result.R;
+import vip.mate.workspace.conversation.ConversationService;
+
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * End-to-end verification of {@code POST /api/v1/channels/webchat/sessions}
+ * (explicit empty-session creation) against a booted context + real H2 with
+ * migrations (incl. V147 {@code webchat_session_id}) applied.
+ * <p>
+ * Covers the four behaviors promised in issue #351:
+ * <ol>
+ *   <li>happy path inserts an empty thread and returns sessionId/conversationId/
+ *       visitorToken;</li>
+ *   <li>a caller-supplied title is persisted and survives the first /stream
+ *       user message (saveMessage's "title-derive" guard must not fire);</li>
+ *   <li>re-creating with a colliding sessionId is idempotent — 200, no title
+ *       clobber;</li>
+ *   <li>the empty-session quota (≤ 5) is enforced with a clear 409.</li>
+ * </ol>
+ */
+@SpringBootTest(
+        classes = MateClawApplication.class,
+        webEnvironment = SpringBootTest.WebEnvironment.NONE
+)
+@TestPropertySource(properties = {
+        "spring.datasource.url=jdbc:h2:mem:webchat_create_sess_${random.uuid};MODE=MySQL;DATABASE_TO_LOWER=TRUE;CASE_INSENSITIVE_IDENTIFIERS=TRUE;DB_CLOSE_DELAY=-1",
+        "spring.ai.dashscope.api-key=test-key",
+        "spring.main.web-application-type=none",
+        "mateclaw.jwt.secret=webchat-it-secret-0123456789"
+})
+class WebChatCreateSessionTest {
+
+    private static final String SECRET = "webchat-it-secret-0123456789";
+    private static final String API_KEY = "testkey1abcdefgh"; // key8 = "testkey1"
+    private static final long CHANNEL_ID = 9_147_101L;
+    private static final long AGENT_ID = 9_147_1011L;
+
+    @Autowired private WebChatController controller;
+    @Autowired private ConversationService conversationService;
+    @Autowired private JdbcTemplate jdbc;
+
+    @BeforeEach
+    void setUp() {
+        jdbc.update("DELETE FROM mate_channel WHERE id = ?", CHANNEL_ID);
+        jdbc.update("DELETE FROM mate_agent WHERE id = ?", AGENT_ID);
+        jdbc.update(
+                "MERGE INTO mate_agent (id, name, agent_type, system_prompt, max_iterations, enabled, " +
+                        "workspace_id, create_time, update_time, deleted) " +
+                        "KEY(id) VALUES (?, 'wc-test-agent', 'react', '', 10, TRUE, 1, " +
+                        "CURRENT_TIMESTAMP, CURRENT_TIMESTAMP, 0)",
+                AGENT_ID);
+        jdbc.update("INSERT INTO mate_channel (id, name, channel_type, agent_id, config_json, enabled, " +
+                        "workspace_id, create_time, update_time, deleted) " +
+                        "VALUES (?, 'wc', 'webchat', ?, ?, TRUE, 1, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP, 0)",
+                CHANNEL_ID, AGENT_ID, "{\"api_key\":\"" + API_KEY + "\"}");
+    }
+
+    private WebChatCreateSessionRequest req(String visitorId, String sessionId, String title) {
+        WebChatCreateSessionRequest r = new WebChatCreateSessionRequest();
+        r.setVisitorId(visitorId);
+        r.setSessionId(sessionId);
+        r.setTitle(title);
+        return r;
+    }
+
+    @Test
+    @DisplayName("createSession inserts an empty thread and returns all required fields")
+    void createsEmptySession() {
+        R<Map<String, Object>> r = controller.createSession(API_KEY, req("visitorA", "s1", null));
+        assertThat(r.getCode()).isEqualTo(200);
+        Map<String, Object> data = r.getData();
+        assertThat(data.get("sessionId")).isEqualTo("s1");
+        assertThat(data.get("conversationId"))
+                .isEqualTo(WebChatController.deriveConversationId(API_KEY, "visitorA", "s1"));
+        assertThat(data.get("visitorToken"))
+                .isEqualTo(WebChatController.computeVisitorToken(SECRET, CHANNEL_ID, "visitorA"));
+        // No title supplied → default placeholder, will be derived from first user message later.
+        assertThat(data.get("title")).isEqualTo("新对话");
+        assertThat(data.get("createTime")).isNotNull();
+
+        // Row actually persisted with message_count = 0.
+        Integer count = jdbc.queryForObject(
+                "SELECT message_count FROM mate_conversation WHERE conversation_id = ?",
+                Integer.class, data.get("conversationId"));
+        assertThat(count).isZero();
+    }
+
+    @Test
+    @DisplayName("caller-supplied title survives the first /stream user message")
+    void titleSurvivesFirstMessage() {
+        String cid = (String) controller
+                .createSession(API_KEY, req("visitorB", "s-title", "Quarterly Report"))
+                .getData().get("conversationId");
+
+        // Simulate /stream saving the first user message.
+        conversationService.saveMessage(cid, "user", "随便说点什么,看看会不会把 title 覆盖掉");
+
+        String persisted = jdbc.queryForObject(
+                "SELECT title FROM mate_conversation WHERE conversation_id = ?",
+                String.class, cid);
+        assertThat(persisted).isEqualTo("Quarterly Report");
+    }
+
+    @Test
+    @DisplayName("default-title thread still derives its title from the first user message")
+    void defaultTitleIsDerivedFromFirstMessage() {
+        String cid = (String) controller
+                .createSession(API_KEY, req("visitorC", "s-default", null))
+                .getData().get("conversationId");
+
+        conversationService.saveMessage(cid, "user", "今天天气不错");
+
+        String persisted = jdbc.queryForObject(
+                "SELECT title FROM mate_conversation WHERE conversation_id = ?",
+                String.class, cid);
+        assertThat(persisted).isEqualTo("今天天气不错");
+    }
+
+    @Test
+    @DisplayName("re-create with colliding sessionId is idempotent — no title clobber")
+    void isIdempotentOnCollision() {
+        // First call creates with a caller title.
+        controller.createSession(API_KEY, req("visitorD", "s-collide", "OriginalTitle"));
+
+        // Second call tries to re-create the same sessionId with a different title.
+        R<Map<String, Object>> r = controller
+                .createSession(API_KEY, req("visitorD", "s-collide", "AttemptedOverride"));
+        assertThat(r.getCode()).isEqualTo(200);
+        assertThat(r.getData().get("title")).isEqualTo("OriginalTitle");
+
+        String persisted = jdbc.queryForObject(
+                "SELECT title FROM mate_conversation WHERE conversation_id = ?",
+                String.class, r.getData().get("conversationId"));
+        assertThat(persisted).isEqualTo("OriginalTitle");
+    }
+
+    @Test
+    @DisplayName("empty-session quota (≤ 5) is enforced with a 409")
+    void enforcesQuota() {
+        // Pre-seed 5 empty threads directly through the service (bypasses the controller
+        // quota so we can verify the controller is the gate, not the service).
+        String owner = WebChatController.webchatUsername("visitorE");
+        for (int i = 1; i <= 5; i++) {
+            conversationService.getOrCreateWebchatConversation(
+                    WebChatController.deriveConversationId(API_KEY, "visitorE", "seed" + i),
+                    null, owner, 1L, "seed" + i);
+        }
+
+        R<Map<String, Object>> r = controller.createSession(API_KEY, req("visitorE", "s-new", null));
+        assertThat(r.getCode()).isEqualTo(409);
+        assertThat(r.getMsg()).contains("未活跃会话数已达上限");
+    }
+
+    @Test
+    @DisplayName("bad API Key → 401")
+    void rejectsBadApiKey() {
+        R<Map<String, Object>> r = controller.createSession("bogus-key", req("visitorF", "s1", null));
+        assertThat(r.getCode()).isEqualTo(401);
+    }
+
+    @Test
+    @DisplayName("illegal sessionId charset → 400")
+    void rejectsIllegalSessionId() {
+        R<Map<String, Object>> r = controller
+                .createSession(API_KEY, req("visitorG", "has space", null));
+        assertThat(r.getCode()).isEqualTo(400);
+    }
+
+    @Test
+    @DisplayName("illegal title length (>100) → 400")
+    void rejectsOverlongTitle() {
+        R<Map<String, Object>> r = controller
+                .createSession(API_KEY, req("visitorH", "s1", "x".repeat(101)));
+        assertThat(r.getCode()).isEqualTo(400);
+    }
+
+    @Test
+    @DisplayName("once a session is created, listSessions sees it (with the recovered sessionId)")
+    @SuppressWarnings("unchecked")
+    void createdSessionIsListable() {
+        controller.createSession(API_KEY, req("visitorI", "s-listed", null));
+
+        String token = WebChatController.computeVisitorToken(SECRET, CHANNEL_ID, "visitorI");
+        R<?> r = controller.listSessions(API_KEY, token, "visitorI");
+        assertThat(r.getCode()).isEqualTo(200);
+        assertThat(((java.util.List<WebChatController.WebChatSessionView>) (Object) r.getData()))
+                .extracting(WebChatController.WebChatSessionView::getSessionId)
+                .contains("s-listed");
+    }
+}

--- a/mateclaw-server/src/test/java/vip/mate/channel/webchat/WebChatFileServiceTest.java
+++ b/mateclaw-server/src/test/java/vip/mate/channel/webchat/WebChatFileServiceTest.java
@@ -27,7 +27,12 @@ class WebChatFileServiceTest {
     private static final String CONV = "webchat:abcd1234:visitor-1";
 
     private WebChatFileService service(boolean enabled, long maxMb, String exts) {
-        return new WebChatFileService(enabled, maxMb, exts);
+        return new WebChatFileService(enabled, maxMb, exts, 50, 200);
+    }
+
+    private WebChatFileService service(boolean enabled, long maxMb, String exts,
+                                       int maxFiles, long maxTotalMb) {
+        return new WebChatFileService(enabled, maxMb, exts, maxFiles, maxTotalMb);
     }
 
     @AfterEach
@@ -90,6 +95,17 @@ class WebChatFileServiceTest {
 
         // Bytes survive on disk for download after consume.
         assertThat(svc.resolve(CONV, stored.storedName())).isPresent();
+    }
+
+    @Test
+    @DisplayName("rejects once the per-conversation file-count quota is hit")
+    void rejectsOverFileCountQuota() throws IOException {
+        WebChatFileService svc = service(true, 20, "txt", 2, 200); // max 2 files
+        svc.store(CONV, new MockMultipartFile("file", "a.txt", "text/plain", "a".getBytes()));
+        svc.store(CONV, new MockMultipartFile("file", "b.txt", "text/plain", "b".getBytes()));
+        assertThatThrownBy(() -> svc.store(CONV,
+                new MockMultipartFile("file", "c.txt", "text/plain", "c".getBytes())))
+                .isInstanceOf(WebChatFileService.UploadRejectedException.class);
     }
 
     @Test

--- a/mateclaw-server/src/test/java/vip/mate/channel/webchat/WebChatFileServiceTest.java
+++ b/mateclaw-server/src/test/java/vip/mate/channel/webchat/WebChatFileServiceTest.java
@@ -1,0 +1,102 @@
+package vip.mate.channel.webchat;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.mock.web.MockMultipartFile;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.Comparator;
+import java.util.Optional;
+import java.util.stream.Stream;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/**
+ * Validation + isolation contract for {@link WebChatFileService}. WebChat
+ * uploads come from untrusted external visitors, so these pin: extension
+ * whitelist, size cap, disabled-switch, per-conversation ownership of staged
+ * ids, and traversal-safe resolution.
+ */
+class WebChatFileServiceTest {
+
+    private static final String CONV = "webchat:abcd1234:visitor-1";
+
+    private WebChatFileService service(boolean enabled, long maxMb, String exts) {
+        return new WebChatFileService(enabled, maxMb, exts);
+    }
+
+    @AfterEach
+    void cleanup() throws IOException {
+        Path dir = Paths.get("data", "chat-uploads", CONV);
+        if (Files.exists(dir)) {
+            try (Stream<Path> walk = Files.walk(dir)) {
+                walk.sorted(Comparator.reverseOrder()).forEach(p -> {
+                    try { Files.deleteIfExists(p); } catch (IOException ignored) { }
+                });
+            }
+        }
+    }
+
+    @Test
+    @DisplayName("rejects a disallowed extension")
+    void rejectsDisallowedExtension() {
+        WebChatFileService svc = service(true, 20, "png,txt");
+        MockMultipartFile evil = new MockMultipartFile("file", "evil.exe",
+                "application/octet-stream", new byte[]{1, 2, 3});
+        assertThatThrownBy(() -> svc.store(CONV, evil))
+                .isInstanceOf(WebChatFileService.UploadRejectedException.class);
+    }
+
+    @Test
+    @DisplayName("rejects an oversized file")
+    void rejectsOversized() {
+        WebChatFileService svc = service(true, 1, "png");
+        byte[] big = new byte[2 * 1024 * 1024]; // 2MB > 1MB cap
+        MockMultipartFile file = new MockMultipartFile("file", "big.png", "image/png", big);
+        assertThatThrownBy(() -> svc.store(CONV, file))
+                .isInstanceOf(WebChatFileService.UploadRejectedException.class);
+    }
+
+    @Test
+    @DisplayName("rejects when disabled")
+    void rejectsWhenDisabled() {
+        WebChatFileService svc = service(false, 20, "png");
+        MockMultipartFile file = new MockMultipartFile("file", "ok.png", "image/png", new byte[]{1});
+        assertThatThrownBy(() -> svc.store(CONV, file))
+                .isInstanceOf(WebChatFileService.UploadRejectedException.class);
+    }
+
+    @Test
+    @DisplayName("accepts allowed file; consume is one-shot and conversation-scoped")
+    void acceptsAndConsumeIsScoped() throws IOException {
+        WebChatFileService svc = service(true, 20, "png,txt");
+        MockMultipartFile file = new MockMultipartFile("file", "hello.txt", "text/plain",
+                "hi".getBytes());
+
+        WebChatFileService.StagedFile stored = svc.store(CONV, file);
+        assertThat(stored.originalName()).isEqualTo("hello.txt");
+        assertThat(stored.conversationId()).isEqualTo(CONV);
+
+        // Foreign conversation can't consume it.
+        assertThat(svc.consume("webchat:abcd1234:other", stored.storedName())).isEmpty();
+        // Owning conversation can — exactly once.
+        assertThat(svc.consume(CONV, stored.storedName())).isPresent();
+        assertThat(svc.consume(CONV, stored.storedName())).isEmpty();
+
+        // Bytes survive on disk for download after consume.
+        assertThat(svc.resolve(CONV, stored.storedName())).isPresent();
+    }
+
+    @Test
+    @DisplayName("resolve is traversal-safe")
+    void resolveRejectsTraversal() {
+        WebChatFileService svc = service(true, 20, "png");
+        Optional<Path> escaped = svc.resolve(CONV, "../../../../etc/passwd");
+        assertThat(escaped).isEmpty();
+    }
+}

--- a/mateclaw-server/src/test/java/vip/mate/channel/webchat/WebChatSessionManagementTest.java
+++ b/mateclaw-server/src/test/java/vip/mate/channel/webchat/WebChatSessionManagementTest.java
@@ -1,0 +1,136 @@
+package vip.mate.channel.webchat;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.test.context.TestPropertySource;
+import vip.mate.MateClawApplication;
+import vip.mate.channel.webchat.WebChatController.WebChatSessionView;
+import vip.mate.common.result.R;
+import vip.mate.workspace.conversation.ConversationService;
+
+import java.util.List;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * End-to-end verification of the WebChat visitor session-management endpoints
+ * against a booted context + real H2 (migrations incl. V147 run). Exercises the
+ * controller's real auth (channel lookup + visitor-token HMAC), pagination,
+ * keyword search, rename, and — the key case — that a thread whose
+ * conversationId hashed (long visitorId + sessionId) is still listed with its
+ * sessionId recovered from the persisted column.
+ */
+@SpringBootTest(
+        classes = MateClawApplication.class,
+        webEnvironment = SpringBootTest.WebEnvironment.NONE
+)
+@TestPropertySource(properties = {
+        "spring.datasource.url=jdbc:h2:mem:webchat_sess_test_${random.uuid};MODE=MySQL;DATABASE_TO_LOWER=TRUE;CASE_INSENSITIVE_IDENTIFIERS=TRUE;DB_CLOSE_DELAY=-1",
+        "spring.ai.dashscope.api-key=test-key",
+        "spring.main.web-application-type=none",
+        "mateclaw.jwt.secret=webchat-it-secret-0123456789"
+})
+class WebChatSessionManagementTest {
+
+    private static final String SECRET = "webchat-it-secret-0123456789";
+    private static final String API_KEY = "testkey1abcdefgh"; // key8 = "testkey1"
+    private static final String VISITOR = "visitorAAAA";
+    private static final long CHANNEL_ID = 9_147_001L;
+    // Long enough that "webchat:testkey1:visitorAAAA:<this>" exceeds 64 chars and hashes.
+    private static final String LONG_SESSION = "session-1234567890-abcdefghij-klmnopqrst";
+
+    @Autowired private WebChatController controller;
+    @Autowired private ConversationService conversationService;
+    @Autowired private JdbcTemplate jdbc;
+
+    private String token;
+
+    @BeforeEach
+    void setUp() {
+        jdbc.update("DELETE FROM mate_channel WHERE id = ?", CHANNEL_ID);
+        jdbc.update("INSERT INTO mate_channel (id, name, channel_type, config_json, enabled, " +
+                        "workspace_id, create_time, update_time, deleted) " +
+                        "VALUES (?, 'wc', 'webchat', ?, TRUE, 1, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP, 0)",
+                CHANNEL_ID, "{\"api_key\":\"" + API_KEY + "\"}");
+
+        String owner = WebChatController.webchatUsername(VISITOR);
+        // default thread (no sessionId)
+        conversationService.getOrCreateWebchatConversation(
+                WebChatController.deriveConversationId(API_KEY, VISITOR, null), null, owner, 1L, null);
+        // short sessioned thread
+        conversationService.getOrCreateWebchatConversation(
+                WebChatController.deriveConversationId(API_KEY, VISITOR, "s1"), null, owner, 1L, "s1");
+        // long sessioned thread → conversationId hashes
+        conversationService.getOrCreateWebchatConversation(
+                WebChatController.deriveConversationId(API_KEY, VISITOR, LONG_SESSION), null, owner, 1L, LONG_SESSION);
+
+        token = WebChatController.computeVisitorToken(SECRET, CHANNEL_ID, VISITOR);
+    }
+
+    @Test
+    @DisplayName("listSessions includes the hashed long-id thread with its sessionId recovered")
+    @SuppressWarnings("unchecked")
+    void listsHashedThread() {
+        R<List<WebChatSessionView>> r = (R<List<WebChatSessionView>>) (R<?>) controller.listSessions(API_KEY, token, VISITOR);
+        assertThat(r.getCode()).isEqualTo(200);
+        List<WebChatSessionView> sessions = r.getData();
+        assertThat(sessions).hasSize(3);
+        assertThat(sessions).extracting(WebChatSessionView::getSessionId)
+                .containsExactlyInAnyOrder(null, "s1", LONG_SESSION);
+    }
+
+    @Test
+    @DisplayName("bad visitor token is rejected")
+    @SuppressWarnings("unchecked")
+    void rejectsBadToken() {
+        R<List<WebChatSessionView>> r = (R<List<WebChatSessionView>>) (R<?>) controller.listSessions(API_KEY, "bogus", VISITOR);
+        assertThat(r.getCode()).isEqualTo(401);
+    }
+
+    @Test
+    @DisplayName("pageSessions paginates and keyword-searches by title")
+    void pagesAndSearches() {
+        R<Map<String, Object>> page = controller.pageSessions(API_KEY, token, VISITOR, 1, 2, null);
+        assertThat(page.getCode()).isEqualTo(200);
+        assertThat(page.getData().get("total")).isEqualTo(3L);
+        assertThat((List<?>) page.getData().get("items")).hasSize(2);
+
+        // Rename one thread, then search for it.
+        controller.renameSession(API_KEY, token, VISITOR, "s1", Map.of("title", "QuarterlyReport"));
+        R<Map<String, Object>> hit = controller.pageSessions(API_KEY, token, VISITOR, 1, 20, "quarterly");
+        assertThat((List<?>) hit.getData().get("items")).hasSize(1);
+    }
+
+    @Test
+    @DisplayName("rename updates the thread title")
+    void renames() {
+        R<Void> r = controller.renameSession(API_KEY, token, VISITOR, "s1", Map.of("title", "Renamed"));
+        assertThat(r.getCode()).isEqualTo(200);
+
+        String cid = WebChatController.deriveConversationId(API_KEY, VISITOR, "s1");
+        String title = jdbc.queryForObject(
+                "SELECT title FROM mate_conversation WHERE conversation_id = ?", String.class, cid);
+        assertThat(title).isEqualTo("Renamed");
+    }
+
+    @Test
+    @DisplayName("sessionMessages paginates with hasMore")
+    @SuppressWarnings("unchecked")
+    void paginatesMessages() {
+        String cid = WebChatController.deriveConversationId(API_KEY, VISITOR, "s1");
+        conversationService.saveMessage(cid, "user", "m1");
+        conversationService.saveMessage(cid, "assistant", "m2");
+        conversationService.saveMessage(cid, "user", "m3");
+
+        R<?> r = controller.sessionMessages(API_KEY, token, VISITOR, "s1", null, 2);
+        assertThat(r.getCode()).isEqualTo(200);
+        Map<String, Object> data = (Map<String, Object>) r.getData();
+        assertThat((List<?>) data.get("messages")).hasSize(2);
+        assertThat(data.get("hasMore")).isEqualTo(true);
+    }
+}

--- a/mateclaw-server/src/test/java/vip/mate/channel/webchat/WebChatStopStreamTest.java
+++ b/mateclaw-server/src/test/java/vip/mate/channel/webchat/WebChatStopStreamTest.java
@@ -1,0 +1,133 @@
+package vip.mate.channel.webchat;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.test.context.TestPropertySource;
+import reactor.core.Disposable;
+import reactor.core.publisher.Flux;
+import vip.mate.MateClawApplication;
+import vip.mate.channel.web.ChatStreamTracker;
+import vip.mate.channel.webchat.WebChatController.WebChatCreateSessionRequest;
+import vip.mate.common.result.R;
+
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * End-to-end verification of {@code POST /api/v1/channels/webchat/sessions/stop}
+ * against a booted context + real H2 (migrations incl. V147).
+ * <p>
+ * The non-trivial case is {@link #stopsActiveStream()}: a real Reactor
+ * {@code Disposable} is registered on the tracker (mirroring what
+ * {@code WebChatController.chatStream} now does after subscribe), and the test
+ * asserts that {@code stopSession} both returns {@code stopped=true} AND
+ * actually disposes the underlying subscription — proving the chatStream
+ * wiring change is what makes the new endpoint functional rather than a no-op.
+ */
+@SpringBootTest(
+        classes = MateClawApplication.class,
+        webEnvironment = SpringBootTest.WebEnvironment.NONE
+)
+@TestPropertySource(properties = {
+        "spring.datasource.url=jdbc:h2:mem:webchat_stop_${random.uuid};MODE=MySQL;DATABASE_TO_LOWER=TRUE;CASE_INSENSITIVE_IDENTIFIERS=TRUE;DB_CLOSE_DELAY=-1",
+        "spring.ai.dashscope.api-key=test-key",
+        "spring.main.web-application-type=none",
+        "mateclaw.jwt.secret=webchat-it-secret-0123456789"
+})
+class WebChatStopStreamTest {
+
+    private static final String SECRET = "webchat-it-secret-0123456789";
+    private static final String API_KEY = "testkey1abcdefgh"; // key8 = "testkey1"
+    private static final long CHANNEL_ID = 9_147_201L;
+    private static final long AGENT_ID = 9_147_2011L;
+
+    @Autowired private WebChatController controller;
+    @Autowired private ChatStreamTracker streamTracker;
+    @Autowired private JdbcTemplate jdbc;
+
+    @BeforeEach
+    void setUp() {
+        jdbc.update("DELETE FROM mate_channel WHERE id = ?", CHANNEL_ID);
+        jdbc.update("DELETE FROM mate_agent WHERE id = ?", AGENT_ID);
+        jdbc.update(
+                "MERGE INTO mate_agent (id, name, agent_type, system_prompt, max_iterations, enabled, " +
+                        "workspace_id, create_time, update_time, deleted) " +
+                        "KEY(id) VALUES (?, 'wc-stop-agent', 'react', '', 10, TRUE, 1, " +
+                        "CURRENT_TIMESTAMP, CURRENT_TIMESTAMP, 0)",
+                AGENT_ID);
+        jdbc.update("INSERT INTO mate_channel (id, name, channel_type, agent_id, config_json, enabled, " +
+                        "workspace_id, create_time, update_time, deleted) " +
+                        "VALUES (?, 'wc', 'webchat', ?, ?, TRUE, 1, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP, 0)",
+                CHANNEL_ID, AGENT_ID, "{\"api_key\":\"" + API_KEY + "\"}");
+    }
+
+    private WebChatCreateSessionRequest req(String visitorId, String sessionId) {
+        WebChatCreateSessionRequest r = new WebChatCreateSessionRequest();
+        r.setVisitorId(visitorId);
+        r.setSessionId(sessionId);
+        return r;
+    }
+
+    private String tokenFor(String visitorId) {
+        return WebChatController.computeVisitorToken(SECRET, CHANNEL_ID, visitorId);
+    }
+
+    @Test
+    @DisplayName("stop actually disposes the active subscription (chatStream wiring works)")
+    void stopsActiveStream() {
+        controller.createSession(API_KEY, req("visitorA", "s1"));
+        String cid = WebChatController.deriveConversationId(API_KEY, "visitorA", "s1");
+
+        // Simulate what WebChatController.chatStream does right after .subscribe():
+        // register the run + bind the Disposable so requestStop() can dispose it.
+        streamTracker.register(cid);
+        Disposable disposable = Flux.never().subscribe();
+        streamTracker.setDisposable(cid, disposable);
+        assertThat(disposable.isDisposed()).isFalse();
+
+        R<Map<String, Object>> r = controller.stopSession(API_KEY, tokenFor("visitorA"), "visitorA", "s1");
+        assertThat(r.getCode()).isEqualTo(200);
+        assertThat(r.getData().get("stopped")).isEqualTo(Boolean.TRUE);
+        assertThat(disposable.isDisposed()).isTrue();
+    }
+
+    @Test
+    @DisplayName("stop returns stopped=false when no stream is active (idempotent)")
+    void noActiveStreamReturnsFalse() {
+        controller.createSession(API_KEY, req("visitorB", "s1"));
+
+        R<Map<String, Object>> r = controller.stopSession(API_KEY, tokenFor("visitorB"), "visitorB", "s1");
+        assertThat(r.getCode()).isEqualTo(200);
+        assertThat(r.getData().get("stopped")).isEqualTo(Boolean.FALSE);
+    }
+
+    @Test
+    @DisplayName("bad visitor token → 401")
+    void rejectsBadToken() {
+        controller.createSession(API_KEY, req("visitorC", "s1"));
+
+        R<Map<String, Object>> r = controller.stopSession(API_KEY, "bogus-token", "visitorC", "s1");
+        assertThat(r.getCode()).isEqualTo(401);
+    }
+
+    @Test
+    @DisplayName("bad API Key → 401")
+    void rejectsBadApiKey() {
+        R<Map<String, Object>> r = controller.stopSession("bogus-key", "any-token", "visitorD", "s1");
+        assertThat(r.getCode()).isEqualTo(401);
+    }
+
+    @Test
+    @DisplayName("unknown sessionId → 404 (no namespace probing)")
+    void rejectsUnknownSession() {
+        // Visitor exists (token verifies) but never created session "ghost".
+        R<Map<String, Object>> r = controller.stopSession(
+                API_KEY, tokenFor("visitorE"), "visitorE", "never-created");
+        assertThat(r.getCode()).isEqualTo(404);
+    }
+}

--- a/mateclaw-server/src/test/java/vip/mate/workspace/conversation/ConversationServiceExternalViewTest.java
+++ b/mateclaw-server/src/test/java/vip/mate/workspace/conversation/ConversationServiceExternalViewTest.java
@@ -1,0 +1,84 @@
+package vip.mate.workspace.conversation;
+
+import com.baomidou.mybatisplus.core.conditions.query.LambdaQueryWrapper;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.Spy;
+import org.mockito.junit.jupiter.MockitoExtension;
+import vip.mate.agent.repository.AgentMapper;
+import vip.mate.workspace.conversation.model.MessageEntity;
+import vip.mate.workspace.conversation.repository.ConversationMapper;
+import vip.mate.workspace.conversation.repository.MessageMapper;
+import vip.mate.workspace.conversation.vo.MessageVO;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
+
+/**
+ * Pin that the external (webchat-facing) message view never leaks the
+ * server-side absolute file path — neither in the structured {@code path} field
+ * nor in the rendered text — while the internal view still carries it for the
+ * agent's file tools.
+ */
+@ExtendWith(MockitoExtension.class)
+class ConversationServiceExternalViewTest {
+
+    @Mock private ConversationMapper conversationMapper;
+    @Mock private MessageMapper messageMapper;
+    @Mock private AgentMapper agentMapper;
+    @Spy private ObjectMapper objectMapper = new ObjectMapper();
+
+    @InjectMocks private ConversationService service;
+
+    private static final String SECRET_PATH = "/srv/mateclaw/data/chat-uploads/secret/doc.pdf";
+
+    private MessageEntity fileMessage() {
+        MessageEntity m = new MessageEntity();
+        m.setId(1L);
+        m.setConversationId("c1");
+        m.setRole("assistant");
+        m.setContent("here is your file");
+        m.setContentParts("[{\"type\":\"file\",\"fileName\":\"doc.pdf\",\"path\":\""
+                + SECRET_PATH + "\"}]");
+        m.setStatus("completed");
+        m.setCreateTime(LocalDateTime.now());
+        return m;
+    }
+
+    @Test
+    @DisplayName("external view nulls part.path and omits path from rendered text")
+    void externalViewStripsPath() {
+        when(messageMapper.selectList(any(LambdaQueryWrapper.class)))
+                .thenReturn(List.of(fileMessage()));
+
+        List<MessageVO> views = service.listMessageViewsExternal("c1");
+
+        assertThat(views).hasSize(1);
+        MessageVO vo = views.get(0);
+        assertThat(vo.getContentParts().get(0).getPath()).isNull();
+        assertThat(vo.getContent()).doesNotContain(SECRET_PATH);
+        assertThat(vo.getContent()).doesNotContain("路径");
+        // filename still surfaced so the visitor can recognize the attachment
+        assertThat(vo.getContent()).contains("doc.pdf");
+    }
+
+    @Test
+    @DisplayName("internal view keeps the path for the agent's file tools")
+    void internalViewKeepsPath() {
+        when(messageMapper.selectList(any(LambdaQueryWrapper.class)))
+                .thenReturn(List.of(fileMessage()));
+
+        List<MessageVO> views = service.listMessageViews("c1");
+
+        assertThat(views.get(0).getContentParts().get(0).getPath()).isEqualTo(SECRET_PATH);
+        assertThat(views.get(0).getContent()).contains(SECRET_PATH);
+    }
+}

--- a/mateclaw-server/src/test/java/vip/mate/workspace/conversation/ConversationServiceExternalViewTest.java
+++ b/mateclaw-server/src/test/java/vip/mate/workspace/conversation/ConversationServiceExternalViewTest.java
@@ -81,4 +81,15 @@ class ConversationServiceExternalViewTest {
         assertThat(views.get(0).getContentParts().get(0).getPath()).isEqualTo(SECRET_PATH);
         assertThat(views.get(0).getContent()).contains(SECRET_PATH);
     }
+
+    @Test
+    @DisplayName("toExternalMessageViews strips path on a pre-loaded list (paginated path)")
+    void toExternalMessageViewsStripsPath() {
+        // Used by the paginated webchat endpoint, which loads entities itself.
+        List<MessageVO> views = service.toExternalMessageViews(List.of(fileMessage()));
+
+        assertThat(views).hasSize(1);
+        assertThat(views.get(0).getContentParts().get(0).getPath()).isNull();
+        assertThat(views.get(0).getContent()).doesNotContain(SECRET_PATH);
+    }
 }


### PR DESCRIPTION
## Summary

让 webchat 渠道**真正能停止**进行中的 SSE 流。在此之前,访客只能客户端关 SSE 连接,服务端 LLM 流继续跑完(浪费 token、副作用工具继续执行)。

Closes #353。

## Why

复用 \`POST /api/v1/chat/{conversationId}/stop\`(SecurityConfig 中 permitAll)对 webchat **实际无效**——根因是 \`WebChatController.chatStream\` 末尾 \`subscribe()\` 直接丢返回值,\`streamTracker\` 拿不到 \`Disposable\`,\`requestStop\` 设了 \`stopRequested\` 标志但 dispose 不发生。详见 issue 描述。

## Changes

### 1. \`WebChatController.chatStream\`:绑定 Disposable

\`\`\`java
reactor.core.Disposable disposable = agentService.chatStructuredStream(...)
        .doOnNext(...)
        .doOnComplete(...)
        .doOnError(...)
        .subscribe();
streamTracker.setDisposable(conversationId, disposable);
\`\`\`

完全对齐 \`ChatController#chatStream\` line 495。\`setDisposable\` 在 sseExecutor 异步线程里调,与 subscribe 同线程,无并发问题。

### 2. 新端点 \`POST /api/v1/channels/webchat/sessions/stop\`

| 项 | 值 |
|---|---|
| 路径 | \`POST /api/v1/channels/webchat/sessions/stop\` |
| 鉴权 | \`X-MC-Key\` + \`X-MC-Visitor-Token\` + 会话归属(同 \`PUT /sessions/title\` / \`DELETE /sessions\`) |
| 请求 | query param \`visitorId\` + \`sessionId\`(可选) |
| 响应 | \`{ "stopped": true|false }\`,false 表示当前无活跃流(幂等) |

行为链:\`resolveChannel\` → \`verifyVisitorToken\` → \`normalizeSessionId\` + \`deriveConversationId\` → \`ownsConversation\`(404 防命名空间探测) → \`streamTracker.requestStop\`。

**不做 approval sweep**:\`ChatController.stopStream\` 会调 \`approvalService.denyAllByConversation\`,但 webchat 没 MateClaw username,且不暴露 approval UI;先不引入这层复杂度。

## Security

- visitorToken HMAC + channelId 绑定,不可跨渠道复用
- \`ownsConversation\` 用 visitorId 派生 username 跟会话归属比对,防越权
- 不暴露任何内部状态(dispose 只是布尔结果回传)

## Test plan

\`WebChatStopStreamTest\`(\`@SpringBootTest\` + H2 + V147,5 个 case):

- [x] \`stopsActiveStream\` —— 在 tracker 上注册一个真实的 \`Flux.never()\` Disposable(镜像 chatStream 改动),stop 后断言 \`stopped=true\` **AND** \`disposable.isDisposed()\`,证明是 chatStream 的 wiring 改动让端点真正生效
- [x] \`noActiveStreamReturnsFalse\` —— 幂等路径
- [x] 坏 visitorToken → 401
- [x] 坏 API Key → 401
- [x] 未知 sessionId → 404

回归:\`WebChatSessionManagementTest\` (5/5)、\`WebChatCreateSessionTest\` (9/9)、\`WebChatFileServiceTest\` (6/6) 全绿。

## Stack

依赖(同 stack 链顶端):
- #341 → #343 → #347 → #348 → #349 → #352(显式创建会话) → **本 PR**

环境:v1.6.0-SNAPSHOT