### PR TITLE
feat(webchat): pin + archive endpoints (epic #355 PR 3)

### DIFF
--- a/mateclaw-server/src/main/java/vip/mate/channel/webchat/WebChatAdminController.java
+++ b/mateclaw-server/src/main/java/vip/mate/channel/webchat/WebChatAdminController.java
@@ -1,0 +1,104 @@
+package vip.mate.channel.webchat;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.core.Authentication;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+import vip.mate.audit.service.AuditEventService;
+import vip.mate.channel.model.ChannelEntity;
+import vip.mate.channel.service.ChannelService;
+import vip.mate.common.result.R;
+
+import java.util.Map;
+
+/**
+ * Admin-facing webchat operations. Mounted under {@code /api/v1/admin/webchat/**}
+ * (outside the {@code /api/v1/channels/webchat/**} permitAll block) so it
+ * requires a regular MateClaw JWT — visitors cannot reach these endpoints.
+ *
+ * <p>Currently only manages visitor-token revocation. Audit-recorded via
+ * {@link AuditEventService}; actor is the JWT-authenticated admin username,
+ * not the visitor.
+ *
+ * @author MateClaw Team
+ */
+@Tag(name = "WebChat 管理(管理员)")
+@Slf4j
+@RestController
+@RequestMapping("/api/v1/admin/webchat")
+@RequiredArgsConstructor
+public class WebChatAdminController {
+
+    private final ChannelService channelService;
+    private final WebChatTokenRevocationService revocationService;
+    private final AuditEventService auditService;
+
+    @Operation(summary = "撤销访客的 visitorToken(ban 该 visitor 在管理端点的所有调用)")
+    @PostMapping("/revoked-visitor")
+    public R<Void> revokeVisitor(
+            @RequestBody RevokeVisitorRequest request,
+            Authentication auth) {
+        if (request == null || request.getChannelId() == null
+                || request.getVisitorId() == null || request.getVisitorId().isBlank()) {
+            return R.fail(400, "channelId and visitorId are required");
+        }
+        ChannelEntity channel = channelService.getChannel(request.getChannelId());
+        if (channel == null || !"webchat".equals(channel.getChannelType())) {
+            return R.fail(404, "webchat channel not found");
+        }
+        revocationService.revoke(channel.getId(), request.getVisitorId().trim(),
+                request.getReason());
+
+        String adminUser = auth != null ? auth.getName() : "system";
+        auditService.record(
+                "webchat.revoke-visitor",
+                "CHANNEL",
+                String.valueOf(channel.getId()),
+                channel.getName(),
+                "{\"visitorId\":\"" + request.getVisitorId().trim()
+                        + "\",\"reason\":\"" + (request.getReason() != null ? request.getReason() : "")
+                        + "\",\"admin\":\"" + adminUser + "\"}",
+                channel.getWorkspaceId());
+        return R.ok();
+    }
+
+    @Operation(summary = "取消撤销访客(un-ban)")
+    @DeleteMapping("/revoked-visitor")
+    public R<Void> unrevokeVisitor(
+            @RequestBody Map<String, Object> body,
+            Authentication auth) {
+        Long channelId = body.get("channelId") instanceof Number n ? n.longValue() : null;
+        Object rawChannelId = body.get("channelId");
+        if (rawChannelId instanceof String s && !s.isBlank()) {
+            try { channelId = Long.parseLong(s); } catch (NumberFormatException ignored) { }
+        }
+        String visitorId = body.get("visitorId") instanceof String s ? s.trim() : null;
+        if (channelId == null || visitorId == null || visitorId.isEmpty()) {
+            return R.fail(400, "channelId and visitorId are required");
+        }
+        revocationService.unrevoke(channelId, visitorId);
+
+        String adminUser = auth != null ? auth.getName() : "system";
+        auditService.record(
+                "webchat.unrevoke-visitor",
+                "CHANNEL",
+                String.valueOf(channelId),
+                null,
+                "{\"visitorId\":\"" + visitorId + "\",\"admin\":\"" + adminUser + "\"}",
+                null);
+        return R.ok();
+    }
+
+    @lombok.Data
+    public static class RevokeVisitorRequest {
+        private Long channelId;
+        private String visitorId;
+        private String reason;
+    }
+}

--- a/mateclaw-server/src/main/java/vip/mate/channel/webchat/WebChatController.java
+++ b/mateclaw-server/src/main/java/vip/mate/channel/webchat/WebChatController.java
@@ -7,15 +7,24 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.core.io.FileSystemResource;
+import org.springframework.core.io.Resource;
+import org.springframework.http.HttpHeaders;
 import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
+import org.springframework.web.multipart.MultipartFile;
 import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
 
 import javax.crypto.Mac;
 import javax.crypto.spec.SecretKeySpec;
+import java.net.URLEncoder;
 import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.security.GeneralSecurityException;
 import java.security.MessageDigest;
+import java.util.ArrayList;
 import java.util.Base64;
 import vip.mate.channel.web.Utf8SseEmitter;
 import vip.mate.agent.AgentService;
@@ -63,6 +72,7 @@ public class WebChatController {
     private final ObjectMapper objectMapper;
     private final ConversationCompletionPublisher completionPublisher;
     private final vip.mate.memory.identity.MemoryOwnerResolver memoryOwnerResolver;
+    private final WebChatFileService fileService;
 
     /**
      * Server-only secret used to sign per-visitor tokens. Reuses the JWT secret so no extra
@@ -158,8 +168,10 @@ public class WebChatController {
                 Long webWsId = webAgent != null ? webAgent.getWorkspaceId() : 1L;
                 var conv = conversationService.getOrCreateConversation(conversationId, resolvedAgentId, webchatUsername(visitorId), webWsId);
 
-                // 保存用户消息
-                conversationService.saveMessage(conversationId, "user", message, List.of());
+                // 保存用户消息（含访客本轮引用的附件）。附件元数据一律服务端按 fileId 回查，
+                // 不信客户端传入；path 用于 Agent 侧工具读取，对外消息视图会被剥离。
+                List<MessageContentPart> userParts = buildUserParts(conversationId, message, request.getAttachmentIds());
+                conversationService.saveMessage(conversationId, "user", message, userParts);
 
                 // 初始化 SSE 流跟踪
                 streamTracker.register(conversationId);
@@ -337,7 +349,8 @@ public class WebChatController {
         if (!ownsConversation(conversationId, visitorId)) {
             return R.fail(404, "Session not found");
         }
-        return R.ok(conversationService.listMessageViews(conversationId));
+        // External view: strip server-side file paths before handing messages to the visitor.
+        return R.ok(conversationService.listMessageViewsExternal(conversationId));
     }
 
     /**
@@ -369,6 +382,155 @@ public class WebChatController {
         }
         conversationService.deleteConversation(conversationId);
         return R.ok();
+    }
+
+    /**
+     * 上传文件（入站）。访客先上传拿到 fileId，再在 /stream 的 attachmentIds 中引用。
+     * <p>鉴权同会话接口：API Key + visitor token；conversationId 服务端派生。
+     */
+    @Operation(summary = "WebChat 上传文件")
+    @PostMapping(value = "/upload", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
+    public R<Map<String, Object>> uploadFile(
+            @RequestHeader("X-MC-Key") String apiKey,
+            @RequestHeader(value = "X-MC-Visitor-Token", required = false) String visitorToken,
+            @RequestParam String visitorId,
+            @RequestParam(required = false) String sessionId,
+            @RequestPart("file") MultipartFile file) {
+        ChannelEntity channel = resolveChannel(apiKey);
+        if (channel == null) {
+            return R.fail(401, "Invalid API Key");
+        }
+        if (!verifyVisitorToken(visitorTokenSecret, channel.getId(), visitorId, visitorToken)) {
+            return R.fail(401, "Invalid or missing visitor token");
+        }
+        // Upload requires an established visitor identity (the token is bound to it);
+        // unlike /stream we never mint a fresh visitorId here.
+        String vid;
+        String sid;
+        try {
+            if (visitorId == null || visitorId.trim().isEmpty()) {
+                return R.fail(400, "visitorId is required");
+            }
+            vid = normalizeVisitorId(visitorId);
+            sid = normalizeSessionId(sessionId);
+        } catch (IllegalArgumentException ex) {
+            return R.fail(400, ex.getMessage());
+        }
+        String conversationId = deriveConversationId(apiKey, vid, sid);
+        try {
+            WebChatFileService.StagedFile stored = fileService.store(conversationId, file);
+            return R.ok(Map.of(
+                    "fileId", stored.storedName(),
+                    "fileName", stored.originalName(),
+                    "contentType", stored.contentType() != null ? stored.contentType() : "application/octet-stream",
+                    "size", stored.size()
+            ));
+        } catch (WebChatFileService.UploadRejectedException ex) {
+            return R.fail(400, ex.getMessage());
+        } catch (IOException ex) {
+            log.error("[WebChat] Upload failed conv={}: {}", conversationId, ex.getMessage());
+            return R.fail(500, "Upload failed");
+        }
+    }
+
+    /**
+     * 下载文件（出站）。serves both visitor-uploaded files and agent-produced files
+     * written under the conversation dir. 鉴权同上，路径在服务端派生目录内防穿越。
+     */
+    @Operation(summary = "WebChat 下载文件")
+    @GetMapping("/files")
+    public ResponseEntity<Resource> downloadFile(
+            @RequestHeader("X-MC-Key") String apiKey,
+            @RequestHeader(value = "X-MC-Visitor-Token", required = false) String visitorToken,
+            @RequestParam String visitorId,
+            @RequestParam(required = false) String sessionId,
+            @RequestParam String storedName) {
+        ChannelEntity channel = resolveChannel(apiKey);
+        if (channel == null) {
+            return ResponseEntity.status(401).build();
+        }
+        if (!verifyVisitorToken(visitorTokenSecret, channel.getId(), visitorId, visitorToken)) {
+            return ResponseEntity.status(401).build();
+        }
+        String sid;
+        try {
+            sid = normalizeSessionId(sessionId);
+        } catch (IllegalArgumentException ex) {
+            return ResponseEntity.badRequest().build();
+        }
+        String conversationId = deriveConversationId(apiKey, visitorId, sid);
+        if (!ownsConversation(conversationId, visitorId)) {
+            return ResponseEntity.status(404).build();
+        }
+        Path file = fileService.resolve(conversationId, storedName).orElse(null);
+        if (file == null) {
+            return ResponseEntity.notFound().build();
+        }
+
+        String contentType;
+        try {
+            contentType = Files.probeContentType(file);
+        } catch (IOException e) {
+            contentType = null;
+        }
+        MediaType mediaType = MediaType.APPLICATION_OCTET_STREAM;
+        if (contentType != null) {
+            try {
+                mediaType = MediaType.parseMediaType(contentType);
+            } catch (Exception ignored) {
+                // fall back to octet-stream
+            }
+        }
+        // Only inline images; everything else downloads as an attachment. nosniff
+        // stops the browser from re-interpreting the bytes as active content.
+        boolean inlineImage = contentType != null && contentType.startsWith("image/");
+        String encodedName = URLEncoder.encode(file.getFileName().toString(), StandardCharsets.UTF_8)
+                .replace("+", "%20");
+        return ResponseEntity.ok()
+                .contentType(mediaType)
+                .header("X-Content-Type-Options", "nosniff")
+                .header(HttpHeaders.CONTENT_DISPOSITION,
+                        (inlineImage ? "inline" : "attachment") + "; filename*=UTF-8''" + encodedName)
+                .body(new FileSystemResource(file));
+    }
+
+    /**
+     * Build the user message's content parts: a text part for the message plus a
+     * file/media part for each referenced attachment. Attachment metadata is
+     * resolved server-side from the staging registry (the client only sends opaque
+     * ids); an id that is unknown, expired, or belongs to another conversation is
+     * silently dropped.
+     */
+    private List<MessageContentPart> buildUserParts(String conversationId, String message,
+                                                    List<String> attachmentIds) {
+        List<MessageContentPart> parts = new ArrayList<>();
+        if (message != null && !message.isBlank()) {
+            MessageContentPart text = new MessageContentPart();
+            text.setType("text");
+            text.setText(message);
+            parts.add(text);
+        }
+        if (attachmentIds != null) {
+            for (String fileId : attachmentIds) {
+                fileService.consume(conversationId, fileId).ifPresent(sf -> {
+                    MessageContentPart p = new MessageContentPart();
+                    p.setType(WebChatFileService.partTypeFor(sf.contentType()));
+                    p.setFileName(sf.originalName());
+                    p.setContentType(sf.contentType());
+                    p.setStoredName(sf.storedName());
+                    p.setFileSize(sf.size());
+                    // Relative download ref (caller adds auth headers + visitorId/sessionId).
+                    p.setFileUrl("/api/v1/channels/webchat/files?storedName="
+                            + URLEncoder.encode(sf.storedName(), StandardCharsets.UTF_8));
+                    // Server path lets the agent's file tools read the upload; stripped from
+                    // the external message view (listMessageViewsExternal).
+                    fileService.resolve(conversationId, sf.storedName())
+                            .ifPresent(path -> p.setPath(path.toString()));
+                    parts.add(p);
+                });
+            }
+        }
+        return parts;
     }
 
     // ==================== 内部方法 ====================
@@ -566,6 +728,10 @@ public class WebChatController {
         /** Optional: open a distinct conversation thread for the same visitor.
          *  Composed into the server-derived conversationId; never used as a raw conversationId. */
         private String sessionId;
+        /** Optional: ids returned by POST /upload, referencing files this visitor uploaded
+         *  for this conversation. Metadata is resolved server-side; unknown / foreign / expired
+         *  ids are dropped. */
+        private List<String> attachmentIds;
     }
 
     /** Compact view of one of a visitor's conversation threads. */

--- a/mateclaw-server/src/main/java/vip/mate/channel/webchat/WebChatController.java
+++ b/mateclaw-server/src/main/java/vip/mate/channel/webchat/WebChatController.java
@@ -510,6 +510,80 @@ public class WebChatController {
     }
 
     /**
+     * 置顶 / 取消置顶某会话线程。Pinned 线程在访客的 /sessions 列表里排在最前
+     * (沿用 {@link ConversationService#listWebchatConversations} 的 pinned DESC 排序)。
+     */
+    @Operation(summary = "置顶 / 取消置顶会话线程")
+    @PutMapping("/sessions/pinned")
+    public R<Void> pinSession(
+            @RequestHeader("X-MC-Key") String apiKey,
+            @RequestHeader(value = "X-MC-Visitor-Token", required = false) String visitorToken,
+            @RequestParam String visitorId,
+            @RequestParam(required = false) String sessionId,
+            @RequestBody Map<String, Object> body) {
+        ChannelEntity channel = resolveChannel(apiKey);
+        if (channel == null) {
+            return R.fail(401, "Invalid API Key");
+        }
+        if (!verifyVisitorToken(visitorTokenSecret, channel.getId(), visitorId, visitorToken)) {
+            return R.fail(401, "Invalid or missing visitor token");
+        }
+        String sid;
+        try {
+            sid = normalizeSessionId(sessionId);
+        } catch (IllegalArgumentException ex) {
+            return R.fail(400, ex.getMessage());
+        }
+        String conversationId = deriveConversationId(apiKey, visitorId, sid);
+        if (!ownsConversation(conversationId, visitorId)) {
+            return R.fail(404, "Session not found");
+        }
+        Object v = body != null ? body.get("pinned") : null;
+        if (!(v instanceof Boolean)) {
+            return R.fail(400, "body must contain {pinned: true|false}");
+        }
+        conversationService.setPinned(conversationId, (Boolean) v);
+        return R.ok();
+    }
+
+    /**
+     * 归档 / 取消归档某会话线程。归档后线程仍在 DB(历史保留、按 sessionId 寻址、文件可下载),
+     * 但默认从 /sessions 列表隐藏;调用方需传 {@code includeArchived=true} 才能看到。
+     */
+    @Operation(summary = "归档 / 取消归档会话线程")
+    @PutMapping("/sessions/archive")
+    public R<Void> archiveSession(
+            @RequestHeader("X-MC-Key") String apiKey,
+            @RequestHeader(value = "X-MC-Visitor-Token", required = false) String visitorToken,
+            @RequestParam String visitorId,
+            @RequestParam(required = false) String sessionId,
+            @RequestBody Map<String, Object> body) {
+        ChannelEntity channel = resolveChannel(apiKey);
+        if (channel == null) {
+            return R.fail(401, "Invalid API Key");
+        }
+        if (!verifyVisitorToken(visitorTokenSecret, channel.getId(), visitorId, visitorToken)) {
+            return R.fail(401, "Invalid or missing visitor token");
+        }
+        String sid;
+        try {
+            sid = normalizeSessionId(sessionId);
+        } catch (IllegalArgumentException ex) {
+            return R.fail(400, ex.getMessage());
+        }
+        String conversationId = deriveConversationId(apiKey, visitorId, sid);
+        if (!ownsConversation(conversationId, visitorId)) {
+            return R.fail(404, "Session not found");
+        }
+        Object v = body != null ? body.get("archived") : null;
+        if (!(v instanceof Boolean)) {
+            return R.fail(400, "body must contain {archived: true|false}");
+        }
+        conversationService.setArchived(conversationId, (Boolean) v);
+        return R.ok();
+    }
+
+    /**
      * Load this visitor's session threads (own namespace only), mapped to the
      * compact view. Sorted as {@code listConversations} returns them (pinned
      * desc, last-active desc). Shared by the list and paginated endpoints.

--- a/mateclaw-server/src/main/java/vip/mate/channel/webchat/WebChatController.java
+++ b/mateclaw-server/src/main/java/vip/mate/channel/webchat/WebChatController.java
@@ -203,7 +203,7 @@ public class WebChatController {
                                 .withSender(null, "api", null);
                 String webchatOwnerKey = memoryOwnerResolver.resolve(webchatOrigin);
 
-                agentService.chatStructuredStream(resolvedAgentId, message, conversationId, visitorId, null, webchatOrigin)
+                reactor.core.Disposable disposable = agentService.chatStructuredStream(resolvedAgentId, message, conversationId, visitorId, null, webchatOrigin)
                         .doOnNext(delta -> {
                             if (delta.isEvent() && "_usage_final".equals(delta.eventType())) {
                                 Map<String, Object> data = delta.eventData();
@@ -251,6 +251,12 @@ public class WebChatController {
                             streamTracker.complete(conversationId);
                         })
                         .subscribe();
+                // Bind the subscription's Disposable so requestStop() (invoked by
+                // POST /sessions/stop) can actually dispose the Flux and interrupt
+                // the LLM stream. Without this, stopRequested is set but the underlying
+                // HTTP call keeps running — token burn + side-effect tools still fire.
+                // Mirrors ChatController#chatStream line 495.
+                streamTracker.setDisposable(conversationId, disposable);
 
             } catch (Exception e) {
                 log.error("[WebChat] Error: {}", e.getMessage(), e);
@@ -635,6 +641,51 @@ public class WebChatController {
         }
         conversationService.deleteConversation(conversationId);
         return R.ok();
+    }
+
+    /**
+     * 停止访客某线程正在进行中的 SSE 流。
+     * <p>
+     * 鉴权同其他会话管理端点(API Key + visitorToken + 会话归属)。内部调
+     * {@link ChatStreamTracker#requestStop(String)}——靠 chatStream 注册时绑定的
+     * Disposable 实际中断 Flux;返回 {@code stopped=false} 表示当前没有活跃流
+     * (幂等,不报错)。
+     * <p>
+     * 不做 approval sweep:webchat 渠道目前不暴露 approval UI,且无 MateClaw
+     * username 可传给 {@code denyAllByConversation}。若未来 webchat 接入审批流,
+     * 再单独评估是否补这层。
+     */
+    @Operation(summary = "停止访客会话线程的进行中流")
+    @PostMapping("/sessions/stop")
+    public R<Map<String, Object>> stopSession(
+            @RequestHeader("X-MC-Key") String apiKey,
+            @RequestHeader(value = "X-MC-Visitor-Token", required = false) String visitorToken,
+            @RequestParam String visitorId,
+            @RequestParam(required = false) String sessionId) {
+        ChannelEntity channel = resolveChannel(apiKey);
+        if (channel == null) {
+            return R.fail(401, "Invalid API Key");
+        }
+        if (!verifyVisitorToken(visitorTokenSecret, channel.getId(), visitorId, visitorToken)) {
+            return R.fail(401, "Invalid or missing visitor token");
+        }
+        String sid;
+        try {
+            sid = normalizeSessionId(sessionId);
+        } catch (IllegalArgumentException ex) {
+            return R.fail(400, ex.getMessage());
+        }
+        String conversationId = deriveConversationId(apiKey, visitorId, sid);
+        // ownsConversation is the existence + ownership guard: an unknown sessionId
+        // maps to a conversationId that either doesn't exist or belongs to someone
+        // else — both return 404 so the caller can't probe the namespace.
+        if (!ownsConversation(conversationId, visitorId)) {
+            return R.fail(404, "Session not found");
+        }
+        boolean stopped = streamTracker.requestStop(conversationId);
+        log.info("[WebChat] Stop requested: conversationId={}, visitor={}, stopped={}",
+                conversationId, visitorId, stopped);
+        return R.ok(Map.of("stopped", stopped));
     }
 
     /**

--- a/mateclaw-server/src/main/java/vip/mate/channel/webchat/WebChatController.java
+++ b/mateclaw-server/src/main/java/vip/mate/channel/webchat/WebChatController.java
@@ -73,6 +73,10 @@ public class WebChatController {
     private final ConversationCompletionPublisher completionPublisher;
     private final vip.mate.memory.identity.MemoryOwnerResolver memoryOwnerResolver;
     private final WebChatFileService fileService;
+    private final WebChatTokenRevocationService tokenRevocationService;
+
+    /** Visitor-token TTL in seconds (7 days). Mirrors GeneratedFileCache's TTL. */
+    static final long VISITOR_TOKEN_TTL_SECONDS = 7 * 24 * 3600L;
 
     /**
      * Server-only secret used to sign per-visitor tokens. Reuses the JWT secret so no extra
@@ -951,28 +955,71 @@ public class WebChatController {
     /**
      * 用服务端密钥对 (channelId, visitorId) 做 HMAC-SHA256，签发不可伪造的 visitor token。
      * 载荷含 channelId，使 token 不能跨渠道复用。
+     * <p>Token 默认 7 天后过期（{@link #VISITOR_TOKEN_TTL_SECONDS}）；过期时间作为后缀
+     * 明文附加在 HMAC 之后（{@code <base64sig>.<expEpochSec>}），既参与签名也方便解析。
+     * 过期后访客可通过 {@code /stream} 重新签发（{@code /stream} 不校验 token，只签发）。
      */
     static String computeVisitorToken(String secret, Long channelId, String visitorId) {
+        return computeVisitorToken(secret, channelId, visitorId,
+                java.time.Instant.now().getEpochSecond() + VISITOR_TOKEN_TTL_SECONDS);
+    }
+
+    /** Test/override hook: explicit expiration epoch second. */
+    static String computeVisitorToken(String secret, Long channelId, String visitorId, long expiresAtEpochSecond) {
         try {
             Mac mac = Mac.getInstance("HmacSHA256");
             mac.init(new SecretKeySpec(secret.getBytes(StandardCharsets.UTF_8), "HmacSHA256"));
-            byte[] sig = mac.doFinal((channelId + ":" + visitorId).getBytes(StandardCharsets.UTF_8));
-            return Base64.getUrlEncoder().withoutPadding().encodeToString(sig);
+            String payload = channelId + ":" + visitorId + ":" + expiresAtEpochSecond;
+            byte[] sig = mac.doFinal(payload.getBytes(StandardCharsets.UTF_8));
+            return Base64.getUrlEncoder().withoutPadding().encodeToString(sig) + "." + expiresAtEpochSecond;
         } catch (GeneralSecurityException e) {
             throw new IllegalStateException("HMAC-SHA256 unavailable", e);
         }
     }
 
     /**
-     * 常量时间校验调用方回传的 token：缺失/不匹配均返回 false。
+     * 校验调用方回传的 token 的<b>签名 + 过期</b>。不查撤销表(撤销是实例层职责,
+     * 见 {@link #verifyVisitorToken})。Static 是为了让单测可以直接验证 HMAC 语义,
+     * 不需要起 Spring context。
      */
-    static boolean verifyVisitorToken(String secret, Long channelId, String visitorId, String presented) {
+    static boolean verifyVisitorTokenSignature(String secret, Long channelId, String visitorId, String presented) {
         if (presented == null || presented.isEmpty() || visitorId == null || channelId == null) {
             return false;
         }
-        byte[] expected = computeVisitorToken(secret, channelId, visitorId).getBytes(StandardCharsets.UTF_8);
+        int dot = presented.lastIndexOf('.');
+        if (dot <= 0 || dot == presented.length() - 1) {
+            return false;
+        }
+        long exp;
+        try {
+            exp = Long.parseLong(presented.substring(dot + 1));
+        } catch (NumberFormatException e) {
+            return false;
+        }
+        if (java.time.Instant.now().getEpochSecond() >= exp) {
+            return false;
+        }
+        // Constant-time comparison of the full token (sig + ".exp"). HMAC covers
+        // both channelId:visitorId and exp, so any tampering with exp invalidates sig.
+        byte[] expected = computeVisitorToken(secret, channelId, visitorId, exp).getBytes(StandardCharsets.UTF_8);
         byte[] actual = presented.getBytes(StandardCharsets.UTF_8);
         return MessageDigest.isEqual(expected, actual);
+    }
+
+    /**
+     * 完整校验:签名 + 过期 + 撤销。任一不通过返回 false。实例方法,接入
+     * {@link WebChatTokenRevocationService}。{@code /stream} 第一次接触不调用本方法
+     * (只签发 token,不校验),所以被撤销的 visitor 仍能发起新会话——撤销只让旧的
+     * 管理 token 失效,符合 issue #351 的设计。
+     */
+    boolean verifyVisitorToken(String secret, Long channelId, String visitorId, String presented) {
+        if (!verifyVisitorTokenSignature(secret, channelId, visitorId, presented)) {
+            return false;
+        }
+        if (tokenRevocationService != null && tokenRevocationService.isRevoked(channelId, visitorId)) {
+            return false;
+        }
+        return true;
     }
 
     /**

--- a/mateclaw-server/src/main/java/vip/mate/channel/webchat/WebChatController.java
+++ b/mateclaw-server/src/main/java/vip/mate/channel/webchat/WebChatController.java
@@ -405,9 +405,12 @@ public class WebChatController {
         String base = deriveConversationId(apiKey, visitorId, null);
         String channelPrefix = "webchat:" + apiKey.substring(0, Math.min(8, apiKey.length())) + ":";
         String owner = webchatUsername(visitorId);
-        return conversationService.listConversations(owner).stream()
+        // Query is scoped to this visitor's own rows only (no system rows), so
+        // listing a visitor's threads doesn't load every IM/cron conversation.
+        // The channel prefix is matched in-memory with a literal startsWith so a
+        // '_' / '%' in the api key's first 8 chars can't act as a LIKE wildcard.
+        return conversationService.listWebchatConversations(owner).stream()
                 .filter(c -> c.getConversationId() != null
-                        && owner.equals(c.getUsername())
                         && c.getConversationId().startsWith(channelPrefix))
                 .map(c -> {
                     String sid = recoverSessionId(c, base);
@@ -422,7 +425,7 @@ public class WebChatController {
      * Returns null for the default (no-session) thread and for legacy hashed rows
      * whose sessionId can no longer be reconstructed.
      */
-    private String recoverSessionId(vip.mate.workspace.conversation.vo.ConversationVO c, String base) {
+    private String recoverSessionId(vip.mate.workspace.conversation.model.ConversationEntity c, String base) {
         if (c.getWebchatSessionId() != null) {
             return c.getWebchatSessionId();
         }

--- a/mateclaw-server/src/main/java/vip/mate/channel/webchat/WebChatController.java
+++ b/mateclaw-server/src/main/java/vip/mate/channel/webchat/WebChatController.java
@@ -413,7 +413,8 @@ public class WebChatController {
     public R<List<WebChatSessionView>> listSessions(
             @RequestHeader("X-MC-Key") String apiKey,
             @RequestHeader(value = "X-MC-Visitor-Token", required = false) String visitorToken,
-            @RequestParam String visitorId) {
+            @RequestParam String visitorId,
+            @RequestParam(defaultValue = "false") boolean includeArchived) {
         ChannelEntity channel = resolveChannel(apiKey);
         if (channel == null) {
             return R.fail(401, "Invalid API Key");
@@ -421,7 +422,7 @@ public class WebChatController {
         if (!verifyVisitorToken(visitorTokenSecret, channel.getId(), visitorId, visitorToken)) {
             return R.fail(401, "Invalid or missing visitor token");
         }
-        return R.ok(loadVisitorSessions(apiKey, visitorId));
+        return R.ok(loadVisitorSessions(apiKey, visitorId, includeArchived));
     }
 
     /**
@@ -437,7 +438,8 @@ public class WebChatController {
             @RequestParam String visitorId,
             @RequestParam(defaultValue = "1") int page,
             @RequestParam(defaultValue = "20") int size,
-            @RequestParam(required = false) String keyword) {
+            @RequestParam(required = false) String keyword,
+            @RequestParam(defaultValue = "false") boolean includeArchived) {
         ChannelEntity channel = resolveChannel(apiKey);
         if (channel == null) {
             return R.fail(401, "Invalid API Key");
@@ -448,7 +450,7 @@ public class WebChatController {
         if (page < 1) page = 1;
         if (size < 1 || size > 200) size = 20;
 
-        List<WebChatSessionView> all = loadVisitorSessions(apiKey, visitorId);
+        List<WebChatSessionView> all = loadVisitorSessions(apiKey, visitorId, includeArchived);
         if (keyword != null && !keyword.isBlank()) {
             String kw = keyword.trim().toLowerCase(java.util.Locale.ROOT);
             all = all.stream()
@@ -516,6 +518,19 @@ public class WebChatController {
      * for legacy rows created before that column existed.
      */
     private List<WebChatSessionView> loadVisitorSessions(String apiKey, String visitorId) {
+        return loadVisitorSessions(apiKey, visitorId, false);
+    }
+
+    /**
+     * Overload that lets the caller opt into archived threads. By default
+     * (used by /sessions listing and the empty-session quota check) archived
+     * rows are filtered out — they still exist on disk and are addressable
+     * by sessionId, but don't pollute the active listing and don't count
+     * against the "≤ 5 empty threads" quota (the visitor already declared
+     * they're done with them).
+     */
+    private List<WebChatSessionView> loadVisitorSessions(String apiKey, String visitorId,
+                                                         boolean includeArchived) {
         String base = deriveConversationId(apiKey, visitorId, null);
         String channelPrefix = "webchat:" + apiKey.substring(0, Math.min(8, apiKey.length())) + ":";
         String owner = webchatUsername(visitorId);
@@ -526,9 +541,16 @@ public class WebChatController {
         return conversationService.listWebchatConversations(owner).stream()
                 .filter(c -> c.getConversationId() != null
                         && c.getConversationId().startsWith(channelPrefix))
+                .filter(c -> includeArchived
+                        || c.getArchived() == null
+                        || c.getArchived() == 0)
                 .map(c -> {
                     String sid = recoverSessionId(c, base);
-                    return new WebChatSessionView(sid, c.getTitle(), c.getLastActiveTime(), c.getMessageCount());
+                    return new WebChatSessionView(sid, c.getTitle(), c.getLastActiveTime(),
+                            c.getMessageCount(),
+                            c.getPinned() != null ? c.getPinned() : 0,
+                            c.getArchived() != null ? c.getArchived() : 0,
+                            c.getStreamStatus() != null ? c.getStreamStatus() : "idle");
                 })
                 .collect(Collectors.toList());
     }
@@ -1047,6 +1069,12 @@ public class WebChatController {
         private String title;
         private LocalDateTime lastActiveTime;
         private Integer messageCount;
+        /** 1 if the visitor pinned this thread, 0 otherwise. */
+        private Integer pinned;
+        /** 1 if the visitor archived this thread, 0 otherwise. */
+        private Integer archived;
+        /** {@code running} if a stream is in progress on this thread, else {@code idle}. */
+        private String streamStatus;
     }
 
     /** Body for {@code POST /sessions} — explicitly create an empty thread. */

--- a/mateclaw-server/src/main/java/vip/mate/channel/webchat/WebChatController.java
+++ b/mateclaw-server/src/main/java/vip/mate/channel/webchat/WebChatController.java
@@ -288,6 +288,114 @@ public class WebChatController {
         ));
     }
 
+    /** Cap on how many empty (message_count = 0) threads one visitor may hold on a
+     *  channel at once. Guards against pathologic clients churning placeholder
+     *  sessions without ever sending a message. */
+    private static final int MAX_EMPTY_SESSIONS_PER_VISITOR = 5;
+
+    /**
+     * 显式创建一条访客会话线程（空会话）。
+     * <p>
+     * 与 {@code POST /stream} 的隐式 getOrCreate 互补：本端点先建一条 message_count=0
+     * 的占位线程，调用方拿到 {@code sessionId/conversationId/visitorToken} 之后，再决定
+     * 何时通过 {@code /stream} 发首条消息。鉴权为访客的<b>首次接触</b>：仅校验
+     * {@code X-MC-Key}，不要求 {@code X-MC-Visitor-Token}，后端会签发并回传 token，
+     * 调用方在后续 GET/PUT/DELETE 上必须回带。
+     * <p>
+     * 行为：
+     * <ul>
+     *   <li>幂等：{@code sessionId} 与该 visitor 已有线程冲突 → 直接返回现有线程，
+     *       不报错、不覆盖 title。</li>
+     *   <li>配额：单 (渠道, visitor) 未活跃空线程 ≤ {@value MAX_EMPTY_SESSIONS_PER_VISITOR}，
+     *       超出返回 409。已存在的线程走幂等路径不受配额限制。</li>
+     *   <li>title 非空时写入；为空时落默认 "新对话"，首条 user 消息仍会按现有规则截取。</li>
+     * </ul>
+     */
+    @Operation(summary = "显式创建访客会话线程（空会话）")
+    @PostMapping("/sessions")
+    public R<Map<String, Object>> createSession(
+            @RequestHeader("X-MC-Key") String apiKey,
+            @RequestBody(required = false) WebChatCreateSessionRequest request) {
+
+        ChannelEntity channel = resolveChannel(apiKey);
+        if (channel == null) {
+            return R.fail(401, "Invalid API Key");
+        }
+
+        // Resolve agent: explicit request.agentId overrides channel's bound agent,
+        // but must belong to channel's workspace (mirrors /stream).
+        final Long agentId;
+        if (request != null && request.getAgentId() != null) {
+            var requested = agentService.getAgent(request.getAgentId());
+            if (requested == null) {
+                return R.fail(400, "Requested agent not found");
+            }
+            if (channel.getWorkspaceId() != null && requested.getWorkspaceId() != null
+                    && !channel.getWorkspaceId().equals(requested.getWorkspaceId())) {
+                return R.fail(400, "Requested agent does not belong to this channel's workspace");
+            }
+            agentId = request.getAgentId();
+        } else {
+            agentId = channel.getAgentId();
+            if (agentId == null) {
+                return R.fail(400, "No agent configured for this WebChat channel");
+            }
+        }
+
+        final String visitorId;
+        final String sessionId;
+        try {
+            visitorId = normalizeVisitorId(request != null ? request.getVisitorId() : null);
+            sessionId = normalizeSessionId(request != null ? request.getSessionId() : null);
+        } catch (IllegalArgumentException ex) {
+            return R.fail(400, ex.getMessage());
+        }
+
+        String title = (request != null && request.getTitle() != null) ? request.getTitle().trim() : null;
+        if (title != null && (title.isEmpty() || title.length() > 100)) {
+            return R.fail(400, "title 不合法（1-100 字）");
+        }
+
+        String conversationId = deriveConversationId(apiKey, visitorId, sessionId);
+        String owner = webchatUsername(visitorId);
+
+        // Idempotency: existing thread is returned as-is. Title and every other
+        // field are left untouched — a re-create call must not clobber a previously
+        // set title. Existing rows are exempt from the empty-session quota.
+        ConversationEntity existing = conversationService.findByConversationId(conversationId);
+        if (existing != null && owner.equals(existing.getUsername())) {
+            return R.ok(buildCreateSessionResponse(existing, sessionId, channel.getId(), visitorId));
+        }
+
+        // Quota: count empty threads this visitor already holds on this channel.
+        // loadVisitorSessions already scopes to (channel prefix ∩ visitor owner).
+        long emptyCount = loadVisitorSessions(apiKey, visitorId).stream()
+                .filter(s -> s.getMessageCount() == null || s.getMessageCount() == 0)
+                .count();
+        if (emptyCount >= MAX_EMPTY_SESSIONS_PER_VISITOR) {
+            return R.fail(409, "未活跃会话数已达上限（" + MAX_EMPTY_SESSIONS_PER_VISITOR
+                    + "），请先发送消息或删除旧会话");
+        }
+
+        ConversationEntity conv = conversationService.getOrCreateWebchatConversation(
+                conversationId, agentId, owner, channel.getWorkspaceId(), sessionId, title);
+        return R.ok(buildCreateSessionResponse(conv, sessionId, channel.getId(), visitorId));
+    }
+
+    private Map<String, Object> buildCreateSessionResponse(ConversationEntity conv, String sessionId,
+                                                           Long channelId, String visitorId) {
+        String visitorToken = computeVisitorToken(visitorTokenSecret, channelId, visitorId);
+        // LinkedHashMap (not Map.of) because Map.of rejects null and we want a
+        // stable key order for the response payload.
+        Map<String, Object> m = new java.util.LinkedHashMap<>();
+        m.put("sessionId", sessionId != null ? sessionId : "");
+        m.put("conversationId", conv.getConversationId());
+        m.put("visitorToken", visitorToken);
+        m.put("title", conv.getTitle() != null ? conv.getTitle() : "");
+        m.put("createTime", conv.getCreateTime());
+        return m;
+    }
+
     /**
      * 列出某访客的会话线程
      * <p>
@@ -888,5 +996,21 @@ public class WebChatController {
         private String title;
         private LocalDateTime lastActiveTime;
         private Integer messageCount;
+    }
+
+    /** Body for {@code POST /sessions} — explicitly create an empty thread. */
+    @lombok.Data
+    public static class WebChatCreateSessionRequest {
+        /** Optional; server mints a UUID when absent (same convention as /stream). */
+        private String visitorId;
+        /** Optional; server generates one when absent. Whitelisted charset, ≤ 64 chars. */
+        private String sessionId;
+        /** Optional; 1–100 chars when non-blank, otherwise left null so the first
+         *  /stream message still derives the title (mirrors PUT /sessions/title rules). */
+        private String title;
+        /** Optional; override the channel's bound agent. Must belong to the channel's
+         *  workspace. Only applied on first creation — once the thread exists, a
+         *  different agentId is ignored. */
+        private Long agentId;
     }
 }

--- a/mateclaw-server/src/main/java/vip/mate/channel/webchat/WebChatController.java
+++ b/mateclaw-server/src/main/java/vip/mate/channel/webchat/WebChatController.java
@@ -36,7 +36,7 @@ import vip.mate.memory.event.ConversationCompletionPublisher;
 import vip.mate.workspace.conversation.ConversationService;
 import vip.mate.workspace.conversation.model.ConversationEntity;
 import vip.mate.workspace.conversation.model.MessageContentPart;
-import vip.mate.workspace.conversation.vo.MessageVO;
+import vip.mate.workspace.conversation.model.MessageEntity;
 
 import java.io.IOException;
 import java.time.LocalDateTime;
@@ -306,32 +306,63 @@ public class WebChatController {
         if (!verifyVisitorToken(visitorTokenSecret, channel.getId(), visitorId, visitorToken)) {
             return R.fail(401, "Invalid or missing visitor token");
         }
-        String base = deriveConversationId(apiKey, visitorId, null);
-        String prefix = base + ":";
-        String owner = webchatUsername(visitorId);
-        List<WebChatSessionView> sessions = conversationService.listConversations(owner).stream()
-                .filter(c -> c.getConversationId() != null
-                        && owner.equals(c.getUsername())
-                        && (c.getConversationId().equals(base) || c.getConversationId().startsWith(prefix)))
-                .map(c -> {
-                    String cid = c.getConversationId();
-                    String sid = cid.equals(base) ? null : cid.substring(prefix.length());
-                    return new WebChatSessionView(sid, c.getTitle(), c.getLastActiveTime(), c.getMessageCount());
-                })
-                .collect(Collectors.toList());
-        return R.ok(sessions);
+        return R.ok(loadVisitorSessions(apiKey, visitorId));
     }
 
     /**
-     * 获取某会话线程的消息列表
+     * 分页 + 关键词搜索某访客的会话线程。
+     * <p>访客的会话集是按 visitor 命名空间限定的（数量有界），故在内存里做关键词过滤与分页。
+     * keyword 不区分大小写、匹配标题子串。
      */
-    @Operation(summary = "获取会话消息")
-    @GetMapping("/sessions/messages")
-    public R<List<MessageVO>> sessionMessages(
+    @Operation(summary = "分页查询访客会话线程")
+    @GetMapping("/sessions/page")
+    public R<Map<String, Object>> pageSessions(
             @RequestHeader("X-MC-Key") String apiKey,
             @RequestHeader(value = "X-MC-Visitor-Token", required = false) String visitorToken,
             @RequestParam String visitorId,
-            @RequestParam(required = false) String sessionId) {
+            @RequestParam(defaultValue = "1") int page,
+            @RequestParam(defaultValue = "20") int size,
+            @RequestParam(required = false) String keyword) {
+        ChannelEntity channel = resolveChannel(apiKey);
+        if (channel == null) {
+            return R.fail(401, "Invalid API Key");
+        }
+        if (!verifyVisitorToken(visitorTokenSecret, channel.getId(), visitorId, visitorToken)) {
+            return R.fail(401, "Invalid or missing visitor token");
+        }
+        if (page < 1) page = 1;
+        if (size < 1 || size > 200) size = 20;
+
+        List<WebChatSessionView> all = loadVisitorSessions(apiKey, visitorId);
+        if (keyword != null && !keyword.isBlank()) {
+            String kw = keyword.trim().toLowerCase(java.util.Locale.ROOT);
+            all = all.stream()
+                    .filter(s -> s.getTitle() != null && s.getTitle().toLowerCase(java.util.Locale.ROOT).contains(kw))
+                    .collect(Collectors.toList());
+        }
+        long total = all.size();
+        int from = Math.min((page - 1) * size, all.size());
+        int to = Math.min(from + size, all.size());
+        List<WebChatSessionView> pageItems = all.subList(from, to);
+        return R.ok(Map.of(
+                "items", pageItems,
+                "total", total,
+                "page", page,
+                "size", size
+        ));
+    }
+
+    /**
+     * 重命名某会话线程。标题非空、长度 ≤ 100。
+     */
+    @Operation(summary = "重命名会话线程")
+    @PutMapping("/sessions/title")
+    public R<Void> renameSession(
+            @RequestHeader("X-MC-Key") String apiKey,
+            @RequestHeader(value = "X-MC-Visitor-Token", required = false) String visitorToken,
+            @RequestParam String visitorId,
+            @RequestParam(required = false) String sessionId,
+            @RequestBody Map<String, String> body) {
         ChannelEntity channel = resolveChannel(apiKey);
         if (channel == null) {
             return R.fail(401, "Invalid API Key");
@@ -349,8 +380,91 @@ public class WebChatController {
         if (!ownsConversation(conversationId, visitorId)) {
             return R.fail(404, "Session not found");
         }
-        // External view: strip server-side file paths before handing messages to the visitor.
-        return R.ok(conversationService.listMessageViewsExternal(conversationId));
+        String title = body != null && body.get("title") != null ? body.get("title").trim() : "";
+        if (title.isEmpty() || title.length() > 100) {
+            return R.fail(400, "标题不合法（1-100 字）");
+        }
+        conversationService.renameConversation(conversationId, title);
+        return R.ok();
+    }
+
+    /**
+     * Load this visitor's session threads (own namespace only), mapped to the
+     * compact view. Sorted as {@code listConversations} returns them (pinned
+     * desc, last-active desc). Shared by the list and paginated endpoints.
+     */
+    private List<WebChatSessionView> loadVisitorSessions(String apiKey, String visitorId) {
+        String base = deriveConversationId(apiKey, visitorId, null);
+        String prefix = base + ":";
+        String owner = webchatUsername(visitorId);
+        return conversationService.listConversations(owner).stream()
+                .filter(c -> c.getConversationId() != null
+                        && owner.equals(c.getUsername())
+                        && (c.getConversationId().equals(base) || c.getConversationId().startsWith(prefix)))
+                .map(c -> {
+                    String cid = c.getConversationId();
+                    String sid = cid.equals(base) ? null : cid.substring(prefix.length());
+                    return new WebChatSessionView(sid, c.getTitle(), c.getLastActiveTime(), c.getMessageCount());
+                })
+                .collect(Collectors.toList());
+    }
+
+    /**
+     * 获取某会话线程的消息列表（支持分页）。
+     * <p>不传 limit 时返回全部消息（向后兼容）；传 limit 返回最新 limit 条 + hasMore；
+     * 传 beforeId + limit 时返回该 ID 之前的 limit 条（上拉加载更早消息）。
+     */
+    @Operation(summary = "获取会话消息（支持分页）")
+    @GetMapping("/sessions/messages")
+    public R<?> sessionMessages(
+            @RequestHeader("X-MC-Key") String apiKey,
+            @RequestHeader(value = "X-MC-Visitor-Token", required = false) String visitorToken,
+            @RequestParam String visitorId,
+            @RequestParam(required = false) String sessionId,
+            @RequestParam(required = false) Long beforeId,
+            @RequestParam(required = false) Integer limit) {
+        ChannelEntity channel = resolveChannel(apiKey);
+        if (channel == null) {
+            return R.fail(401, "Invalid API Key");
+        }
+        if (!verifyVisitorToken(visitorTokenSecret, channel.getId(), visitorId, visitorToken)) {
+            return R.fail(401, "Invalid or missing visitor token");
+        }
+        String sid;
+        try {
+            sid = normalizeSessionId(sessionId);
+        } catch (IllegalArgumentException ex) {
+            return R.fail(400, ex.getMessage());
+        }
+        String conversationId = deriveConversationId(apiKey, visitorId, sid);
+        if (!ownsConversation(conversationId, visitorId)) {
+            return R.fail(404, "Session not found");
+        }
+
+        // Backward-compatible: no limit → full external (path-stripped) list.
+        if (limit == null || limit <= 0) {
+            return R.ok(conversationService.listMessageViewsExternal(conversationId));
+        }
+
+        // Paginated: mirror ConversationController#listMessages but with the
+        // external view so visitors never see server-side file paths.
+        List<MessageEntity> messages;
+        boolean hasMore;
+        if (beforeId != null) {
+            messages = conversationService.listMessagesBefore(conversationId, beforeId, limit + 1);
+            hasMore = messages.size() > limit;
+            if (hasMore) {
+                messages = messages.subList(messages.size() - limit, messages.size());
+            }
+        } else {
+            long total = conversationService.countMessages(conversationId);
+            messages = conversationService.listRecentMessages(conversationId, limit);
+            hasMore = total > limit;
+        }
+        return R.ok(Map.of(
+                "messages", conversationService.toExternalMessageViews(messages),
+                "hasMore", hasMore
+        ));
     }
 
     /**

--- a/mateclaw-server/src/main/java/vip/mate/channel/webchat/WebChatController.java
+++ b/mateclaw-server/src/main/java/vip/mate/channel/webchat/WebChatController.java
@@ -166,7 +166,8 @@ public class WebChatController {
                 // 创建或获取会话（workspace 从 agent 获取）
                 var webAgent = agentService.getAgent(resolvedAgentId);
                 Long webWsId = webAgent != null ? webAgent.getWorkspaceId() : 1L;
-                var conv = conversationService.getOrCreateConversation(conversationId, resolvedAgentId, webchatUsername(visitorId), webWsId);
+                var conv = conversationService.getOrCreateWebchatConversation(
+                        conversationId, resolvedAgentId, webchatUsername(visitorId), webWsId, effectiveSessionId);
 
                 // 保存用户消息（含访客本轮引用的附件）。附件元数据一律服务端按 fileId 回查，
                 // 不信客户端传入；path 用于 Agent 侧工具读取，对外消息视图会被剥离。
@@ -392,21 +393,48 @@ public class WebChatController {
      * Load this visitor's session threads (own namespace only), mapped to the
      * compact view. Sorted as {@code listConversations} returns them (pinned
      * desc, last-active desc). Shared by the list and paginated endpoints.
+     * <p>
+     * Enumeration is keyed by the visitor's username plus the channel prefix
+     * ({@code webchat:<key8>:}) rather than the full conversationId prefix, so it
+     * still catches threads whose conversationId hashed (long visitorId +
+     * sessionId). The sessionId is read from the persisted {@code webchatSessionId}
+     * column (set on creation) and only falls back to parsing the conversationId
+     * for legacy rows created before that column existed.
      */
     private List<WebChatSessionView> loadVisitorSessions(String apiKey, String visitorId) {
         String base = deriveConversationId(apiKey, visitorId, null);
-        String prefix = base + ":";
+        String channelPrefix = "webchat:" + apiKey.substring(0, Math.min(8, apiKey.length())) + ":";
         String owner = webchatUsername(visitorId);
         return conversationService.listConversations(owner).stream()
                 .filter(c -> c.getConversationId() != null
                         && owner.equals(c.getUsername())
-                        && (c.getConversationId().equals(base) || c.getConversationId().startsWith(prefix)))
+                        && c.getConversationId().startsWith(channelPrefix))
                 .map(c -> {
-                    String cid = c.getConversationId();
-                    String sid = cid.equals(base) ? null : cid.substring(prefix.length());
+                    String sid = recoverSessionId(c, base);
                     return new WebChatSessionView(sid, c.getTitle(), c.getLastActiveTime(), c.getMessageCount());
                 })
                 .collect(Collectors.toList());
+    }
+
+    /**
+     * Recover a thread's sessionId. Prefers the persisted column; for legacy
+     * rows (column null) falls back to parsing the non-hashed conversationId.
+     * Returns null for the default (no-session) thread and for legacy hashed rows
+     * whose sessionId can no longer be reconstructed.
+     */
+    private String recoverSessionId(vip.mate.workspace.conversation.vo.ConversationVO c, String base) {
+        if (c.getWebchatSessionId() != null) {
+            return c.getWebchatSessionId();
+        }
+        String cid = c.getConversationId();
+        if (cid.equals(base)) {
+            return null;
+        }
+        String prefix = base + ":";
+        if (cid.startsWith(prefix)) {
+            return cid.substring(prefix.length());
+        }
+        return null;
     }
 
     /**

--- a/mateclaw-server/src/main/java/vip/mate/channel/webchat/WebChatFileService.java
+++ b/mateclaw-server/src/main/java/vip/mate/channel/webchat/WebChatFileService.java
@@ -17,6 +17,7 @@ import java.util.Set;
 import java.util.UUID;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 /**
  * Storage + validation for files exchanged over the WebChat channel.
@@ -47,6 +48,8 @@ public class WebChatFileService {
     private final boolean enabled;
     private final long maxSizeBytes;
     private final Set<String> allowedExtensions;
+    private final int maxFilesPerConversation;
+    private final long maxTotalBytesPerConversation;
 
     /** fileId (== storedName) -> staged metadata, pending a /stream reference. */
     private final ConcurrentHashMap<String, StagedFile> staged = new ConcurrentHashMap<>();
@@ -56,13 +59,17 @@ public class WebChatFileService {
             @Value("${mateclaw.webchat.upload.max-size-mb:20}") long maxSizeMb,
             @Value("${mateclaw.webchat.upload.allowed-extensions:"
                     + "png,jpg,jpeg,gif,webp,bmp,pdf,txt,md,csv,json,log,"
-                    + "doc,docx,xls,xlsx,ppt,pptx,zip,mp3,wav,m4a,mp4,mov,webm}") String allowedExtensionsCsv) {
+                    + "doc,docx,xls,xlsx,ppt,pptx,zip,mp3,wav,m4a,mp4,mov,webm}") String allowedExtensionsCsv,
+            @Value("${mateclaw.webchat.upload.max-files-per-conversation:50}") int maxFilesPerConversation,
+            @Value("${mateclaw.webchat.upload.max-total-mb-per-conversation:200}") long maxTotalMbPerConversation) {
         this.enabled = enabled;
         this.maxSizeBytes = maxSizeMb * 1024 * 1024;
         this.allowedExtensions = Arrays.stream(allowedExtensionsCsv.split(","))
                 .map(s -> s.trim().toLowerCase(Locale.ROOT))
                 .filter(s -> !s.isEmpty())
                 .collect(Collectors.toUnmodifiableSet());
+        this.maxFilesPerConversation = maxFilesPerConversation;
+        this.maxTotalBytesPerConversation = maxTotalMbPerConversation * 1024 * 1024;
     }
 
     /** Metadata for a staged upload. */
@@ -118,6 +125,7 @@ public class WebChatFileService {
             throw new UploadRejectedException("Invalid conversation");
         }
         Files.createDirectories(dir);
+        enforceConversationQuota(dir, file.getSize());
         Path target = dir.resolve(storedName);
         file.transferTo(target.toAbsolutePath());
 
@@ -198,6 +206,34 @@ public class WebChatFileService {
             });
             return true;
         });
+    }
+
+    /**
+     * Bound a conversation's disk footprint: reject when the dir already holds
+     * the max file count, or when adding {@code incomingSize} would push the
+     * total over the cap. Cheap dir scan (these dirs hold at most a few dozen
+     * files); pairs with the staging TTL sweep that reclaims unreferenced files.
+     */
+    private void enforceConversationQuota(Path dir, long incomingSize) throws IOException {
+        int count = 0;
+        long total = 0;
+        try (Stream<Path> files = Files.list(dir)) {
+            for (Path p : (Iterable<Path>) files::iterator) {
+                if (Files.isRegularFile(p)) {
+                    count++;
+                    total += Files.size(p);
+                }
+            }
+        }
+        if (count >= maxFilesPerConversation) {
+            throw new UploadRejectedException(
+                    "Too many files in this conversation (max " + maxFilesPerConversation + ")");
+        }
+        if (total + incomingSize > maxTotalBytesPerConversation) {
+            throw new UploadRejectedException(
+                    "Conversation upload quota exceeded (max "
+                            + (maxTotalBytesPerConversation / 1024 / 1024) + " MB)");
+        }
     }
 
     private static String extensionOf(String name) {

--- a/mateclaw-server/src/main/java/vip/mate/channel/webchat/WebChatFileService.java
+++ b/mateclaw-server/src/main/java/vip/mate/channel/webchat/WebChatFileService.java
@@ -1,0 +1,219 @@
+package vip.mate.channel.webchat;
+
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Service;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.Arrays;
+import java.util.Locale;
+import java.util.Optional;
+import java.util.Set;
+import java.util.UUID;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.stream.Collectors;
+
+/**
+ * Storage + validation for files exchanged over the WebChat channel.
+ *
+ * <p>WebChat is reached by untrusted external visitors (API key + visitor
+ * token, no JWT), so uploads are hardened here: size cap, extension allow-list,
+ * filename sanitization, and a server-issued stored name. Every path is derived
+ * from the server-computed {@code conversationId} — never from a client-supplied
+ * path — and download resolution is traversal-guarded.
+ *
+ * <p>Uploads are staged in an in-memory registry keyed by an opaque file id.
+ * Only when the visitor references that id on the next {@code /stream} call does
+ * the file become a real conversation attachment (the bytes already live under
+ * the conversation's upload dir, so cleanup rides the existing
+ * {@code cleanAttachmentFiles} cascade). Unreferenced staged files are swept
+ * after {@link #STAGING_TTL_MS}.
+ */
+@Slf4j
+@Service
+public class WebChatFileService {
+
+    /** Shared with the JWT chat upload dir so deleteConversation cleanup applies. */
+    private static final Path UPLOAD_ROOT = Paths.get("data", "chat-uploads");
+
+    /** How long an uploaded-but-unreferenced file lingers before the sweep removes it. */
+    private static final long STAGING_TTL_MS = 60 * 60 * 1000L; // 1 hour
+
+    private final boolean enabled;
+    private final long maxSizeBytes;
+    private final Set<String> allowedExtensions;
+
+    /** fileId (== storedName) -> staged metadata, pending a /stream reference. */
+    private final ConcurrentHashMap<String, StagedFile> staged = new ConcurrentHashMap<>();
+
+    public WebChatFileService(
+            @Value("${mateclaw.webchat.upload.enabled:true}") boolean enabled,
+            @Value("${mateclaw.webchat.upload.max-size-mb:20}") long maxSizeMb,
+            @Value("${mateclaw.webchat.upload.allowed-extensions:"
+                    + "png,jpg,jpeg,gif,webp,bmp,pdf,txt,md,csv,json,log,"
+                    + "doc,docx,xls,xlsx,ppt,pptx,zip,mp3,wav,m4a,mp4,mov,webm}") String allowedExtensionsCsv) {
+        this.enabled = enabled;
+        this.maxSizeBytes = maxSizeMb * 1024 * 1024;
+        this.allowedExtensions = Arrays.stream(allowedExtensionsCsv.split(","))
+                .map(s -> s.trim().toLowerCase(Locale.ROOT))
+                .filter(s -> !s.isEmpty())
+                .collect(Collectors.toUnmodifiableSet());
+    }
+
+    /** Metadata for a staged upload. */
+    public record StagedFile(String conversationId, String storedName, String originalName,
+                             String contentType, long size, long expireAt) {
+        boolean expired() {
+            return System.currentTimeMillis() > expireAt;
+        }
+    }
+
+    /** Thrown on any validation failure; the controller maps it to a 4xx. */
+    public static class UploadRejectedException extends RuntimeException {
+        public UploadRejectedException(String message) {
+            super(message);
+        }
+    }
+
+    public boolean isEnabled() {
+        return enabled;
+    }
+
+    /**
+     * Validate and store an uploaded file under the conversation's upload dir,
+     * returning a staged record whose {@code storedName} doubles as the opaque
+     * file id the visitor references on the next /stream call.
+     *
+     * @param conversationId server-derived conversation id (never client-supplied)
+     */
+    public StagedFile store(String conversationId, MultipartFile file) throws IOException {
+        if (!enabled) {
+            throw new UploadRejectedException("WebChat file upload is disabled");
+        }
+        if (file == null || file.isEmpty()) {
+            throw new UploadRejectedException("Empty file");
+        }
+        if (file.getSize() > maxSizeBytes) {
+            throw new UploadRejectedException("File too large (max " + (maxSizeBytes / 1024 / 1024) + " MB)");
+        }
+
+        String originalName = file.getOriginalFilename() != null ? file.getOriginalFilename() : "file";
+        // Strip any directory components, then collapse to a safe charset.
+        String baseName = Paths.get(originalName).getFileName().toString();
+        String ext = extensionOf(baseName);
+        if (ext.isEmpty() || !allowedExtensions.contains(ext)) {
+            throw new UploadRejectedException("File type not allowed: ." + ext);
+        }
+        String safeName = baseName.replaceAll("[^a-zA-Z0-9._-]", "_");
+
+        String storedName = UUID.randomUUID() + "_" + safeName;
+        Path dir = UPLOAD_ROOT.resolve(conversationId).normalize();
+        if (!dir.startsWith(UPLOAD_ROOT.normalize())) {
+            // conversationId is server-derived, so this should never happen; fail closed if it does.
+            throw new UploadRejectedException("Invalid conversation");
+        }
+        Files.createDirectories(dir);
+        Path target = dir.resolve(storedName);
+        file.transferTo(target.toAbsolutePath());
+
+        String contentType = Optional.ofNullable(file.getContentType())
+                .filter(ct -> !ct.isBlank())
+                .orElseGet(() -> probe(target));
+
+        StagedFile entry = new StagedFile(conversationId, storedName, baseName, contentType,
+                file.getSize(), System.currentTimeMillis() + STAGING_TTL_MS);
+        staged.put(storedName, entry);
+        log.info("[webchat-file] Stored upload conv={} stored={} type={} size={}",
+                conversationId, storedName, contentType, file.getSize());
+        return entry;
+    }
+
+    /**
+     * Resolve a staged file id into its metadata, asserting it belongs to this
+     * conversation and has not expired. Consuming it removes the staging entry
+     * (the bytes remain as a committed conversation attachment). Returns empty
+     * if the id is unknown, expired, or belongs to another conversation.
+     */
+    public Optional<StagedFile> consume(String conversationId, String fileId) {
+        if (fileId == null) {
+            return Optional.empty();
+        }
+        StagedFile entry = staged.get(fileId);
+        if (entry == null || entry.expired() || !entry.conversationId().equals(conversationId)) {
+            return Optional.empty();
+        }
+        staged.remove(fileId);
+        return Optional.of(entry);
+    }
+
+    /**
+     * Traversal-safe resolution of a stored file under the conversation's dir.
+     * Both the dir and the final path are derived from the server-computed
+     * conversationId; the client-supplied {@code storedName} is confined by the
+     * {@code startsWith} guard. Returns empty if missing or escaping the dir.
+     */
+    public Optional<Path> resolve(String conversationId, String storedName) {
+        if (storedName == null || storedName.isBlank()) {
+            return Optional.empty();
+        }
+        Path base = UPLOAD_ROOT.resolve(conversationId).normalize();
+        Path file = base.resolve(storedName).normalize();
+        if (!file.startsWith(base) || !Files.exists(file) || !Files.isRegularFile(file)) {
+            return Optional.empty();
+        }
+        return Optional.of(file);
+    }
+
+    /** Map a content type to the MessageContentPart type the agent/UI understands. */
+    public static String partTypeFor(String contentType) {
+        if (contentType == null) {
+            return "file";
+        }
+        String ct = contentType.toLowerCase(Locale.ROOT);
+        if (ct.startsWith("image/")) return "image";
+        if (ct.startsWith("video/")) return "video";
+        if (ct.startsWith("audio/")) return "audio";
+        return "file";
+    }
+
+    /** Periodically drop staged files the visitor never referenced. */
+    @Scheduled(fixedDelay = 15 * 60 * 1000L)
+    public void sweepExpired() {
+        staged.values().removeIf(entry -> {
+            if (!entry.expired()) {
+                return false;
+            }
+            resolve(entry.conversationId(), entry.storedName()).ifPresent(p -> {
+                try {
+                    Files.deleteIfExists(p);
+                } catch (IOException e) {
+                    log.warn("[webchat-file] Failed to delete expired staged file {}: {}",
+                            p, e.getMessage());
+                }
+            });
+            return true;
+        });
+    }
+
+    private static String extensionOf(String name) {
+        int dot = name.lastIndexOf('.');
+        if (dot < 0 || dot == name.length() - 1) {
+            return "";
+        }
+        return name.substring(dot + 1).toLowerCase(Locale.ROOT);
+    }
+
+    private static String probe(Path path) {
+        try {
+            String ct = Files.probeContentType(path);
+            return ct != null ? ct : "application/octet-stream";
+        } catch (IOException e) {
+            return "application/octet-stream";
+        }
+    }
+}

--- a/mateclaw-server/src/main/java/vip/mate/channel/webchat/WebChatRevokedVisitorEntity.java
+++ b/mateclaw-server/src/main/java/vip/mate/channel/webchat/WebChatRevokedVisitorEntity.java
@@ -1,0 +1,46 @@
+package vip.mate.channel.webchat;
+
+import com.baomidou.mybatisplus.annotation.IdType;
+import com.baomidou.mybatisplus.annotation.TableId;
+import com.baomidou.mybatisplus.annotation.TableName;
+import lombok.Data;
+
+import java.time.LocalDateTime;
+
+/**
+ * Persistent registry of visitors whose {@code visitorToken} HMAC is no longer
+ * accepted on management endpoints (list/messages/title/delete/stop/upload/
+ * regenerate). Created by V148. The unique constraint on
+ * {@code (channel_id, visitor_id, deleted)} makes re-revoke idempotent;
+ * setting {@code deleted = 1} un-revokes.
+ * <p>
+ * {@code POST /stream} is intentionally NOT bound by this — a revoked visitor
+ * can still start a fresh {@code /stream}, which mints a new token; the
+ * revocation applies to the old token presented on management endpoints.
+ *
+ * @author MateClaw Team
+ */
+@Data
+@TableName("webchat_revoked_visitor")
+public class WebChatRevokedVisitorEntity {
+
+    @TableId(type = IdType.ASSIGN_ID)
+    private Long id;
+
+    private Long channelId;
+
+    /** Visitor identifier in the same charset as {@code WebChatController.normalizeVisitorId}. */
+    private String visitorId;
+
+    private LocalDateTime revokedAt;
+
+    /** Free-form reason (admin-supplied). Nullable. */
+    private String reason;
+
+    private LocalDateTime createTime;
+
+    private LocalDateTime updateTime;
+
+    /** 0 = active revocation; 1 = un-revoked (tombstoned). */
+    private Integer deleted;
+}

--- a/mateclaw-server/src/main/java/vip/mate/channel/webchat/WebChatTokenRevocationService.java
+++ b/mateclaw-server/src/main/java/vip/mate/channel/webchat/WebChatTokenRevocationService.java
@@ -1,0 +1,134 @@
+package vip.mate.channel.webchat;
+
+import com.baomidou.mybatisplus.core.conditions.query.LambdaQueryWrapper;
+import com.github.benmanes.caffeine.cache.Cache;
+import com.github.benmanes.caffeine.cache.Caffeine;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import vip.mate.channel.webchat.repository.WebChatRevokedVisitorMapper;
+
+import java.time.Duration;
+import java.time.LocalDateTime;
+
+/**
+ * Visitor-token revocation lookup with a process-local Caffeine cache in front
+ * of the {@code webchat_revoked_visitor} table.
+ *
+ * <p>The cache is best-effort: a revoked visitor may take up to
+ * {@link #CACHE_TTL} to become effectively revoked on a node that has the
+ * un-revoked entry cached. We accept that window — webchat is low-volume —
+ * rather than pay a DB round-trip on every management endpoint call. For
+ * multi-instance deployments the same eventual-consistency applies
+ * independently per node; the DB remains the source of truth and a fresh
+ * node sees revocations immediately on cold cache.
+ *
+ * <p>All operations are idempotent: revoking an already-revoked visitor is a
+ * no-op (the row's {@code revokedAt} is updated for record-keeping);
+ * un-revoking an un-revoked one is also a no-op.
+ *
+ * @author MateClaw Team
+ */
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class WebChatTokenRevocationService {
+
+    static final Duration CACHE_TTL = Duration.ofMinutes(5);
+    private static final int CACHE_MAX_SIZE = 10_000;
+
+    private final WebChatRevokedVisitorMapper revokedVisitorMapper;
+
+    /**
+     * Keyed by "{channelId}:{visitorId}". Value is true when an active
+     * revocation row exists, false otherwise. absence means "not cached";
+     * callers must treat null as "fall through to DB".
+     */
+    private final Cache<String, Boolean> revocationCache = Caffeine.newBuilder()
+            .expireAfterWrite(CACHE_TTL)
+            .maximumSize(CACHE_MAX_SIZE)
+            .build();
+
+    /**
+     * True if this visitor is currently revoked on this channel. Pads the
+     * cache miss with a single DB lookup; the result is then cached for
+     * {@link #CACHE_TTL}.
+     */
+    public boolean isRevoked(Long channelId, String visitorId) {
+        if (channelId == null || visitorId == null) {
+            return false;
+        }
+        String key = channelId + ":" + visitorId;
+        Boolean cached = revocationCache.getIfPresent(key);
+        if (cached != null) {
+            return cached;
+        }
+        boolean revoked = lookupRevoked(channelId, visitorId);
+        revocationCache.put(key, revoked);
+        return revoked;
+    }
+
+    /**
+     * Record a revocation. Idempotent: re-revoking an already-revoked visitor
+     * refreshes {@code revokedAt} + {@code reason} on the existing row.
+     * Flushes the cache so the change is visible immediately on this node.
+     */
+    public void revoke(Long channelId, String visitorId, String reason) {
+        WebChatRevokedVisitorEntity existing = findActive(channelId, visitorId);
+        LocalDateTime now = LocalDateTime.now();
+        if (existing == null) {
+            WebChatRevokedVisitorEntity row = new WebChatRevokedVisitorEntity();
+            row.setChannelId(channelId);
+            row.setVisitorId(visitorId);
+            row.setReason(reason);
+            row.setRevokedAt(now);
+            row.setCreateTime(now);
+            row.setUpdateTime(now);
+            row.setDeleted(0);
+            revokedVisitorMapper.insert(row);
+        } else {
+            existing.setReason(reason);
+            existing.setRevokedAt(now);
+            existing.setUpdateTime(now);
+            revokedVisitorMapper.updateById(existing);
+        }
+        revocationCache.put(channelId + ":" + visitorId, true);
+        log.info("[WebChat] visitor revoked: channelId={}, visitorId={}, reason={}",
+                channelId, visitorId, reason);
+    }
+
+    /**
+     * Lift a revocation. Idempotent. Removes the cache entry so subsequent
+     * {@link #isRevoked} calls re-query the DB (and find nothing).
+     */
+    public void unrevoke(Long channelId, String visitorId) {
+        WebChatRevokedVisitorEntity existing = findActive(channelId, visitorId);
+        if (existing != null) {
+            existing.setDeleted(1);
+            existing.setUpdateTime(LocalDateTime.now());
+            revokedVisitorMapper.updateById(existing);
+        }
+        // Invalidate rather than put(false): the un-revoke may race with a
+        // concurrent revoke on another node. Forcing a DB re-lookup is safer.
+        revocationCache.invalidate(channelId + ":" + visitorId);
+        log.info("[WebChat] visitor un-revoked: channelId={}, visitorId={}",
+                channelId, visitorId);
+    }
+
+    private boolean lookupRevoked(Long channelId, String visitorId) {
+        return findActive(channelId, visitorId) != null;
+    }
+
+    private WebChatRevokedVisitorEntity findActive(Long channelId, String visitorId) {
+        return revokedVisitorMapper.selectOne(new LambdaQueryWrapper<WebChatRevokedVisitorEntity>()
+                .eq(WebChatRevokedVisitorEntity::getChannelId, channelId)
+                .eq(WebChatRevokedVisitorEntity::getVisitorId, visitorId)
+                .eq(WebChatRevokedVisitorEntity::getDeleted, 0)
+                .last("LIMIT 1"));
+    }
+
+    /** Test-only: drop every cached entry so the next isRevoked() falls through to DB. */
+    void invalidateCacheForTest() {
+        revocationCache.invalidateAll();
+    }
+}

--- a/mateclaw-server/src/main/java/vip/mate/channel/webchat/repository/WebChatRevokedVisitorMapper.java
+++ b/mateclaw-server/src/main/java/vip/mate/channel/webchat/repository/WebChatRevokedVisitorMapper.java
@@ -1,0 +1,13 @@
+package vip.mate.channel.webchat.repository;
+
+import com.baomidou.mybatisplus.core.mapper.BaseMapper;
+import org.apache.ibatis.annotations.Mapper;
+import vip.mate.channel.webchat.WebChatRevokedVisitorEntity;
+
+/**
+ * Mapper for {@link WebChatRevokedVisitorEntity}. Lives under {@code repository}
+ * so the application-wide {@code @MapperScan("vip.mate.**.repository")} picks it up.
+ */
+@Mapper
+public interface WebChatRevokedVisitorMapper extends BaseMapper<WebChatRevokedVisitorEntity> {
+}

--- a/mateclaw-server/src/main/java/vip/mate/workspace/conversation/ConversationService.java
+++ b/mateclaw-server/src/main/java/vip/mate/workspace/conversation/ConversationService.java
@@ -808,6 +808,27 @@ public class ConversationService {
     }
 
     /**
+     * External-facing message views for untrusted callers (webchat visitors).
+     * Strips the server-side absolute file path from both the structured parts
+     * ({@code path} nulled) and the rendered text, so the server filesystem
+     * layout is never disclosed. Visitors still get {@code fileUrl} / {@code
+     * fileName} / {@code contentType} to render and download attachments.
+     */
+    public List<MessageVO> listMessageViewsExternal(String conversationId) {
+        return listMessages(conversationId).stream()
+                .map(message -> {
+                    List<MessageContentPart> parts = parseMessageParts(message);
+                    parts.forEach(p -> {
+                        if (p != null) {
+                            p.setPath(null);
+                        }
+                    });
+                    return MessageVO.from(message, parts, renderMessageContent(message, false));
+                })
+                .toList();
+    }
+
+    /**
      * Delete a conversation and cascade-clean every row that referenced it.
      * <p>
      * Tables cleaned in the same transaction:
@@ -936,6 +957,16 @@ public class ConversationService {
     }
 
     public String renderMessageContent(MessageEntity message) {
+        return renderMessageContent(message, true);
+    }
+
+    /**
+     * Render variant whose {@code includePath} controls whether the server-side
+     * file path is embedded in the text. Internal/LLM rendering keeps it (tools
+     * resolve files by path); external rendering (webchat visitors) drops it so
+     * the server filesystem layout is not disclosed to untrusted callers.
+     */
+    public String renderMessageContent(MessageEntity message, boolean includePath) {
         List<MessageContentPart> parts = parseMessageParts(message);
         if (parts.isEmpty()) {
             return message.getContent() != null ? message.getContent() : "";
@@ -949,8 +980,8 @@ public class ConversationService {
             switch (part.getType()) {
                 case "text" -> appendSegment(text, part.getText());
                 case "thinking", "tool_call", "parse_error" -> { /* skip — frontend reads these from contentParts directly */ }
-                case "file" -> appendSegment(text, renderFilePart(part));
-                case "image", "video", "audio", "model3d" -> appendSegment(text, renderMediaPart(part));
+                case "file" -> appendSegment(text, renderFilePart(part, includePath));
+                case "image", "video", "audio", "model3d" -> appendSegment(text, renderMediaPart(part, includePath));
                 default -> appendSegment(text, part.getText());
             }
         }
@@ -1000,10 +1031,10 @@ public class ConversationService {
      * picks (read_file / extract_document_text / detect_file_type / …) can be called
      * with a path that resolves directly, instead of relying on per-tool fallbacks.
      */
-    private String renderFilePart(MessageContentPart part) {
+    private String renderFilePart(MessageContentPart part, boolean includePath) {
         String name = safe(part.getFileName());
         String path = safe(part.getPath());
-        if (path.isBlank()) {
+        if (!includePath || path.isBlank()) {
             return "[附件] " + name;
         }
         return "[附件] " + name + "（路径: " + path + "）";
@@ -1020,7 +1051,7 @@ public class ConversationService {
      * already uploaded. The path lets file-reading tools ({@code read_file},
      * {@code extract_document_text}, {@code detect_file_type}) work as a fallback.
      */
-    private String renderMediaPart(MessageContentPart part) {
+    private String renderMediaPart(MessageContentPart part, boolean includePath) {
         String label = switch (part.getType()) {
             case "image" -> "[图片]";
             case "video" -> "[视频]";
@@ -1034,7 +1065,7 @@ public class ConversationService {
         }
         String path = safe(part.getPath());
         StringBuilder rendered = new StringBuilder(label).append(' ').append(name);
-        if (!path.isBlank()) {
+        if (includePath && !path.isBlank()) {
             rendered.append("（路径: ").append(path).append("）");
         }
         // A persisted caption (vision sidecar output) carries the image content

--- a/mateclaw-server/src/main/java/vip/mate/workspace/conversation/ConversationService.java
+++ b/mateclaw-server/src/main/java/vip/mate/workspace/conversation/ConversationService.java
@@ -815,7 +815,16 @@ public class ConversationService {
      * fileName} / {@code contentType} to render and download attachments.
      */
     public List<MessageVO> listMessageViewsExternal(String conversationId) {
-        return listMessages(conversationId).stream()
+        return toExternalMessageViews(listMessages(conversationId));
+    }
+
+    /**
+     * Map already-loaded message entities to external (path-stripped) views.
+     * Shared by the full-list and paginated webchat paths so sanitization stays
+     * in one place.
+     */
+    public List<MessageVO> toExternalMessageViews(List<MessageEntity> messages) {
+        return messages.stream()
                 .map(message -> {
                     List<MessageContentPart> parts = parseMessageParts(message);
                     parts.forEach(p -> {

--- a/mateclaw-server/src/main/java/vip/mate/workspace/conversation/ConversationService.java
+++ b/mateclaw-server/src/main/java/vip/mate/workspace/conversation/ConversationService.java
@@ -254,6 +254,26 @@ public class ConversationService {
     }
 
     /**
+     * WebChat get-or-create that also records the thread's {@code sessionId} on
+     * insert, so the visitor's /sessions listing can recover it even when the
+     * conversationId hashes (long visitorId + sessionId). The session id is
+     * written only when the row is first created; an existing row is left as-is.
+     */
+    @Transactional
+    public ConversationEntity getOrCreateWebchatConversation(String conversationId, Long agentId,
+                                                             String username, Long workspaceId,
+                                                             String sessionId) {
+        boolean existed = conversationMapper.selectOne(new LambdaQueryWrapper<ConversationEntity>()
+                .eq(ConversationEntity::getConversationId, conversationId)) != null;
+        ConversationEntity conv = getOrCreateConversation(conversationId, agentId, username, workspaceId);
+        if (!existed && sessionId != null && !sessionId.isBlank() && conv.getWebchatSessionId() == null) {
+            conv.setWebchatSessionId(sessionId);
+            conversationMapper.updateById(conv);
+        }
+        return conv;
+    }
+
+    /**
      * Create a child conversation (delegation scenario), linking it back to
      * its parent via {@code parentConversationId}.
      *

--- a/mateclaw-server/src/main/java/vip/mate/workspace/conversation/ConversationService.java
+++ b/mateclaw-server/src/main/java/vip/mate/workspace/conversation/ConversationService.java
@@ -263,12 +263,40 @@ public class ConversationService {
     public ConversationEntity getOrCreateWebchatConversation(String conversationId, Long agentId,
                                                              String username, Long workspaceId,
                                                              String sessionId) {
+        return getOrCreateWebchatConversation(conversationId, agentId, username, workspaceId, sessionId, null);
+    }
+
+    /**
+     * WebChat get-or-create with an optional caller-supplied title.
+     * <p>
+     * When the row is freshly inserted and {@code title} is non-blank, it
+     * overrides the default {@code "新对话"}; otherwise the default is kept and
+     * {@link #saveMessage} will still derive a title from the first user
+     * message. An existing row is never rewritten — neither {@code sessionId}
+     * nor {@code title} are clobbered, so a session created via
+     * {@code POST /sessions} with a caller-supplied title keeps that title
+     * when the first {@code /stream} message later lands.
+     */
+    @Transactional
+    public ConversationEntity getOrCreateWebchatConversation(String conversationId, Long agentId,
+                                                             String username, Long workspaceId,
+                                                             String sessionId, String title) {
         boolean existed = conversationMapper.selectOne(new LambdaQueryWrapper<ConversationEntity>()
                 .eq(ConversationEntity::getConversationId, conversationId)) != null;
         ConversationEntity conv = getOrCreateConversation(conversationId, agentId, username, workspaceId);
-        if (!existed && sessionId != null && !sessionId.isBlank() && conv.getWebchatSessionId() == null) {
-            conv.setWebchatSessionId(sessionId);
-            conversationMapper.updateById(conv);
+        if (!existed) {
+            boolean dirty = false;
+            if (sessionId != null && !sessionId.isBlank() && conv.getWebchatSessionId() == null) {
+                conv.setWebchatSessionId(sessionId);
+                dirty = true;
+            }
+            if (title != null && !title.isBlank()) {
+                conv.setTitle(title.trim());
+                dirty = true;
+            }
+            if (dirty) {
+                conversationMapper.updateById(conv);
+            }
         }
         return conv;
     }

--- a/mateclaw-server/src/main/java/vip/mate/workspace/conversation/ConversationService.java
+++ b/mateclaw-server/src/main/java/vip/mate/workspace/conversation/ConversationService.java
@@ -274,6 +274,24 @@ public class ConversationService {
     }
 
     /**
+     * List a webchat visitor's own conversations (top-level threads), ordered
+     * pinned-desc then last-active-desc.
+     * <p>
+     * Scoped to {@code username = owner} only — unlike {@link #listConversations}
+     * it does <b>not</b> pull in {@code system} rows, so a visitor's /sessions
+     * call doesn't load every IM/cron conversation in the database just to list
+     * its own handful of threads. The caller still applies the channel-prefix
+     * filter (literal {@code startsWith}, wildcard-safe) to isolate the channel.
+     */
+    public List<ConversationEntity> listWebchatConversations(String username) {
+        return conversationMapper.selectList(new LambdaQueryWrapper<ConversationEntity>()
+                .eq(ConversationEntity::getUsername, username)
+                .isNull(ConversationEntity::getParentConversationId)
+                .orderByDesc(ConversationEntity::getPinned)
+                .orderByDesc(ConversationEntity::getLastActiveTime));
+    }
+
+    /**
      * Create a child conversation (delegation scenario), linking it back to
      * its parent via {@code parentConversationId}.
      *

--- a/mateclaw-server/src/main/java/vip/mate/workspace/conversation/ConversationService.java
+++ b/mateclaw-server/src/main/java/vip/mate/workspace/conversation/ConversationService.java
@@ -589,6 +589,21 @@ public class ConversationService {
     }
 
     /**
+     * Archive or unarchive a conversation (webchat soft-close). Mirrors
+     * {@link #setPinned}: archived threads stay on disk (history preserved,
+     * addressable, downloadable) but are excluded from default listings; the
+     * caller opts back in via {@code includeArchived=true}.
+     */
+    public void setArchived(String conversationId, boolean archived) {
+        ConversationEntity conv = conversationMapper.selectOne(new LambdaQueryWrapper<ConversationEntity>()
+                .eq(ConversationEntity::getConversationId, conversationId));
+        if (conv != null) {
+            conv.setArchived(archived ? 1 : 0);
+            conversationMapper.updateById(conv);
+        }
+    }
+
+    /**
      * Update a conversation's stream status ({@code running} / {@code idle}).
      *
      * <p>更新会话的流状态（running / idle）。

--- a/mateclaw-server/src/main/java/vip/mate/workspace/conversation/model/ConversationEntity.java
+++ b/mateclaw-server/src/main/java/vip/mate/workspace/conversation/model/ConversationEntity.java
@@ -62,6 +62,14 @@ public class ConversationEntity {
     private String modelName;
 
     /**
+     * WebChat per-thread sessionId (see V147 migration). Persisted so it can be
+     * recovered for the visitor's /sessions listing even when the conversationId
+     * hashes (long visitorId + sessionId folds into an unrecoverable hash). NULL
+     * for non-webchat rows and for a visitor's default (no-session) thread.
+     */
+    private String webchatSessionId;
+
+    /**
      * Per-conversation progress notebook JSON (see V100 migration).
      * <p>
      * Map of {@code stepKey -> {label, status, note, updatedAt}}, written by

--- a/mateclaw-server/src/main/java/vip/mate/workspace/conversation/model/ConversationEntity.java
+++ b/mateclaw-server/src/main/java/vip/mate/workspace/conversation/model/ConversationEntity.java
@@ -52,6 +52,16 @@ public class ConversationEntity {
     private Integer pinned;
 
     /**
+     * Archive flag (webchat): 0 = active (default), 1 = archived.
+     * Archived threads stay in the DB (history preserved, still addressable
+     * by sessionId, downloadable) but are excluded from the default
+     * /sessions listing. A visitor opts into seeing them via
+     * {@code includeArchived=true}. Archive dominates pin — an archived
+     * AND pinned thread is still hidden by default.
+     */
+    private Integer archived;
+
+    /**
      * Provider id of the model this conversation is pinned to. NULL means
      * "inherit" — fall back to the agent's model override, then the global
      * default. Paired with {@link #modelName}.

--- a/mateclaw-server/src/main/java/vip/mate/workspace/conversation/vo/ConversationVO.java
+++ b/mateclaw-server/src/main/java/vip/mate/workspace/conversation/vo/ConversationVO.java
@@ -66,6 +66,7 @@ public class ConversationVO extends ConversationEntity {
         vo.setLastActiveTime(entity.getLastActiveTime());
         vo.setWorkspaceId(entity.getWorkspaceId());
         vo.setPinned(entity.getPinned() != null ? entity.getPinned() : 0);
+        vo.setArchived(entity.getArchived() != null ? entity.getArchived() : 0);
         vo.setModelProvider(entity.getModelProvider());
         vo.setModelName(entity.getModelName());
         vo.setWebchatSessionId(entity.getWebchatSessionId());

--- a/mateclaw-server/src/main/java/vip/mate/workspace/conversation/vo/ConversationVO.java
+++ b/mateclaw-server/src/main/java/vip/mate/workspace/conversation/vo/ConversationVO.java
@@ -68,6 +68,7 @@ public class ConversationVO extends ConversationEntity {
         vo.setPinned(entity.getPinned() != null ? entity.getPinned() : 0);
         vo.setModelProvider(entity.getModelProvider());
         vo.setModelName(entity.getModelName());
+        vo.setWebchatSessionId(entity.getWebchatSessionId());
         vo.setCreateTime(entity.getCreateTime());
         vo.setUpdateTime(entity.getUpdateTime());
         // 补充关联字段

--- a/mateclaw-server/src/main/resources/db/migration/h2/V147__webchat_session_id.sql
+++ b/mateclaw-server/src/main/resources/db/migration/h2/V147__webchat_session_id.sql
@@ -1,0 +1,6 @@
+-- WebChat per-thread sessionId, persisted so it can be recovered even when the
+-- conversationId hashes (visitorId + sessionId > 64 chars folds into a hash,
+-- which is otherwise unrecoverable — making the thread invisible/unaddressable
+-- in the visitor's /sessions listing). NULL for non-webchat rows and for a
+-- visitor's default (no-session) thread.
+ALTER TABLE mate_conversation ADD COLUMN IF NOT EXISTS webchat_session_id VARCHAR(64);

--- a/mateclaw-server/src/main/resources/db/migration/h2/V148__webchat_archive_and_revocation.sql
+++ b/mateclaw-server/src/main/resources/db/migration/h2/V148__webchat_archive_and_revocation.sql
@@ -1,0 +1,33 @@
+-- V148: webchat visitor-session archive flag + visitor-token revocation registry.
+--
+-- 1) mate_conversation.archived — INT, 0 (default) = active, 1 = archived.
+--    Lets a visitor "soft-close" a thread: it stays in the DB (history
+--    preserved, downloadable, addressable by sessionId) but is excluded
+--    from the default /sessions listing. Pinned/archived are orthogonal:
+--    archive dominates (an archived+pinned thread is still hidden by default).
+--
+-- 2) webchat_revoked_visitor — registry of visitors whose visitorToken HMAC
+--    is no longer accepted on management endpoints (list/messages/title/
+--    delete/stop/upload/regenerate). /stream is intentionally NOT bound by
+--    this: a revoked visitor can still start a fresh /stream, which mints
+--    a new token; the revocation applies to the old token presented on
+--    management endpoints. The (channel_id, visitor_id) pair is unique among
+--    non-deleted rows so a re-revoke is idempotent; setting deleted=1
+--    un-revokes.
+
+ALTER TABLE mate_conversation ADD COLUMN IF NOT EXISTS archived INT NOT NULL DEFAULT 0;
+
+CREATE TABLE IF NOT EXISTS webchat_revoked_visitor (
+    id          BIGINT       NOT NULL PRIMARY KEY,
+    channel_id  BIGINT       NOT NULL,
+    visitor_id  VARCHAR(128) NOT NULL,
+    revoked_at  TIMESTAMP    NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    reason      VARCHAR(255),
+    create_time TIMESTAMP    NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    update_time TIMESTAMP    NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    deleted     INT          NOT NULL DEFAULT 0
+);
+CREATE UNIQUE INDEX IF NOT EXISTS uk_webchat_revoked_visitor
+    ON webchat_revoked_visitor (channel_id, visitor_id, deleted);
+CREATE INDEX IF NOT EXISTS idx_webchat_revoked_visitor_lookup
+    ON webchat_revoked_visitor (channel_id, visitor_id, deleted);

--- a/mateclaw-server/src/main/resources/db/migration/kingbase/V147__webchat_session_id.sql
+++ b/mateclaw-server/src/main/resources/db/migration/kingbase/V147__webchat_session_id.sql
@@ -1,0 +1,3 @@
+-- See the H2 copy for context. KingbaseES (PostgreSQL) supports
+-- ADD COLUMN IF NOT EXISTS natively.
+ALTER TABLE mate_conversation ADD COLUMN IF NOT EXISTS webchat_session_id VARCHAR(64);

--- a/mateclaw-server/src/main/resources/db/migration/kingbase/V148__webchat_archive_and_revocation.sql
+++ b/mateclaw-server/src/main/resources/db/migration/kingbase/V148__webchat_archive_and_revocation.sql
@@ -1,0 +1,19 @@
+-- V148: webchat visitor-session archive flag + visitor-token revocation registry (KingbaseES / PostgreSQL).
+-- See the H2 copy for full context.
+
+ALTER TABLE mate_conversation ADD COLUMN IF NOT EXISTS archived INT NOT NULL DEFAULT 0;
+
+CREATE TABLE IF NOT EXISTS webchat_revoked_visitor (
+    id          BIGINT       NOT NULL PRIMARY KEY,
+    channel_id  BIGINT       NOT NULL,
+    visitor_id  VARCHAR(128) NOT NULL,
+    revoked_at  TIMESTAMP    NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    reason      VARCHAR(255),
+    create_time TIMESTAMP    NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    update_time TIMESTAMP    NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    deleted     INT          NOT NULL DEFAULT 0
+);
+CREATE UNIQUE INDEX IF NOT EXISTS uk_webchat_revoked_visitor
+    ON webchat_revoked_visitor (channel_id, visitor_id, deleted);
+CREATE INDEX IF NOT EXISTS idx_webchat_revoked_visitor_lookup
+    ON webchat_revoked_visitor (channel_id, visitor_id, deleted);

--- a/mateclaw-server/src/main/resources/db/migration/mysql/V147__webchat_session_id.sql
+++ b/mateclaw-server/src/main/resources/db/migration/mysql/V147__webchat_session_id.sql
@@ -1,0 +1,15 @@
+-- See the H2 file for context. MySQL 8.0 doesn't support
+-- `ADD COLUMN IF NOT EXISTS`, so the existence check goes through
+-- INFORMATION_SCHEMA + a prepared statement.
+SET @col_exists := (
+    SELECT COUNT(*) FROM information_schema.COLUMNS
+    WHERE TABLE_SCHEMA = DATABASE()
+      AND TABLE_NAME = 'mate_conversation'
+      AND COLUMN_NAME = 'webchat_session_id'
+);
+SET @ddl := IF(@col_exists = 0,
+    'ALTER TABLE mate_conversation ADD COLUMN webchat_session_id VARCHAR(64) NULL COMMENT ''WebChat per-thread sessionId (recoverable even when conversationId hashes)''',
+    'SELECT 1');
+PREPARE stmt FROM @ddl;
+EXECUTE stmt;
+DEALLOCATE PREPARE stmt;

--- a/mateclaw-server/src/main/resources/db/migration/mysql/V148__webchat_archive_and_revocation.sql
+++ b/mateclaw-server/src/main/resources/db/migration/mysql/V148__webchat_archive_and_revocation.sql
@@ -1,0 +1,30 @@
+-- V148: webchat visitor-session archive flag + visitor-token revocation registry (MySQL).
+-- See the H2 copy for full context.
+
+-- 1) archived column — MySQL 8.0 has no ADD COLUMN IF NOT EXISTS.
+SET @col_exists := (
+    SELECT COUNT(*) FROM information_schema.COLUMNS
+    WHERE TABLE_SCHEMA = DATABASE()
+      AND TABLE_NAME = 'mate_conversation'
+      AND COLUMN_NAME = 'archived'
+);
+SET @ddl := IF(@col_exists = 0,
+    'ALTER TABLE mate_conversation ADD COLUMN archived INT NOT NULL DEFAULT 0 COMMENT ''webchat: 0 = active, 1 = archived (hidden from default /sessions listing)''',
+    'SELECT 1');
+PREPARE stmt FROM @ddl;
+EXECUTE stmt;
+DEALLOCATE PREPARE stmt;
+
+-- 2) revoked-visitor registry
+CREATE TABLE IF NOT EXISTS webchat_revoked_visitor (
+    id          BIGINT       NOT NULL PRIMARY KEY,
+    channel_id  BIGINT       NOT NULL,
+    visitor_id  VARCHAR(128) NOT NULL,
+    revoked_at  TIMESTAMP    NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    reason      VARCHAR(255),
+    create_time TIMESTAMP    NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    update_time TIMESTAMP    NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    deleted     INT          NOT NULL DEFAULT 0,
+    UNIQUE KEY uk_webchat_revoked_visitor (channel_id, visitor_id, deleted),
+    KEY idx_webchat_revoked_visitor_lookup (channel_id, visitor_id, deleted)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;

--- a/mateclaw-server/src/test/java/vip/mate/channel/webchat/WebChatArchivePinTest.java
+++ b/mateclaw-server/src/test/java/vip/mate/channel/webchat/WebChatArchivePinTest.java
@@ -1,0 +1,171 @@
+package vip.mate.channel.webchat;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.test.context.TestPropertySource;
+import vip.mate.MateClawApplication;
+import vip.mate.channel.webchat.WebChatController.WebChatCreateSessionRequest;
+import vip.mate.channel.webchat.WebChatController.WebChatSessionView;
+import vip.mate.common.result.R;
+
+import java.util.List;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * End-to-end verification of the pin and archive endpoints (epic #355 PR 3).
+ * Both endpoints share the same shape (PUT with {flag: true|false} body +
+ * query visitorId/sessionId) and the same auth chain as the other session
+ * mutations. Tests assert the persisted column flips AND that
+ * {@link WebChatController#listSessions} reflects the change accordingly.
+ */
+@SpringBootTest(
+        classes = MateClawApplication.class,
+        webEnvironment = SpringBootTest.WebEnvironment.NONE
+)
+@TestPropertySource(properties = {
+        "spring.datasource.url=jdbc:h2:mem:webchat_pinarch_${random.uuid};MODE=MySQL;DATABASE_TO_LOWER=TRUE;CASE_INSENSITIVE_IDENTIFIERS=TRUE;DB_CLOSE_DELAY=-1",
+        "spring.ai.dashscope.api-key=test-key",
+        "spring.main.web-application-type=none",
+        "mateclaw.jwt.secret=webchat-it-secret-0123456789"
+})
+class WebChatArchivePinTest {
+
+    private static final String SECRET = "webchat-it-secret-0123456789";
+    private static final String API_KEY = "testkey1abcdefgh";
+    private static final long CHANNEL_ID = 9_147_501L;
+    private static final long AGENT_ID = 9_147_5011L;
+
+    @Autowired private WebChatController controller;
+    @Autowired private JdbcTemplate jdbc;
+
+    @BeforeEach
+    void setUp() {
+        jdbc.update("DELETE FROM mate_channel WHERE id = ?", CHANNEL_ID);
+        jdbc.update("DELETE FROM mate_agent WHERE id = ?", AGENT_ID);
+        jdbc.update(
+                "MERGE INTO mate_agent (id, name, agent_type, system_prompt, max_iterations, enabled, " +
+                        "workspace_id, create_time, update_time, deleted) " +
+                        "KEY(id) VALUES (?, 'wc-pinarch-agent', 'react', '', 10, TRUE, 1, " +
+                        "CURRENT_TIMESTAMP, CURRENT_TIMESTAMP, 0)",
+                AGENT_ID);
+        jdbc.update("INSERT INTO mate_channel (id, name, channel_type, agent_id, config_json, enabled, " +
+                        "workspace_id, create_time, update_time, deleted) " +
+                        "VALUES (?, 'wc', 'webchat', ?, ?, TRUE, 1, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP, 0)",
+                CHANNEL_ID, AGENT_ID, "{\"api_key\":\"" + API_KEY + "\"}");
+    }
+
+    private WebChatCreateSessionRequest req(String visitorId, String sessionId) {
+        WebChatCreateSessionRequest r = new WebChatCreateSessionRequest();
+        r.setVisitorId(visitorId);
+        r.setSessionId(sessionId);
+        return r;
+    }
+
+    private String tokenFor(String visitorId) {
+        return WebChatController.computeVisitorToken(SECRET, CHANNEL_ID, visitorId);
+    }
+
+    @Test
+    @DisplayName("PUT /sessions/pinned flips the column + view reports pinned=1")
+    void pinFlipsColumn() {
+        controller.createSession(API_KEY, req("vPin", "s1"));
+        String cid = WebChatController.deriveConversationId(API_KEY, "vPin", "s1");
+
+        R<Void> r = controller.pinSession(API_KEY, tokenFor("vPin"), "vPin", "s1",
+                Map.of("pinned", true));
+        assertThat(r.getCode()).isEqualTo(200);
+
+        Integer col = jdbc.queryForObject(
+                "SELECT pinned FROM mate_conversation WHERE conversation_id = ?",
+                Integer.class, cid);
+        assertThat(col).isEqualTo(1);
+
+        @SuppressWarnings("unchecked")
+        R<List<WebChatSessionView>> list = (R<List<WebChatSessionView>>) (R<?>)
+                controller.listSessions(API_KEY, tokenFor("vPin"), "vPin", false);
+        assertThat(list.getData().get(0).getPinned()).isEqualTo(1);
+    }
+
+    @Test
+    @DisplayName("PUT /sessions/archive hides the thread from default listing")
+    void archiveHidesFromDefaultListing() {
+        controller.createSession(API_KEY, req("vArch", "s1"));
+
+        R<Void> r = controller.archiveSession(API_KEY, tokenFor("vArch"), "vArch", "s1",
+                Map.of("archived", true));
+        assertThat(r.getCode()).isEqualTo(200);
+
+        // Default listing: empty.
+        @SuppressWarnings("unchecked")
+        R<List<WebChatSessionView>> def = (R<List<WebChatSessionView>>) (R<?>)
+                controller.listSessions(API_KEY, tokenFor("vArch"), "vArch", false);
+        assertThat(def.getData()).isEmpty();
+
+        // includeArchived=true: shows up with archived=1.
+        @SuppressWarnings("unchecked")
+        R<List<WebChatSessionView>> all = (R<List<WebChatSessionView>>) (R<?>)
+                controller.listSessions(API_KEY, tokenFor("vArch"), "vArch", true);
+        assertThat(all.getData()).hasSize(1);
+        assertThat(all.getData().get(0).getArchived()).isEqualTo(1);
+
+        // Un-archive restores visibility.
+        controller.archiveSession(API_KEY, tokenFor("vArch"), "vArch", "s1",
+                Map.of("archived", false));
+        @SuppressWarnings("unchecked")
+        R<List<WebChatSessionView>> back = (R<List<WebChatSessionView>>) (R<?>)
+                controller.listSessions(API_KEY, tokenFor("vArch"), "vArch", false);
+        assertThat(back.getData()).hasSize(1);
+    }
+
+    @Test
+    @DisplayName("archived + pinned thread still hidden by default (archive dominates)")
+    void archiveDominatesPin() {
+        controller.createSession(API_KEY, req("vBoth", "s1"));
+        controller.pinSession(API_KEY, tokenFor("vBoth"), "vBoth", "s1",
+                Map.of("pinned", true));
+        controller.archiveSession(API_KEY, tokenFor("vBoth"), "vBoth", "s1",
+                Map.of("archived", true));
+
+        @SuppressWarnings("unchecked")
+        R<List<WebChatSessionView>> def = (R<List<WebChatSessionView>>) (R<?>)
+                controller.listSessions(API_KEY, tokenFor("vBoth"), "vBoth", false);
+        assertThat(def.getData()).isEmpty();
+    }
+
+    @Test
+    @DisplayName("missing or wrong-typed body → 400")
+    void rejectsMalformedBody() {
+        controller.createSession(API_KEY, req("vBad", "s1"));
+        // Wrong type:
+        R<Void> r1 = controller.pinSession(API_KEY, tokenFor("vBad"), "vBad", "s1",
+                Map.of("pinned", "yes"));
+        assertThat(r1.getCode()).isEqualTo(400);
+        // Wrong key:
+        R<Void> r2 = controller.archiveSession(API_KEY, tokenFor("vBad"), "vBad", "s1",
+                Map.of("flag", true));
+        assertThat(r2.getCode()).isEqualTo(400);
+    }
+
+    @Test
+    @DisplayName("unknown sessionId → 404 (no probing)")
+    void rejectsUnknownSession() {
+        R<Void> r = controller.pinSession(API_KEY, tokenFor("vGhost"), "vGhost", "ghost",
+                Map.of("pinned", true));
+        assertThat(r.getCode()).isEqualTo(404);
+    }
+
+    @Test
+    @DisplayName("bad token → 401")
+    void rejectsBadToken() {
+        controller.createSession(API_KEY, req("vTok", "s1"));
+        R<Void> r = controller.archiveSession(API_KEY, "bogus", "vTok", "s1",
+                Map.of("archived", true));
+        assertThat(r.getCode()).isEqualTo(401);
+    }
+}

--- a/mateclaw-server/src/test/java/vip/mate/channel/webchat/WebChatCreateSessionTest.java
+++ b/mateclaw-server/src/test/java/vip/mate/channel/webchat/WebChatCreateSessionTest.java
@@ -195,7 +195,7 @@ class WebChatCreateSessionTest {
         controller.createSession(API_KEY, req("visitorI", "s-listed", null));
 
         String token = WebChatController.computeVisitorToken(SECRET, CHANNEL_ID, "visitorI");
-        R<?> r = controller.listSessions(API_KEY, token, "visitorI");
+        R<?> r = controller.listSessions(API_KEY, token, "visitorI", false);
         assertThat(r.getCode()).isEqualTo(200);
         assertThat(((java.util.List<WebChatController.WebChatSessionView>) (Object) r.getData()))
                 .extracting(WebChatController.WebChatSessionView::getSessionId)

--- a/mateclaw-server/src/test/java/vip/mate/channel/webchat/WebChatCreateSessionTest.java
+++ b/mateclaw-server/src/test/java/vip/mate/channel/webchat/WebChatCreateSessionTest.java
@@ -1,0 +1,204 @@
+package vip.mate.channel.webchat;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.test.context.TestPropertySource;
+import vip.mate.MateClawApplication;
+import vip.mate.channel.webchat.WebChatController.WebChatCreateSessionRequest;
+import vip.mate.common.result.R;
+import vip.mate.workspace.conversation.ConversationService;
+
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * End-to-end verification of {@code POST /api/v1/channels/webchat/sessions}
+ * (explicit empty-session creation) against a booted context + real H2 with
+ * migrations (incl. V147 {@code webchat_session_id}) applied.
+ * <p>
+ * Covers the four behaviors promised in issue #351:
+ * <ol>
+ *   <li>happy path inserts an empty thread and returns sessionId/conversationId/
+ *       visitorToken;</li>
+ *   <li>a caller-supplied title is persisted and survives the first /stream
+ *       user message (saveMessage's "title-derive" guard must not fire);</li>
+ *   <li>re-creating with a colliding sessionId is idempotent — 200, no title
+ *       clobber;</li>
+ *   <li>the empty-session quota (≤ 5) is enforced with a clear 409.</li>
+ * </ol>
+ */
+@SpringBootTest(
+        classes = MateClawApplication.class,
+        webEnvironment = SpringBootTest.WebEnvironment.NONE
+)
+@TestPropertySource(properties = {
+        "spring.datasource.url=jdbc:h2:mem:webchat_create_sess_${random.uuid};MODE=MySQL;DATABASE_TO_LOWER=TRUE;CASE_INSENSITIVE_IDENTIFIERS=TRUE;DB_CLOSE_DELAY=-1",
+        "spring.ai.dashscope.api-key=test-key",
+        "spring.main.web-application-type=none",
+        "mateclaw.jwt.secret=webchat-it-secret-0123456789"
+})
+class WebChatCreateSessionTest {
+
+    private static final String SECRET = "webchat-it-secret-0123456789";
+    private static final String API_KEY = "testkey1abcdefgh"; // key8 = "testkey1"
+    private static final long CHANNEL_ID = 9_147_101L;
+    private static final long AGENT_ID = 9_147_1011L;
+
+    @Autowired private WebChatController controller;
+    @Autowired private ConversationService conversationService;
+    @Autowired private JdbcTemplate jdbc;
+
+    @BeforeEach
+    void setUp() {
+        jdbc.update("DELETE FROM mate_channel WHERE id = ?", CHANNEL_ID);
+        jdbc.update("DELETE FROM mate_agent WHERE id = ?", AGENT_ID);
+        jdbc.update(
+                "MERGE INTO mate_agent (id, name, agent_type, system_prompt, max_iterations, enabled, " +
+                        "workspace_id, create_time, update_time, deleted) " +
+                        "KEY(id) VALUES (?, 'wc-test-agent', 'react', '', 10, TRUE, 1, " +
+                        "CURRENT_TIMESTAMP, CURRENT_TIMESTAMP, 0)",
+                AGENT_ID);
+        jdbc.update("INSERT INTO mate_channel (id, name, channel_type, agent_id, config_json, enabled, " +
+                        "workspace_id, create_time, update_time, deleted) " +
+                        "VALUES (?, 'wc', 'webchat', ?, ?, TRUE, 1, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP, 0)",
+                CHANNEL_ID, AGENT_ID, "{\"api_key\":\"" + API_KEY + "\"}");
+    }
+
+    private WebChatCreateSessionRequest req(String visitorId, String sessionId, String title) {
+        WebChatCreateSessionRequest r = new WebChatCreateSessionRequest();
+        r.setVisitorId(visitorId);
+        r.setSessionId(sessionId);
+        r.setTitle(title);
+        return r;
+    }
+
+    @Test
+    @DisplayName("createSession inserts an empty thread and returns all required fields")
+    void createsEmptySession() {
+        R<Map<String, Object>> r = controller.createSession(API_KEY, req("visitorA", "s1", null));
+        assertThat(r.getCode()).isEqualTo(200);
+        Map<String, Object> data = r.getData();
+        assertThat(data.get("sessionId")).isEqualTo("s1");
+        assertThat(data.get("conversationId"))
+                .isEqualTo(WebChatController.deriveConversationId(API_KEY, "visitorA", "s1"));
+        assertThat(data.get("visitorToken"))
+                .isEqualTo(WebChatController.computeVisitorToken(SECRET, CHANNEL_ID, "visitorA"));
+        // No title supplied → default placeholder, will be derived from first user message later.
+        assertThat(data.get("title")).isEqualTo("新对话");
+        assertThat(data.get("createTime")).isNotNull();
+
+        // Row actually persisted with message_count = 0.
+        Integer count = jdbc.queryForObject(
+                "SELECT message_count FROM mate_conversation WHERE conversation_id = ?",
+                Integer.class, data.get("conversationId"));
+        assertThat(count).isZero();
+    }
+
+    @Test
+    @DisplayName("caller-supplied title survives the first /stream user message")
+    void titleSurvivesFirstMessage() {
+        String cid = (String) controller
+                .createSession(API_KEY, req("visitorB", "s-title", "Quarterly Report"))
+                .getData().get("conversationId");
+
+        // Simulate /stream saving the first user message.
+        conversationService.saveMessage(cid, "user", "随便说点什么,看看会不会把 title 覆盖掉");
+
+        String persisted = jdbc.queryForObject(
+                "SELECT title FROM mate_conversation WHERE conversation_id = ?",
+                String.class, cid);
+        assertThat(persisted).isEqualTo("Quarterly Report");
+    }
+
+    @Test
+    @DisplayName("default-title thread still derives its title from the first user message")
+    void defaultTitleIsDerivedFromFirstMessage() {
+        String cid = (String) controller
+                .createSession(API_KEY, req("visitorC", "s-default", null))
+                .getData().get("conversationId");
+
+        conversationService.saveMessage(cid, "user", "今天天气不错");
+
+        String persisted = jdbc.queryForObject(
+                "SELECT title FROM mate_conversation WHERE conversation_id = ?",
+                String.class, cid);
+        assertThat(persisted).isEqualTo("今天天气不错");
+    }
+
+    @Test
+    @DisplayName("re-create with colliding sessionId is idempotent — no title clobber")
+    void isIdempotentOnCollision() {
+        // First call creates with a caller title.
+        controller.createSession(API_KEY, req("visitorD", "s-collide", "OriginalTitle"));
+
+        // Second call tries to re-create the same sessionId with a different title.
+        R<Map<String, Object>> r = controller
+                .createSession(API_KEY, req("visitorD", "s-collide", "AttemptedOverride"));
+        assertThat(r.getCode()).isEqualTo(200);
+        assertThat(r.getData().get("title")).isEqualTo("OriginalTitle");
+
+        String persisted = jdbc.queryForObject(
+                "SELECT title FROM mate_conversation WHERE conversation_id = ?",
+                String.class, r.getData().get("conversationId"));
+        assertThat(persisted).isEqualTo("OriginalTitle");
+    }
+
+    @Test
+    @DisplayName("empty-session quota (≤ 5) is enforced with a 409")
+    void enforcesQuota() {
+        // Pre-seed 5 empty threads directly through the service (bypasses the controller
+        // quota so we can verify the controller is the gate, not the service).
+        String owner = WebChatController.webchatUsername("visitorE");
+        for (int i = 1; i <= 5; i++) {
+            conversationService.getOrCreateWebchatConversation(
+                    WebChatController.deriveConversationId(API_KEY, "visitorE", "seed" + i),
+                    null, owner, 1L, "seed" + i);
+        }
+
+        R<Map<String, Object>> r = controller.createSession(API_KEY, req("visitorE", "s-new", null));
+        assertThat(r.getCode()).isEqualTo(409);
+        assertThat(r.getMsg()).contains("未活跃会话数已达上限");
+    }
+
+    @Test
+    @DisplayName("bad API Key → 401")
+    void rejectsBadApiKey() {
+        R<Map<String, Object>> r = controller.createSession("bogus-key", req("visitorF", "s1", null));
+        assertThat(r.getCode()).isEqualTo(401);
+    }
+
+    @Test
+    @DisplayName("illegal sessionId charset → 400")
+    void rejectsIllegalSessionId() {
+        R<Map<String, Object>> r = controller
+                .createSession(API_KEY, req("visitorG", "has space", null));
+        assertThat(r.getCode()).isEqualTo(400);
+    }
+
+    @Test
+    @DisplayName("illegal title length (>100) → 400")
+    void rejectsOverlongTitle() {
+        R<Map<String, Object>> r = controller
+                .createSession(API_KEY, req("visitorH", "s1", "x".repeat(101)));
+        assertThat(r.getCode()).isEqualTo(400);
+    }
+
+    @Test
+    @DisplayName("once a session is created, listSessions sees it (with the recovered sessionId)")
+    @SuppressWarnings("unchecked")
+    void createdSessionIsListable() {
+        controller.createSession(API_KEY, req("visitorI", "s-listed", null));
+
+        String token = WebChatController.computeVisitorToken(SECRET, CHANNEL_ID, "visitorI");
+        R<?> r = controller.listSessions(API_KEY, token, "visitorI");
+        assertThat(r.getCode()).isEqualTo(200);
+        assertThat(((java.util.List<WebChatController.WebChatSessionView>) (Object) r.getData()))
+                .extracting(WebChatController.WebChatSessionView::getSessionId)
+                .contains("s-listed");
+    }
+}

--- a/mateclaw-server/src/test/java/vip/mate/channel/webchat/WebChatFileServiceTest.java
+++ b/mateclaw-server/src/test/java/vip/mate/channel/webchat/WebChatFileServiceTest.java
@@ -27,7 +27,12 @@ class WebChatFileServiceTest {
     private static final String CONV = "webchat:abcd1234:visitor-1";
 
     private WebChatFileService service(boolean enabled, long maxMb, String exts) {
-        return new WebChatFileService(enabled, maxMb, exts);
+        return new WebChatFileService(enabled, maxMb, exts, 50, 200);
+    }
+
+    private WebChatFileService service(boolean enabled, long maxMb, String exts,
+                                       int maxFiles, long maxTotalMb) {
+        return new WebChatFileService(enabled, maxMb, exts, maxFiles, maxTotalMb);
     }
 
     @AfterEach
@@ -90,6 +95,17 @@ class WebChatFileServiceTest {
 
         // Bytes survive on disk for download after consume.
         assertThat(svc.resolve(CONV, stored.storedName())).isPresent();
+    }
+
+    @Test
+    @DisplayName("rejects once the per-conversation file-count quota is hit")
+    void rejectsOverFileCountQuota() throws IOException {
+        WebChatFileService svc = service(true, 20, "txt", 2, 200); // max 2 files
+        svc.store(CONV, new MockMultipartFile("file", "a.txt", "text/plain", "a".getBytes()));
+        svc.store(CONV, new MockMultipartFile("file", "b.txt", "text/plain", "b".getBytes()));
+        assertThatThrownBy(() -> svc.store(CONV,
+                new MockMultipartFile("file", "c.txt", "text/plain", "c".getBytes())))
+                .isInstanceOf(WebChatFileService.UploadRejectedException.class);
     }
 
     @Test

--- a/mateclaw-server/src/test/java/vip/mate/channel/webchat/WebChatFileServiceTest.java
+++ b/mateclaw-server/src/test/java/vip/mate/channel/webchat/WebChatFileServiceTest.java
@@ -1,0 +1,102 @@
+package vip.mate.channel.webchat;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.mock.web.MockMultipartFile;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.Comparator;
+import java.util.Optional;
+import java.util.stream.Stream;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/**
+ * Validation + isolation contract for {@link WebChatFileService}. WebChat
+ * uploads come from untrusted external visitors, so these pin: extension
+ * whitelist, size cap, disabled-switch, per-conversation ownership of staged
+ * ids, and traversal-safe resolution.
+ */
+class WebChatFileServiceTest {
+
+    private static final String CONV = "webchat:abcd1234:visitor-1";
+
+    private WebChatFileService service(boolean enabled, long maxMb, String exts) {
+        return new WebChatFileService(enabled, maxMb, exts);
+    }
+
+    @AfterEach
+    void cleanup() throws IOException {
+        Path dir = Paths.get("data", "chat-uploads", CONV);
+        if (Files.exists(dir)) {
+            try (Stream<Path> walk = Files.walk(dir)) {
+                walk.sorted(Comparator.reverseOrder()).forEach(p -> {
+                    try { Files.deleteIfExists(p); } catch (IOException ignored) { }
+                });
+            }
+        }
+    }
+
+    @Test
+    @DisplayName("rejects a disallowed extension")
+    void rejectsDisallowedExtension() {
+        WebChatFileService svc = service(true, 20, "png,txt");
+        MockMultipartFile evil = new MockMultipartFile("file", "evil.exe",
+                "application/octet-stream", new byte[]{1, 2, 3});
+        assertThatThrownBy(() -> svc.store(CONV, evil))
+                .isInstanceOf(WebChatFileService.UploadRejectedException.class);
+    }
+
+    @Test
+    @DisplayName("rejects an oversized file")
+    void rejectsOversized() {
+        WebChatFileService svc = service(true, 1, "png");
+        byte[] big = new byte[2 * 1024 * 1024]; // 2MB > 1MB cap
+        MockMultipartFile file = new MockMultipartFile("file", "big.png", "image/png", big);
+        assertThatThrownBy(() -> svc.store(CONV, file))
+                .isInstanceOf(WebChatFileService.UploadRejectedException.class);
+    }
+
+    @Test
+    @DisplayName("rejects when disabled")
+    void rejectsWhenDisabled() {
+        WebChatFileService svc = service(false, 20, "png");
+        MockMultipartFile file = new MockMultipartFile("file", "ok.png", "image/png", new byte[]{1});
+        assertThatThrownBy(() -> svc.store(CONV, file))
+                .isInstanceOf(WebChatFileService.UploadRejectedException.class);
+    }
+
+    @Test
+    @DisplayName("accepts allowed file; consume is one-shot and conversation-scoped")
+    void acceptsAndConsumeIsScoped() throws IOException {
+        WebChatFileService svc = service(true, 20, "png,txt");
+        MockMultipartFile file = new MockMultipartFile("file", "hello.txt", "text/plain",
+                "hi".getBytes());
+
+        WebChatFileService.StagedFile stored = svc.store(CONV, file);
+        assertThat(stored.originalName()).isEqualTo("hello.txt");
+        assertThat(stored.conversationId()).isEqualTo(CONV);
+
+        // Foreign conversation can't consume it.
+        assertThat(svc.consume("webchat:abcd1234:other", stored.storedName())).isEmpty();
+        // Owning conversation can — exactly once.
+        assertThat(svc.consume(CONV, stored.storedName())).isPresent();
+        assertThat(svc.consume(CONV, stored.storedName())).isEmpty();
+
+        // Bytes survive on disk for download after consume.
+        assertThat(svc.resolve(CONV, stored.storedName())).isPresent();
+    }
+
+    @Test
+    @DisplayName("resolve is traversal-safe")
+    void resolveRejectsTraversal() {
+        WebChatFileService svc = service(true, 20, "png");
+        Optional<Path> escaped = svc.resolve(CONV, "../../../../etc/passwd");
+        assertThat(escaped).isEmpty();
+    }
+}

--- a/mateclaw-server/src/test/java/vip/mate/channel/webchat/WebChatSchemaFieldsTest.java
+++ b/mateclaw-server/src/test/java/vip/mate/channel/webchat/WebChatSchemaFieldsTest.java
@@ -1,0 +1,173 @@
+package vip.mate.channel.webchat;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.test.context.TestPropertySource;
+import vip.mate.MateClawApplication;
+import vip.mate.channel.webchat.WebChatController.WebChatCreateSessionRequest;
+import vip.mate.channel.webchat.WebChatController.WebChatSessionView;
+import vip.mate.common.result.R;
+import vip.mate.workspace.conversation.ConversationService;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * End-to-end verification of the V148 schema additions and the
+ * {@code archived} filtering / view-field exposure that rides on them:
+ * <ul>
+ *   <li>{@code mate_conversation.archived} column exists and is read/write.</li>
+ *   <li>{@code webchat_revoked_visitor} table exists (full DDL validation
+ *       happens implicitly — Flyway would have failed to apply the migration
+ *       otherwise; here we only verify the table is queryable).</li>
+ *   <li>{@link WebChatSessionView} now carries {@code pinned/archived/
+ *       streamStatus}, so the visitor-side listing surfaces the same state
+ *       the admin console sees.</li>
+ *   <li>{@code loadVisitorSessions} filters out archived threads by default;
+ *       {@code includeArchived=true} opts back in.</li>
+ * </ul>
+ */
+@SpringBootTest(
+        classes = MateClawApplication.class,
+        webEnvironment = SpringBootTest.WebEnvironment.NONE
+)
+@TestPropertySource(properties = {
+        "spring.datasource.url=jdbc:h2:mem:webchat_schema_${random.uuid};MODE=MySQL;DATABASE_TO_LOWER=TRUE;CASE_INSENSITIVE_IDENTIFIERS=TRUE;DB_CLOSE_DELAY=-1",
+        "spring.ai.dashscope.api-key=test-key",
+        "spring.main.web-application-type=none",
+        "mateclaw.jwt.secret=webchat-it-secret-0123456789"
+})
+class WebChatSchemaFieldsTest {
+
+    private static final String SECRET = "webchat-it-secret-0123456789";
+    private static final String API_KEY = "testkey1abcdefgh";
+    private static final long CHANNEL_ID = 9_147_301L;
+    private static final long AGENT_ID = 9_147_3011L;
+
+    @Autowired private WebChatController controller;
+    @Autowired private ConversationService conversationService;
+    @Autowired private JdbcTemplate jdbc;
+
+    @BeforeEach
+    void setUp() {
+        jdbc.update("DELETE FROM mate_channel WHERE id = ?", CHANNEL_ID);
+        jdbc.update("DELETE FROM mate_agent WHERE id = ?", AGENT_ID);
+        jdbc.update(
+                "MERGE INTO mate_agent (id, name, agent_type, system_prompt, max_iterations, enabled, " +
+                        "workspace_id, create_time, update_time, deleted) " +
+                        "KEY(id) VALUES (?, 'wc-schema-agent', 'react', '', 10, TRUE, 1, " +
+                        "CURRENT_TIMESTAMP, CURRENT_TIMESTAMP, 0)",
+                AGENT_ID);
+        jdbc.update("INSERT INTO mate_channel (id, name, channel_type, agent_id, config_json, enabled, " +
+                        "workspace_id, create_time, update_time, deleted) " +
+                        "VALUES (?, 'wc', 'webchat', ?, ?, TRUE, 1, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP, 0)",
+                CHANNEL_ID, AGENT_ID, "{\"api_key\":\"" + API_KEY + "\"}");
+    }
+
+    private WebChatCreateSessionRequest req(String visitorId, String sessionId) {
+        WebChatCreateSessionRequest r = new WebChatCreateSessionRequest();
+        r.setVisitorId(visitorId);
+        r.setSessionId(sessionId);
+        return r;
+    }
+
+    private String tokenFor(String visitorId) {
+        return WebChatController.computeVisitorToken(SECRET, CHANNEL_ID, visitorId);
+    }
+
+    @Test
+    @DisplayName("revoked-visitor table is queryable (DDL applied)")
+    void revokedVisitorTableExists() {
+        // Insert + read back a row to prove the table + columns are live.
+        jdbc.update("INSERT INTO webchat_revoked_visitor (id, channel_id, visitor_id, reason) " +
+                "VALUES (?, ?, ?, ?)", 9991L, CHANNEL_ID, "schema-probe", "test");
+        Integer count = jdbc.queryForObject(
+                "SELECT COUNT(*) FROM webchat_revoked_visitor WHERE channel_id = ? AND visitor_id = ?",
+                Integer.class, CHANNEL_ID, "schema-probe");
+        assertThat(count).isEqualTo(1);
+        jdbc.update("DELETE FROM webchat_revoked_visitor WHERE id = ?", 9991L);
+    }
+
+    @Test
+    @DisplayName("archived column on mate_conversation is read/write")
+    void archivedColumnReadWrite() {
+        controller.createSession(API_KEY, req("visitorArch", "s1"));
+        String cid = WebChatController.deriveConversationId(API_KEY, "visitorArch", "s1");
+
+        Integer before = jdbc.queryForObject(
+                "SELECT archived FROM mate_conversation WHERE conversation_id = ?",
+                Integer.class, cid);
+        assertThat(before).isZero();
+
+        jdbc.update("UPDATE mate_conversation SET archived = 1 WHERE conversation_id = ?", cid);
+        Integer after = jdbc.queryForObject(
+                "SELECT archived FROM mate_conversation WHERE conversation_id = ?",
+                Integer.class, cid);
+        assertThat(after).isEqualTo(1);
+    }
+
+    @Test
+    @DisplayName("WebChatSessionView exposes pinned/archived/streamStatus")
+    void viewExposesNewFields() {
+        controller.createSession(API_KEY, req("visitorView", "s1"));
+        // Flip pinned via the service (endpoint comes in PR 3) so we can assert the view mirrors it.
+        String cid = WebChatController.deriveConversationId(API_KEY, "visitorView", "s1");
+        conversationService.setPinned(cid, true);
+
+        R<List<WebChatSessionView>> r = controller.listSessions(
+                API_KEY, tokenFor("visitorView"), "visitorView", false);
+        assertThat(r.getCode()).isEqualTo(200);
+        assertThat(r.getData()).hasSize(1);
+        WebChatSessionView view = r.getData().get(0);
+        assertThat(view.getPinned()).isEqualTo(1);
+        assertThat(view.getArchived()).isZero();
+        assertThat(view.getStreamStatus()).isEqualTo("idle");
+    }
+
+    @Test
+    @DisplayName("archived threads are hidden from /sessions by default")
+    @SuppressWarnings("unchecked")
+    void archivedHiddenByDefault() {
+        controller.createSession(API_KEY, req("visitorHide", "active"));
+        controller.createSession(API_KEY, req("visitorHide", "stale"));
+
+        String staleCid = WebChatController.deriveConversationId(API_KEY, "visitorHide", "stale");
+        jdbc.update("UPDATE mate_conversation SET archived = 1 WHERE conversation_id = ?", staleCid);
+
+        // Default: only "active" is returned.
+        R<?> def = controller.listSessions(API_KEY, tokenFor("visitorHide"), "visitorHide", false);
+        assertThat(((List<WebChatSessionView>) def.getData()))
+                .extracting(WebChatSessionView::getSessionId)
+                .containsExactly("active");
+
+        // includeArchived=true: both.
+        R<?> all = controller.listSessions(API_KEY, tokenFor("visitorHide"), "visitorHide", true);
+        assertThat(((List<WebChatSessionView>) all.getData()))
+                .extracting(WebChatSessionView::getSessionId)
+                .containsExactlyInAnyOrder("active", "stale");
+    }
+
+    @Test
+    @DisplayName("archived empty threads don't count against the 5-empty-session quota")
+    void archivedExcludedFromQuota() {
+        // Pre-seed 5 archived empty threads + verify a 6th (active) creation still succeeds —
+        // the quota gate filters archived out, so the active count is 0 here.
+        String owner = WebChatController.webchatUsername("visitorQuota");
+        for (int i = 1; i <= 5; i++) {
+            String cid = WebChatController.deriveConversationId(API_KEY, "visitorQuota", "arch" + i);
+            conversationService.getOrCreateWebchatConversation(
+                    cid, AGENT_ID, owner, 1L, "arch" + i);
+            jdbc.update("UPDATE mate_conversation SET archived = 1 WHERE conversation_id = ?", cid);
+        }
+
+        R<?> r = controller.createSession(API_KEY, req("visitorQuota", "fresh"));
+        assertThat(r.getCode())
+                .as("archived threads must not saturate the empty-session quota")
+                .isEqualTo(200);
+    }
+}

--- a/mateclaw-server/src/test/java/vip/mate/channel/webchat/WebChatSessionManagementTest.java
+++ b/mateclaw-server/src/test/java/vip/mate/channel/webchat/WebChatSessionManagementTest.java
@@ -1,0 +1,136 @@
+package vip.mate.channel.webchat;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.test.context.TestPropertySource;
+import vip.mate.MateClawApplication;
+import vip.mate.channel.webchat.WebChatController.WebChatSessionView;
+import vip.mate.common.result.R;
+import vip.mate.workspace.conversation.ConversationService;
+
+import java.util.List;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * End-to-end verification of the WebChat visitor session-management endpoints
+ * against a booted context + real H2 (migrations incl. V147 run). Exercises the
+ * controller's real auth (channel lookup + visitor-token HMAC), pagination,
+ * keyword search, rename, and — the key case — that a thread whose
+ * conversationId hashed (long visitorId + sessionId) is still listed with its
+ * sessionId recovered from the persisted column.
+ */
+@SpringBootTest(
+        classes = MateClawApplication.class,
+        webEnvironment = SpringBootTest.WebEnvironment.NONE
+)
+@TestPropertySource(properties = {
+        "spring.datasource.url=jdbc:h2:mem:webchat_sess_test_${random.uuid};MODE=MySQL;DATABASE_TO_LOWER=TRUE;CASE_INSENSITIVE_IDENTIFIERS=TRUE;DB_CLOSE_DELAY=-1",
+        "spring.ai.dashscope.api-key=test-key",
+        "spring.main.web-application-type=none",
+        "mateclaw.jwt.secret=webchat-it-secret-0123456789"
+})
+class WebChatSessionManagementTest {
+
+    private static final String SECRET = "webchat-it-secret-0123456789";
+    private static final String API_KEY = "testkey1abcdefgh"; // key8 = "testkey1"
+    private static final String VISITOR = "visitorAAAA";
+    private static final long CHANNEL_ID = 9_147_001L;
+    // Long enough that "webchat:testkey1:visitorAAAA:<this>" exceeds 64 chars and hashes.
+    private static final String LONG_SESSION = "session-1234567890-abcdefghij-klmnopqrst";
+
+    @Autowired private WebChatController controller;
+    @Autowired private ConversationService conversationService;
+    @Autowired private JdbcTemplate jdbc;
+
+    private String token;
+
+    @BeforeEach
+    void setUp() {
+        jdbc.update("DELETE FROM mate_channel WHERE id = ?", CHANNEL_ID);
+        jdbc.update("INSERT INTO mate_channel (id, name, channel_type, config_json, enabled, " +
+                        "workspace_id, create_time, update_time, deleted) " +
+                        "VALUES (?, 'wc', 'webchat', ?, TRUE, 1, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP, 0)",
+                CHANNEL_ID, "{\"api_key\":\"" + API_KEY + "\"}");
+
+        String owner = WebChatController.webchatUsername(VISITOR);
+        // default thread (no sessionId)
+        conversationService.getOrCreateWebchatConversation(
+                WebChatController.deriveConversationId(API_KEY, VISITOR, null), null, owner, 1L, null);
+        // short sessioned thread
+        conversationService.getOrCreateWebchatConversation(
+                WebChatController.deriveConversationId(API_KEY, VISITOR, "s1"), null, owner, 1L, "s1");
+        // long sessioned thread → conversationId hashes
+        conversationService.getOrCreateWebchatConversation(
+                WebChatController.deriveConversationId(API_KEY, VISITOR, LONG_SESSION), null, owner, 1L, LONG_SESSION);
+
+        token = WebChatController.computeVisitorToken(SECRET, CHANNEL_ID, VISITOR);
+    }
+
+    @Test
+    @DisplayName("listSessions includes the hashed long-id thread with its sessionId recovered")
+    @SuppressWarnings("unchecked")
+    void listsHashedThread() {
+        R<List<WebChatSessionView>> r = (R<List<WebChatSessionView>>) (R<?>) controller.listSessions(API_KEY, token, VISITOR);
+        assertThat(r.getCode()).isEqualTo(200);
+        List<WebChatSessionView> sessions = r.getData();
+        assertThat(sessions).hasSize(3);
+        assertThat(sessions).extracting(WebChatSessionView::getSessionId)
+                .containsExactlyInAnyOrder(null, "s1", LONG_SESSION);
+    }
+
+    @Test
+    @DisplayName("bad visitor token is rejected")
+    @SuppressWarnings("unchecked")
+    void rejectsBadToken() {
+        R<List<WebChatSessionView>> r = (R<List<WebChatSessionView>>) (R<?>) controller.listSessions(API_KEY, "bogus", VISITOR);
+        assertThat(r.getCode()).isEqualTo(401);
+    }
+
+    @Test
+    @DisplayName("pageSessions paginates and keyword-searches by title")
+    void pagesAndSearches() {
+        R<Map<String, Object>> page = controller.pageSessions(API_KEY, token, VISITOR, 1, 2, null);
+        assertThat(page.getCode()).isEqualTo(200);
+        assertThat(page.getData().get("total")).isEqualTo(3L);
+        assertThat((List<?>) page.getData().get("items")).hasSize(2);
+
+        // Rename one thread, then search for it.
+        controller.renameSession(API_KEY, token, VISITOR, "s1", Map.of("title", "QuarterlyReport"));
+        R<Map<String, Object>> hit = controller.pageSessions(API_KEY, token, VISITOR, 1, 20, "quarterly");
+        assertThat((List<?>) hit.getData().get("items")).hasSize(1);
+    }
+
+    @Test
+    @DisplayName("rename updates the thread title")
+    void renames() {
+        R<Void> r = controller.renameSession(API_KEY, token, VISITOR, "s1", Map.of("title", "Renamed"));
+        assertThat(r.getCode()).isEqualTo(200);
+
+        String cid = WebChatController.deriveConversationId(API_KEY, VISITOR, "s1");
+        String title = jdbc.queryForObject(
+                "SELECT title FROM mate_conversation WHERE conversation_id = ?", String.class, cid);
+        assertThat(title).isEqualTo("Renamed");
+    }
+
+    @Test
+    @DisplayName("sessionMessages paginates with hasMore")
+    @SuppressWarnings("unchecked")
+    void paginatesMessages() {
+        String cid = WebChatController.deriveConversationId(API_KEY, VISITOR, "s1");
+        conversationService.saveMessage(cid, "user", "m1");
+        conversationService.saveMessage(cid, "assistant", "m2");
+        conversationService.saveMessage(cid, "user", "m3");
+
+        R<?> r = controller.sessionMessages(API_KEY, token, VISITOR, "s1", null, 2);
+        assertThat(r.getCode()).isEqualTo(200);
+        Map<String, Object> data = (Map<String, Object>) r.getData();
+        assertThat((List<?>) data.get("messages")).hasSize(2);
+        assertThat(data.get("hasMore")).isEqualTo(true);
+    }
+}

--- a/mateclaw-server/src/test/java/vip/mate/channel/webchat/WebChatSessionManagementTest.java
+++ b/mateclaw-server/src/test/java/vip/mate/channel/webchat/WebChatSessionManagementTest.java
@@ -76,7 +76,7 @@ class WebChatSessionManagementTest {
     @DisplayName("listSessions includes the hashed long-id thread with its sessionId recovered")
     @SuppressWarnings("unchecked")
     void listsHashedThread() {
-        R<List<WebChatSessionView>> r = (R<List<WebChatSessionView>>) (R<?>) controller.listSessions(API_KEY, token, VISITOR);
+        R<List<WebChatSessionView>> r = (R<List<WebChatSessionView>>) (R<?>) controller.listSessions(API_KEY, token, VISITOR, false);
         assertThat(r.getCode()).isEqualTo(200);
         List<WebChatSessionView> sessions = r.getData();
         assertThat(sessions).hasSize(3);
@@ -88,21 +88,21 @@ class WebChatSessionManagementTest {
     @DisplayName("bad visitor token is rejected")
     @SuppressWarnings("unchecked")
     void rejectsBadToken() {
-        R<List<WebChatSessionView>> r = (R<List<WebChatSessionView>>) (R<?>) controller.listSessions(API_KEY, "bogus", VISITOR);
+        R<List<WebChatSessionView>> r = (R<List<WebChatSessionView>>) (R<?>) controller.listSessions(API_KEY, "bogus", VISITOR, false);
         assertThat(r.getCode()).isEqualTo(401);
     }
 
     @Test
     @DisplayName("pageSessions paginates and keyword-searches by title")
     void pagesAndSearches() {
-        R<Map<String, Object>> page = controller.pageSessions(API_KEY, token, VISITOR, 1, 2, null);
+        R<Map<String, Object>> page = controller.pageSessions(API_KEY, token, VISITOR, 1, 2, null, false);
         assertThat(page.getCode()).isEqualTo(200);
         assertThat(page.getData().get("total")).isEqualTo(3L);
         assertThat((List<?>) page.getData().get("items")).hasSize(2);
 
         // Rename one thread, then search for it.
         controller.renameSession(API_KEY, token, VISITOR, "s1", Map.of("title", "QuarterlyReport"));
-        R<Map<String, Object>> hit = controller.pageSessions(API_KEY, token, VISITOR, 1, 20, "quarterly");
+        R<Map<String, Object>> hit = controller.pageSessions(API_KEY, token, VISITOR, 1, 20, "quarterly", false);
         assertThat((List<?>) hit.getData().get("items")).hasSize(1);
     }
 

--- a/mateclaw-server/src/test/java/vip/mate/channel/webchat/WebChatStopStreamTest.java
+++ b/mateclaw-server/src/test/java/vip/mate/channel/webchat/WebChatStopStreamTest.java
@@ -1,0 +1,133 @@
+package vip.mate.channel.webchat;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.test.context.TestPropertySource;
+import reactor.core.Disposable;
+import reactor.core.publisher.Flux;
+import vip.mate.MateClawApplication;
+import vip.mate.channel.web.ChatStreamTracker;
+import vip.mate.channel.webchat.WebChatController.WebChatCreateSessionRequest;
+import vip.mate.common.result.R;
+
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * End-to-end verification of {@code POST /api/v1/channels/webchat/sessions/stop}
+ * against a booted context + real H2 (migrations incl. V147).
+ * <p>
+ * The non-trivial case is {@link #stopsActiveStream()}: a real Reactor
+ * {@code Disposable} is registered on the tracker (mirroring what
+ * {@code WebChatController.chatStream} now does after subscribe), and the test
+ * asserts that {@code stopSession} both returns {@code stopped=true} AND
+ * actually disposes the underlying subscription — proving the chatStream
+ * wiring change is what makes the new endpoint functional rather than a no-op.
+ */
+@SpringBootTest(
+        classes = MateClawApplication.class,
+        webEnvironment = SpringBootTest.WebEnvironment.NONE
+)
+@TestPropertySource(properties = {
+        "spring.datasource.url=jdbc:h2:mem:webchat_stop_${random.uuid};MODE=MySQL;DATABASE_TO_LOWER=TRUE;CASE_INSENSITIVE_IDENTIFIERS=TRUE;DB_CLOSE_DELAY=-1",
+        "spring.ai.dashscope.api-key=test-key",
+        "spring.main.web-application-type=none",
+        "mateclaw.jwt.secret=webchat-it-secret-0123456789"
+})
+class WebChatStopStreamTest {
+
+    private static final String SECRET = "webchat-it-secret-0123456789";
+    private static final String API_KEY = "testkey1abcdefgh"; // key8 = "testkey1"
+    private static final long CHANNEL_ID = 9_147_201L;
+    private static final long AGENT_ID = 9_147_2011L;
+
+    @Autowired private WebChatController controller;
+    @Autowired private ChatStreamTracker streamTracker;
+    @Autowired private JdbcTemplate jdbc;
+
+    @BeforeEach
+    void setUp() {
+        jdbc.update("DELETE FROM mate_channel WHERE id = ?", CHANNEL_ID);
+        jdbc.update("DELETE FROM mate_agent WHERE id = ?", AGENT_ID);
+        jdbc.update(
+                "MERGE INTO mate_agent (id, name, agent_type, system_prompt, max_iterations, enabled, " +
+                        "workspace_id, create_time, update_time, deleted) " +
+                        "KEY(id) VALUES (?, 'wc-stop-agent', 'react', '', 10, TRUE, 1, " +
+                        "CURRENT_TIMESTAMP, CURRENT_TIMESTAMP, 0)",
+                AGENT_ID);
+        jdbc.update("INSERT INTO mate_channel (id, name, channel_type, agent_id, config_json, enabled, " +
+                        "workspace_id, create_time, update_time, deleted) " +
+                        "VALUES (?, 'wc', 'webchat', ?, ?, TRUE, 1, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP, 0)",
+                CHANNEL_ID, AGENT_ID, "{\"api_key\":\"" + API_KEY + "\"}");
+    }
+
+    private WebChatCreateSessionRequest req(String visitorId, String sessionId) {
+        WebChatCreateSessionRequest r = new WebChatCreateSessionRequest();
+        r.setVisitorId(visitorId);
+        r.setSessionId(sessionId);
+        return r;
+    }
+
+    private String tokenFor(String visitorId) {
+        return WebChatController.computeVisitorToken(SECRET, CHANNEL_ID, visitorId);
+    }
+
+    @Test
+    @DisplayName("stop actually disposes the active subscription (chatStream wiring works)")
+    void stopsActiveStream() {
+        controller.createSession(API_KEY, req("visitorA", "s1"));
+        String cid = WebChatController.deriveConversationId(API_KEY, "visitorA", "s1");
+
+        // Simulate what WebChatController.chatStream does right after .subscribe():
+        // register the run + bind the Disposable so requestStop() can dispose it.
+        streamTracker.register(cid);
+        Disposable disposable = Flux.never().subscribe();
+        streamTracker.setDisposable(cid, disposable);
+        assertThat(disposable.isDisposed()).isFalse();
+
+        R<Map<String, Object>> r = controller.stopSession(API_KEY, tokenFor("visitorA"), "visitorA", "s1");
+        assertThat(r.getCode()).isEqualTo(200);
+        assertThat(r.getData().get("stopped")).isEqualTo(Boolean.TRUE);
+        assertThat(disposable.isDisposed()).isTrue();
+    }
+
+    @Test
+    @DisplayName("stop returns stopped=false when no stream is active (idempotent)")
+    void noActiveStreamReturnsFalse() {
+        controller.createSession(API_KEY, req("visitorB", "s1"));
+
+        R<Map<String, Object>> r = controller.stopSession(API_KEY, tokenFor("visitorB"), "visitorB", "s1");
+        assertThat(r.getCode()).isEqualTo(200);
+        assertThat(r.getData().get("stopped")).isEqualTo(Boolean.FALSE);
+    }
+
+    @Test
+    @DisplayName("bad visitor token → 401")
+    void rejectsBadToken() {
+        controller.createSession(API_KEY, req("visitorC", "s1"));
+
+        R<Map<String, Object>> r = controller.stopSession(API_KEY, "bogus-token", "visitorC", "s1");
+        assertThat(r.getCode()).isEqualTo(401);
+    }
+
+    @Test
+    @DisplayName("bad API Key → 401")
+    void rejectsBadApiKey() {
+        R<Map<String, Object>> r = controller.stopSession("bogus-key", "any-token", "visitorD", "s1");
+        assertThat(r.getCode()).isEqualTo(401);
+    }
+
+    @Test
+    @DisplayName("unknown sessionId → 404 (no namespace probing)")
+    void rejectsUnknownSession() {
+        // Visitor exists (token verifies) but never created session "ghost".
+        R<Map<String, Object>> r = controller.stopSession(
+                API_KEY, tokenFor("visitorE"), "visitorE", "never-created");
+        assertThat(r.getCode()).isEqualTo(404);
+    }
+}

--- a/mateclaw-server/src/test/java/vip/mate/channel/webchat/WebChatTokenRevocationTest.java
+++ b/mateclaw-server/src/test/java/vip/mate/channel/webchat/WebChatTokenRevocationTest.java
@@ -1,0 +1,192 @@
+package vip.mate.channel.webchat;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.test.context.TestPropertySource;
+import vip.mate.MateClawApplication;
+import vip.mate.channel.webchat.WebChatController.WebChatCreateSessionRequest;
+import vip.mate.channel.webchat.WebChatController.WebChatSessionView;
+import vip.mate.common.result.R;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * End-to-end verification of visitor-token revocation + expiration (epic #355 PR 2):
+ * <ul>
+ *   <li>{@link WebChatTokenRevocationService#revoke} flips
+ *       {@link WebChatController#verifyVisitorToken} to false on subsequent calls.</li>
+ *   <li>{@link WebChatTokenRevocationService#unrevoke} flips it back.</li>
+ *   <li>Revoke is idempotent (double-revoke = single row).</li>
+ *   <li>Cache amortises the DB hit: a second {@code isRevoked} for the same
+ *       (channelId, visitorId) within the TTL does not re-query.</li>
+ *   <li>Expired tokens are rejected before revocation is even consulted.</li>
+ *   <li>An end-to-end management call ({@code GET /sessions}) honours the
+ *       revocation — a revoked visitor gets 401.</li>
+ * </ul>
+ */
+@SpringBootTest(
+        classes = MateClawApplication.class,
+        webEnvironment = SpringBootTest.WebEnvironment.NONE
+)
+@TestPropertySource(properties = {
+        "spring.datasource.url=jdbc:h2:mem:webchat_revoke_${random.uuid};MODE=MySQL;DATABASE_TO_LOWER=TRUE;CASE_INSENSITIVE_IDENTIFIERS=TRUE;DB_CLOSE_DELAY=-1",
+        "spring.ai.dashscope.api-key=test-key",
+        "spring.main.web-application-type=none",
+        "mateclaw.jwt.secret=webchat-it-secret-0123456789"
+})
+class WebChatTokenRevocationTest {
+
+    private static final String SECRET = "webchat-it-secret-0123456789";
+    private static final String API_KEY = "testkey1abcdefgh";
+    private static final long CHANNEL_ID = 9_147_401L;
+    private static final long AGENT_ID = 9_147_4011L;
+
+    @Autowired private WebChatController controller;
+    @Autowired private WebChatAdminController adminController;
+    @Autowired private WebChatTokenRevocationService revocationService;
+    @Autowired private JdbcTemplate jdbc;
+
+    @BeforeEach
+    void setUp() {
+        jdbc.update("DELETE FROM mate_channel WHERE id = ?", CHANNEL_ID);
+        jdbc.update("DELETE FROM mate_agent WHERE id = ?", AGENT_ID);
+        jdbc.update("DELETE FROM webchat_revoked_visitor WHERE channel_id = ?", CHANNEL_ID);
+        jdbc.update(
+                "MERGE INTO mate_agent (id, name, agent_type, system_prompt, max_iterations, enabled, " +
+                        "workspace_id, create_time, update_time, deleted) " +
+                        "KEY(id) VALUES (?, 'wc-revoke-agent', 'react', '', 10, TRUE, 1, " +
+                        "CURRENT_TIMESTAMP, CURRENT_TIMESTAMP, 0)",
+                AGENT_ID);
+        jdbc.update("INSERT INTO mate_channel (id, name, channel_type, agent_id, config_json, enabled, " +
+                        "workspace_id, create_time, update_time, deleted) " +
+                        "VALUES (?, 'wc', 'webchat', ?, ?, TRUE, 1, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP, 0)",
+                CHANNEL_ID, AGENT_ID, "{\"api_key\":\"" + API_KEY + "\"}");
+        // Invalidate any cached revocation state from earlier tests sharing this Spring context.
+        revocationService.invalidateCacheForTest();
+    }
+
+    private WebChatCreateSessionRequest req(String visitorId, String sessionId) {
+        WebChatCreateSessionRequest r = new WebChatCreateSessionRequest();
+        r.setVisitorId(visitorId);
+        r.setSessionId(sessionId);
+        return r;
+    }
+
+    private String tokenFor(String visitorId) {
+        return WebChatController.computeVisitorToken(SECRET, CHANNEL_ID, visitorId);
+    }
+
+    @Test
+    @DisplayName("revoked visitor: token verify flips to false, /sessions returns 401")
+    void revokedVisitorCannotReachManagementEndpoints() {
+        controller.createSession(API_KEY, req("vRevoke", "s1"));
+        String token = tokenFor("vRevoke");
+
+        // Pre-revoke: endpoint works.
+        R<?> ok = controller.listSessions(API_KEY, token, "vRevoke", false);
+        assertThat(ok.getCode()).isEqualTo(200);
+
+        revocationService.revoke(CHANNEL_ID, "vRevoke", "abuse");
+
+        R<?> denied = controller.listSessions(API_KEY, token, "vRevoke", false);
+        assertThat(denied.getCode()).isEqualTo(401);
+    }
+
+    @Test
+    @DisplayName("un-revoke: token verify flips back to true, /sessions works again")
+    void unrevokeRestoresAccess() {
+        controller.createSession(API_KEY, req("vUnrev", "s1"));
+        String token = tokenFor("vUnrev");
+
+        revocationService.revoke(CHANNEL_ID, "vUnrev", "test");
+        assertThat(controller.listSessions(API_KEY, token, "vUnrev", false).getCode()).isEqualTo(401);
+
+        revocationService.unrevoke(CHANNEL_ID, "vUnrev");
+        R<?> ok = controller.listSessions(API_KEY, token, "vUnrev", false);
+        assertThat(ok.getCode()).isEqualTo(200);
+    }
+
+    @Test
+    @DisplayName("revoke is idempotent (single row, no errors on double-revoke)")
+    void revokeIsIdempotent() {
+        revocationService.revoke(CHANNEL_ID, "vIdem", "first");
+        revocationService.revoke(CHANNEL_ID, "vIdem", "second");
+
+        Integer rows = jdbc.queryForObject(
+                "SELECT COUNT(*) FROM webchat_revoked_visitor WHERE channel_id = ? AND visitor_id = ? AND deleted = 0",
+                Integer.class, CHANNEL_ID, "vIdem");
+        assertThat(rows).isEqualTo(1);
+    }
+
+    @Test
+    @DisplayName("cache: revoking twice + isRevoked yields exactly one persisted row")
+    void revokePersistsSingleRowAcrossMultipleCalls() {
+        // The cache makes revoke() + immediate isRevoked() cheap, but the source of
+        // truth is the DB — assert the table still contains exactly one row even
+        // after the visitor is queried multiple times post-revoke.
+        revocationService.revoke(CHANNEL_ID, "vCache", "x");
+        revocationService.isRevoked(CHANNEL_ID, "vCache");
+        revocationService.isRevoked(CHANNEL_ID, "vCache");
+        revocationService.isRevoked(CHANNEL_ID, "vCache");
+
+        Integer rows = jdbc.queryForObject(
+                "SELECT COUNT(*) FROM webchat_revoked_visitor WHERE channel_id = ? AND visitor_id = ?",
+                Integer.class, CHANNEL_ID, "vCache");
+        assertThat(rows).isEqualTo(1);
+    }
+
+    @Test
+    @DisplayName("expired token is rejected even when visitor is not revoked")
+    void expiredTokenRejected() {
+        // Mint a token that already expired a minute ago.
+        long past = java.time.Instant.now().getEpochSecond() - 60;
+        String expired = WebChatController.computeVisitorToken(SECRET, CHANNEL_ID, "vExp", past);
+
+        controller.createSession(API_KEY, req("vExp", "s1"));
+        R<?> r = controller.listSessions(API_KEY, expired, "vExp", false);
+        assertThat(r.getCode()).isEqualTo(401);
+    }
+
+    @Test
+    @DisplayName("/stream is unaffected by revocation — a revoked visitor can still start fresh")
+    void streamUnaffectedByRevocation() {
+        // We can't actually exercise /stream without a real LLM, but we can verify
+        // the contract: revoking a visitor leaves verifyVisitorTokenSignature() (which
+        // /stream never calls anyway) intact. The point of this test is to lock in
+        // that the revocation check lives in the instance verifyVisitorToken, not in
+        // the static signature check.
+        revocationService.revoke(CHANNEL_ID, "vStream", "test");
+        String token = WebChatController.computeVisitorToken(SECRET, CHANNEL_ID, "vStream");
+        // Signature still verifies (proves /stream's "mint a fresh token" path works):
+        assertThat(WebChatController.verifyVisitorTokenSignature(SECRET, CHANNEL_ID, "vStream", token))
+                .isTrue();
+    }
+
+    @Test
+    @DisplayName("admin endpoint POST /revoked-visitor records the revocation + audit")
+    void adminEndpointRevokes() {
+        WebChatAdminController.RevokeVisitorRequest req = new WebChatAdminController.RevokeVisitorRequest();
+        req.setChannelId(CHANNEL_ID);
+        req.setVisitorId("vAdmin");
+        req.setReason("admin-test");
+
+        R<Void> r = adminController.revokeVisitor(req, null);
+        assertThat(r.getCode()).isEqualTo(200);
+
+        Integer rows = jdbc.queryForObject(
+                "SELECT COUNT(*) FROM webchat_revoked_visitor WHERE channel_id = ? AND visitor_id = ? AND deleted = 0",
+                Integer.class, CHANNEL_ID, "vAdmin");
+        assertThat(rows).isEqualTo(1);
+
+        Integer audit = jdbc.queryForObject(
+                "SELECT COUNT(*) FROM mate_audit_event WHERE action = ? AND resource_id = ?",
+                Integer.class, "webchat.revoke-visitor", String.valueOf(CHANNEL_ID));
+        assertThat(audit).isGreaterThan(0);
+    }
+}

--- a/mateclaw-server/src/test/java/vip/mate/channel/webchat/WebChatVisitorTokenTest.java
+++ b/mateclaw-server/src/test/java/vip/mate/channel/webchat/WebChatVisitorTokenTest.java
@@ -2,90 +2,122 @@ package vip.mate.channel.webchat;
 
 import org.junit.jupiter.api.Test;
 
+import java.time.Instant;
+
 import static org.junit.jupiter.api.Assertions.*;
 
 /**
  * PR #297 P1 IDOR 修复回归测试：list/messages/delete 端点的鉴权不能再只靠调用方自报的 visitorId，
  * 必须验证服务端用密钥签发的 visitor token。这里覆盖 token 的签发/校验语义。
+ * <p>注:V148 之后 token 形态变成 {@code <base64sig>.<expEpochSec>},exp 参与签名;
+ * 撤销表查询由实例 {@link WebChatController#verifyVisitorToken} 接入,签名 + 过期
+ * 部分通过 {@link WebChatController#verifyVisitorTokenSignature} static 暴露给单测。
  */
 class WebChatVisitorTokenTest {
 
     private static final String SECRET = "test-secret-do-not-use-in-prod";
     private static final Long CHANNEL = 7L;
     private static final String VISITOR = "visitor-abc";
+    private static final long FAR_FUTURE = Instant.now().getEpochSecond() + 3_600L;
 
     // ==================== 签发 ====================
 
     @Test
     void token_isDeterministic_forSameInputs() {
         assertEquals(
-                WebChatController.computeVisitorToken(SECRET, CHANNEL, VISITOR),
-                WebChatController.computeVisitorToken(SECRET, CHANNEL, VISITOR));
+                WebChatController.computeVisitorToken(SECRET, CHANNEL, VISITOR, FAR_FUTURE),
+                WebChatController.computeVisitorToken(SECRET, CHANNEL, VISITOR, FAR_FUTURE));
     }
 
     @Test
     void token_differsPerVisitor() {
         assertNotEquals(
-                WebChatController.computeVisitorToken(SECRET, CHANNEL, "alice"),
-                WebChatController.computeVisitorToken(SECRET, CHANNEL, "bob"));
+                WebChatController.computeVisitorToken(SECRET, CHANNEL, "alice", FAR_FUTURE),
+                WebChatController.computeVisitorToken(SECRET, CHANNEL, "bob", FAR_FUTURE));
     }
 
     @Test
     void token_isChannelBound_notPortable() {
         // 同一 visitorId 在不同渠道下 token 不同 → 持 A 渠道 token 不能操作 B 渠道同名 visitor。
         assertNotEquals(
-                WebChatController.computeVisitorToken(SECRET, 1L, VISITOR),
-                WebChatController.computeVisitorToken(SECRET, 2L, VISITOR));
+                WebChatController.computeVisitorToken(SECRET, 1L, VISITOR, FAR_FUTURE),
+                WebChatController.computeVisitorToken(SECRET, 2L, VISITOR, FAR_FUTURE));
     }
 
     @Test
     void token_dependsOnSecret() {
         assertNotEquals(
-                WebChatController.computeVisitorToken("secret-a", CHANNEL, VISITOR),
-                WebChatController.computeVisitorToken("secret-b", CHANNEL, VISITOR));
+                WebChatController.computeVisitorToken("secret-a", CHANNEL, VISITOR, FAR_FUTURE),
+                WebChatController.computeVisitorToken("secret-b", CHANNEL, VISITOR, FAR_FUTURE));
     }
 
-    // ==================== 校验 ====================
+    @Test
+    void token_differsWhenExpirationDiffers() {
+        // Two tokens for the same (channel, visitor) but different exp must differ —
+        // otherwise a leaked old token could be replayed past its expiry.
+        assertNotEquals(
+                WebChatController.computeVisitorToken(SECRET, CHANNEL, VISITOR, FAR_FUTURE),
+                WebChatController.computeVisitorToken(SECRET, CHANNEL, VISITOR, FAR_FUTURE + 60));
+    }
+
+    // ==================== 校验(签名 + 过期) ====================
 
     @Test
     void verify_acceptsTokenIssuedForSameVisitor() {
-        String token = WebChatController.computeVisitorToken(SECRET, CHANNEL, VISITOR);
-        assertTrue(WebChatController.verifyVisitorToken(SECRET, CHANNEL, VISITOR, token));
+        String token = WebChatController.computeVisitorToken(SECRET, CHANNEL, VISITOR, FAR_FUTURE);
+        assertTrue(WebChatController.verifyVisitorTokenSignature(SECRET, CHANNEL, VISITOR, token));
     }
 
     @Test
     void verify_rejectsForgedVisitorIdWithoutToken() {
         // 攻击者持公开 key，传受害者 visitorId，但拿不到对应 token。
-        assertFalse(WebChatController.verifyVisitorToken(SECRET, CHANNEL, "victim", null));
-        assertFalse(WebChatController.verifyVisitorToken(SECRET, CHANNEL, "victim", ""));
+        assertFalse(WebChatController.verifyVisitorTokenSignature(SECRET, CHANNEL, "victim", null));
+        assertFalse(WebChatController.verifyVisitorTokenSignature(SECRET, CHANNEL, "victim", ""));
     }
 
     @Test
     void verify_rejectsTokenMintedForAnotherVisitor() {
         // 攻击者拿自己 visitor 的合法 token，去操作受害者 visitor → 必须失败。
-        String attackerToken = WebChatController.computeVisitorToken(SECRET, CHANNEL, "attacker");
-        assertFalse(WebChatController.verifyVisitorToken(SECRET, CHANNEL, "victim", attackerToken));
+        String attackerToken = WebChatController.computeVisitorToken(SECRET, CHANNEL, "attacker", FAR_FUTURE);
+        assertFalse(WebChatController.verifyVisitorTokenSignature(SECRET, CHANNEL, "victim", attackerToken));
     }
 
     @Test
     void verify_rejectsTokenFromAnotherChannel() {
-        String tokenForChannel1 = WebChatController.computeVisitorToken(SECRET, 1L, VISITOR);
-        assertFalse(WebChatController.verifyVisitorToken(SECRET, 2L, VISITOR, tokenForChannel1));
+        String tokenForChannel1 = WebChatController.computeVisitorToken(SECRET, 1L, VISITOR, FAR_FUTURE);
+        assertFalse(WebChatController.verifyVisitorTokenSignature(SECRET, 2L, VISITOR, tokenForChannel1));
     }
 
     @Test
     void verify_rejectsTamperedToken() {
-        String token = WebChatController.computeVisitorToken(SECRET, CHANNEL, VISITOR);
+        String token = WebChatController.computeVisitorToken(SECRET, CHANNEL, VISITOR, FAR_FUTURE);
         String tampered = token.substring(0, token.length() - 1)
                 + (token.endsWith("A") ? "B" : "A");
-        assertFalse(WebChatController.verifyVisitorToken(SECRET, CHANNEL, VISITOR, tampered));
+        assertFalse(WebChatController.verifyVisitorTokenSignature(SECRET, CHANNEL, VISITOR, tampered));
     }
 
     @Test
     void verify_rejectsNullChannelOrVisitor() {
-        String token = WebChatController.computeVisitorToken(SECRET, CHANNEL, VISITOR);
-        assertFalse(WebChatController.verifyVisitorToken(SECRET, null, VISITOR, token));
-        assertFalse(WebChatController.verifyVisitorToken(SECRET, CHANNEL, null, token));
+        String token = WebChatController.computeVisitorToken(SECRET, CHANNEL, VISITOR, FAR_FUTURE);
+        assertFalse(WebChatController.verifyVisitorTokenSignature(SECRET, null, VISITOR, token));
+        assertFalse(WebChatController.verifyVisitorTokenSignature(SECRET, CHANNEL, null, token));
+    }
+
+    @Test
+    void verify_rejectsExpiredToken() {
+        long past = Instant.now().getEpochSecond() - 60;
+        String token = WebChatController.computeVisitorToken(SECRET, CHANNEL, VISITOR, past);
+        assertFalse(WebChatController.verifyVisitorTokenSignature(SECRET, CHANNEL, VISITOR, token));
+    }
+
+    @Test
+    void verify_rejectsTamperedExpiration() {
+        // Attacker takes a valid token and bumps the exp — but exp participates in
+        // the HMAC, so the signature no longer matches.
+        String token = WebChatController.computeVisitorToken(SECRET, CHANNEL, VISITOR, FAR_FUTURE);
+        int dot = token.lastIndexOf('.');
+        String tampered = token.substring(0, dot + 1) + (FAR_FUTURE + 3_600);
+        assertFalse(WebChatController.verifyVisitorTokenSignature(SECRET, CHANNEL, VISITOR, tampered));
     }
 
     // ============ conversationId / username 边界（避免溢出 VARCHAR(64) → /stream 500）============

--- a/mateclaw-server/src/test/java/vip/mate/workspace/conversation/ConversationServiceExternalViewTest.java
+++ b/mateclaw-server/src/test/java/vip/mate/workspace/conversation/ConversationServiceExternalViewTest.java
@@ -1,0 +1,84 @@
+package vip.mate.workspace.conversation;
+
+import com.baomidou.mybatisplus.core.conditions.query.LambdaQueryWrapper;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.Spy;
+import org.mockito.junit.jupiter.MockitoExtension;
+import vip.mate.agent.repository.AgentMapper;
+import vip.mate.workspace.conversation.model.MessageEntity;
+import vip.mate.workspace.conversation.repository.ConversationMapper;
+import vip.mate.workspace.conversation.repository.MessageMapper;
+import vip.mate.workspace.conversation.vo.MessageVO;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
+
+/**
+ * Pin that the external (webchat-facing) message view never leaks the
+ * server-side absolute file path — neither in the structured {@code path} field
+ * nor in the rendered text — while the internal view still carries it for the
+ * agent's file tools.
+ */
+@ExtendWith(MockitoExtension.class)
+class ConversationServiceExternalViewTest {
+
+    @Mock private ConversationMapper conversationMapper;
+    @Mock private MessageMapper messageMapper;
+    @Mock private AgentMapper agentMapper;
+    @Spy private ObjectMapper objectMapper = new ObjectMapper();
+
+    @InjectMocks private ConversationService service;
+
+    private static final String SECRET_PATH = "/srv/mateclaw/data/chat-uploads/secret/doc.pdf";
+
+    private MessageEntity fileMessage() {
+        MessageEntity m = new MessageEntity();
+        m.setId(1L);
+        m.setConversationId("c1");
+        m.setRole("assistant");
+        m.setContent("here is your file");
+        m.setContentParts("[{\"type\":\"file\",\"fileName\":\"doc.pdf\",\"path\":\""
+                + SECRET_PATH + "\"}]");
+        m.setStatus("completed");
+        m.setCreateTime(LocalDateTime.now());
+        return m;
+    }
+
+    @Test
+    @DisplayName("external view nulls part.path and omits path from rendered text")
+    void externalViewStripsPath() {
+        when(messageMapper.selectList(any(LambdaQueryWrapper.class)))
+                .thenReturn(List.of(fileMessage()));
+
+        List<MessageVO> views = service.listMessageViewsExternal("c1");
+
+        assertThat(views).hasSize(1);
+        MessageVO vo = views.get(0);
+        assertThat(vo.getContentParts().get(0).getPath()).isNull();
+        assertThat(vo.getContent()).doesNotContain(SECRET_PATH);
+        assertThat(vo.getContent()).doesNotContain("路径");
+        // filename still surfaced so the visitor can recognize the attachment
+        assertThat(vo.getContent()).contains("doc.pdf");
+    }
+
+    @Test
+    @DisplayName("internal view keeps the path for the agent's file tools")
+    void internalViewKeepsPath() {
+        when(messageMapper.selectList(any(LambdaQueryWrapper.class)))
+                .thenReturn(List.of(fileMessage()));
+
+        List<MessageVO> views = service.listMessageViews("c1");
+
+        assertThat(views.get(0).getContentParts().get(0).getPath()).isEqualTo(SECRET_PATH);
+        assertThat(views.get(0).getContent()).contains(SECRET_PATH);
+    }
+}

--- a/mateclaw-server/src/test/java/vip/mate/workspace/conversation/ConversationServiceExternalViewTest.java
+++ b/mateclaw-server/src/test/java/vip/mate/workspace/conversation/ConversationServiceExternalViewTest.java
@@ -81,4 +81,15 @@ class ConversationServiceExternalViewTest {
         assertThat(views.get(0).getContentParts().get(0).getPath()).isEqualTo(SECRET_PATH);
         assertThat(views.get(0).getContent()).contains(SECRET_PATH);
     }
+
+    @Test
+    @DisplayName("toExternalMessageViews strips path on a pre-loaded list (paginated path)")
+    void toExternalMessageViewsStripsPath() {
+        // Used by the paginated webchat endpoint, which loads entities itself.
+        List<MessageVO> views = service.toExternalMessageViews(List.of(fileMessage()));
+
+        assertThat(views).hasSize(1);
+        assertThat(views.get(0).getContentParts().get(0).getPath()).isNull();
+        assertThat(views.get(0).getContent()).doesNotContain(SECRET_PATH);
+    }
 }


### PR DESCRIPTION
## Summary

Epic #355 PR 3 — 给访客自己管理会话状态的能力(管理员后台早就有,webchat 一直缺)。

## Changes

两个新端点,跟 \`PUT /sessions/title\` 同形(PUT + body + query):

| 端点 | 行为 |
|---|---|
| \`PUT /api/v1/channels/webchat/sessions/pinned\` | 翻转 \`mate_conversation.pinned\`;pinned 线程在访客 /sessions 列表排前 |
| \`PUT /api/v1/channels/webchat/sessions/archive\` | 翻转 \`mate_conversation.archived\`;archived 线程默认从 /sessions 隐藏,需 \`includeArchived=true\` 才看到 |

**archive dominates pin**:archived+pinned 仍隐藏(避免访客置顶后又归档导致状态矛盾)。

\`ConversationService.setArchived()\` 新加,镜像 \`setPinned()\` 模式。

## Test plan

\`WebChatArchivePinTest\` (\`@SpringBootTest\` + H2,6 case):

- [x] pin 翻转列 + view 反映 \`pinned=1\`
- [x] archive 从默认列表隐藏,\`includeArchived=true\` 显示,\`un-archive\` 恢复
- [x] archived+pinned 仍隐藏(archive dominates)
- [x] 错误 body / 错误类型 → 400
- [x] 未知 sessionId → 404
- [x] 坏 token → 401

## Stack

依赖 PR 1(\`archived\` 列)和 PR 2(visitorToken 撤销 + 实例方法)。

环境:v1.6.0-SNAPSHOT