### PR TITLE
fix(conversation): exclude malformed conversationIds from admin list/page

### DIFF
--- a/mateclaw-server/src/main/java/vip/mate/workspace/conversation/ConversationService.java
+++ b/mateclaw-server/src/main/java/vip/mate/workspace/conversation/ConversationService.java
@@ -150,6 +150,7 @@ public class ConversationService {
         boolean includeWebchat = includeChannelPrincipals && isGlobalAdmin(username);
         LambdaQueryWrapper<ConversationEntity> wrapper = new LambdaQueryWrapper<ConversationEntity>()
                 .and(w -> applyOwnerScope(w, username, includeWebchat))
+                .and(this::applyMalformedIdGuard)
                 .isNull(ConversationEntity::getParentConversationId)
                 .orderByDesc(ConversationEntity::getPinned)
                 .orderByDesc(ConversationEntity::getLastActiveTime);
@@ -204,6 +205,17 @@ public class ConversationService {
     }
 
     /**
+     * Exclude rows whose conversationId ends in ":" — malformed (e.g.
+     * {@code webchat:<key8>:} with empty visitorId, from older versions).
+     * Showing them in the console surfaces threads that 500/403 on open
+     * because the trailing ":" makes some reverse proxies strip the path
+     * tail (issue #369).
+     */
+    private void applyMalformedIdGuard(LambdaQueryWrapper<ConversationEntity> w) {
+        w.notLike(ConversationEntity::getConversationId, "%:");
+    }
+
+    /**
      * Whether the user is a global admin (role=admin), resolved from the DB —
      * never from client-controlled data. Gates webchat row visibility in the
      * admin-console list/page: {@link #isConversationOwner} only lets a global
@@ -239,6 +251,7 @@ public class ConversationService {
         // conversation (issue #344), so non-admins must not see those rows.
         LambdaQueryWrapper<ConversationEntity> wrapper = new LambdaQueryWrapper<ConversationEntity>()
                 .and(w -> applyOwnerScope(w, username, isGlobalAdmin(username)))
+                .and(this::applyMalformedIdGuard)
                 .isNull(ConversationEntity::getParentConversationId)
                 .orderByDesc(ConversationEntity::getPinned)
                 .orderByDesc(ConversationEntity::getLastActiveTime);

--- a/mateclaw-server/src/main/java/vip/mate/workspace/conversation/ConversationService.java
+++ b/mateclaw-server/src/main/java/vip/mate/workspace/conversation/ConversationService.java
@@ -210,9 +210,18 @@ public class ConversationService {
      * Showing them in the console surfaces threads that 500/403 on open
      * because the trailing ":" makes some reverse proxies strip the path
      * tail (issue #369).
+     *
+     * <p>Uses {@code notLikeLeft} rather than {@code notLike(...,"%:")}: the
+     * latter auto-wraps the value with extra {@code %} on both sides AND
+     * escapes the user-supplied {@code %}, producing a {@code %%:%} pattern
+     * that matches <em>any id containing a colon</em> — silently filtering
+     * out every {@code webchat:…}, {@code feishu:…}, {@code cron:…}
+     * conversation from the list. {@code notLikeLeft} only prepends the
+     * wildcard, giving the intended {@code NOT LIKE '%:'} ("does not end
+     * with a colon").
      */
     private void applyMalformedIdGuard(LambdaQueryWrapper<ConversationEntity> w) {
-        w.notLike(ConversationEntity::getConversationId, "%:");
+        w.notLikeLeft(ConversationEntity::getConversationId, ":");
     }
 
     /**

--- a/mateclaw-server/src/test/java/vip/mate/workspace/conversation/ConversationServiceWebchatVisibilityTest.java
+++ b/mateclaw-server/src/test/java/vip/mate/workspace/conversation/ConversationServiceWebchatVisibilityTest.java
@@ -156,12 +156,12 @@ class ConversationServiceWebchatVisibilityTest {
 
         service.listConversations("admin", 1L, true);
 
-        // Assert on the rendered SQL (not the param values, which MyBatis-Plus
-        // percent-escapes internally) so the test stays independent of that
-        // implementation detail.
-        String sql = captor.getValue().getTargetSql().toLowerCase();
-        assertThat(sql).contains("not like");
-        assertThat(sql).contains("conversation_id");
+        // The bound LIKE pattern must be exactly "%:" (ends-with colon), not
+        // "%%:%" (contains colon). The earlier notLike("%:") form produced
+        // the latter via MyBatis-Plus auto-wrapping + percent-escape, which
+        // filtered out every webchat:… / feishu:… / cron:… conversation.
+        assertThat(captor.getValue().getTargetSql().toLowerCase()).contains("not like");
+        assertThat(captor.getValue().getParamNameValuePairs().values()).contains("%:");
     }
 
     @Test
@@ -175,9 +175,10 @@ class ConversationServiceWebchatVisibilityTest {
 
         service.pageConversations("admin", 1L, 1, 20, null);
 
-        String sql = captor.getValue().getTargetSql().toLowerCase();
-        assertThat(sql).contains("not like");
-        assertThat(sql).contains("conversation_id");
+        // Force the nested-wrapper param merge: getParamNameValuePairs() is
+        // empty until getTargetSql() (or equivalent) has been called once.
+        assertThat(captor.getValue().getTargetSql().toLowerCase()).contains("not like");
+        assertThat(captor.getValue().getParamNameValuePairs().values()).contains("%:");
     }
 
     @Test
@@ -189,9 +190,9 @@ class ConversationServiceWebchatVisibilityTest {
 
         service.listConversations("admin", 1L); // strict 2-arg
 
-        String sql = captor.getValue().getTargetSql().toLowerCase();
-        assertThat(sql).contains("not like");
-        assertThat(sql).contains("conversation_id");
+        // Force the nested-wrapper param merge before checking values.
+        assertThat(captor.getValue().getTargetSql().toLowerCase()).contains("not like");
+        assertThat(captor.getValue().getParamNameValuePairs().values()).contains("%:");
     }
 
     private static UserEntity user(String role) {

--- a/mateclaw-server/src/test/java/vip/mate/workspace/conversation/ConversationServiceWebchatVisibilityTest.java
+++ b/mateclaw-server/src/test/java/vip/mate/workspace/conversation/ConversationServiceWebchatVisibilityTest.java
@@ -79,7 +79,7 @@ class ConversationServiceWebchatVisibilityTest {
     }
 
     @Test
-    @DisplayName("lenient list, non-admin: excludes webchat principals (no LIKE clause)")
+    @DisplayName("lenient list, non-admin: excludes webchat principals (no 'webchat:%' param)")
     void lenientListNonAdminExcludesWebchat() {
         when(authService.findByUsername("alice")).thenReturn(user("member"));
         ArgumentCaptor<LambdaQueryWrapper<ConversationEntity>> captor =
@@ -88,12 +88,14 @@ class ConversationServiceWebchatVisibilityTest {
 
         service.listConversations("alice", 1L, true);
 
-        String sql = captor.getValue().getTargetSql();
-        assertThat(sql).doesNotContainIgnoringCase("like");
+        // The malformed-id guard still emits a NOT LIKE, so we assert on the
+        // param value instead of the LIKE keyword.
+        assertThat(captor.getValue().getParamNameValuePairs().values())
+                .doesNotContain("webchat:%");
     }
 
     @Test
-    @DisplayName("strict list excludes webchat principals (no LIKE clause, no role lookup)")
+    @DisplayName("strict list excludes webchat principals (no 'webchat:%' param, no role lookup)")
     void strictListExcludesWebchat() {
         ArgumentCaptor<LambdaQueryWrapper<ConversationEntity>> captor =
                 ArgumentCaptor.forClass(LambdaQueryWrapper.class);
@@ -101,8 +103,8 @@ class ConversationServiceWebchatVisibilityTest {
 
         service.listConversations("admin", 1L); // strict 2-arg
 
-        String sql = captor.getValue().getTargetSql();
-        assertThat(sql).doesNotContainIgnoringCase("like");
+        assertThat(captor.getValue().getParamNameValuePairs().values())
+                .doesNotContain("webchat:%");
     }
 
     @Test
@@ -133,8 +135,63 @@ class ConversationServiceWebchatVisibilityTest {
 
         service.pageConversations("alice", 1L, 1, 20, null);
 
-        String sql = captor.getValue().getTargetSql();
-        assertThat(sql).doesNotContainIgnoringCase("like");
+        assertThat(captor.getValue().getParamNameValuePairs().values())
+                .doesNotContain("webchat:%");
+    }
+
+    // ------------------------------------------------------------------
+    // Malformed conversationId guard — rows whose id ends in ":" (e.g. an
+    // empty-visitorId webchat thread) are filtered out of every admin list
+    // query, regardless of role. Surfacing them triggers 500/403 on open
+    // because the trailing ":" confuses some reverse proxies (issue #369).
+    // ------------------------------------------------------------------
+
+    @Test
+    @DisplayName("lenient list: applies NOT LIKE '%:' guard to filter malformed ids")
+    void lenientListAppliesMalformedIdGuard() {
+        when(authService.findByUsername("admin")).thenReturn(user("admin"));
+        ArgumentCaptor<LambdaQueryWrapper<ConversationEntity>> captor =
+                ArgumentCaptor.forClass(LambdaQueryWrapper.class);
+        when(conversationMapper.selectList(captor.capture())).thenReturn(List.of());
+
+        service.listConversations("admin", 1L, true);
+
+        // Assert on the rendered SQL (not the param values, which MyBatis-Plus
+        // percent-escapes internally) so the test stays independent of that
+        // implementation detail.
+        String sql = captor.getValue().getTargetSql().toLowerCase();
+        assertThat(sql).contains("not like");
+        assertThat(sql).contains("conversation_id");
+    }
+
+    @Test
+    @DisplayName("page query: applies the same NOT LIKE '%:' guard")
+    void pageAppliesMalformedIdGuard() {
+        when(authService.findByUsername("admin")).thenReturn(user("admin"));
+        ArgumentCaptor<LambdaQueryWrapper<ConversationEntity>> captor =
+                ArgumentCaptor.forClass(LambdaQueryWrapper.class);
+        when(conversationMapper.selectPage(any(Page.class), captor.capture()))
+                .thenReturn(new Page<>());
+
+        service.pageConversations("admin", 1L, 1, 20, null);
+
+        String sql = captor.getValue().getTargetSql().toLowerCase();
+        assertThat(sql).contains("not like");
+        assertThat(sql).contains("conversation_id");
+    }
+
+    @Test
+    @DisplayName("strict list also applies the guard — malformed ids never leak to owner-only views")
+    void strictListAppliesMalformedIdGuard() {
+        ArgumentCaptor<LambdaQueryWrapper<ConversationEntity>> captor =
+                ArgumentCaptor.forClass(LambdaQueryWrapper.class);
+        when(conversationMapper.selectList(captor.capture())).thenReturn(List.of());
+
+        service.listConversations("admin", 1L); // strict 2-arg
+
+        String sql = captor.getValue().getTargetSql().toLowerCase();
+        assertThat(sql).contains("not like");
+        assertThat(sql).contains("conversation_id");
     }
 
     private static UserEntity user(String role) {


### PR DESCRIPTION
## Summary

- New helper `ConversationService.applyMalformedIdGuard` adds a `NOT LIKE '%:'` clause to every admin list/page query, excluding rows whose `conversationId` ends in `:` (e.g. `webchat:<key8>:` with an empty visitorId, from older webchat versions before `normalizeVisitorId` tightened its check).
- Applied to `listConversations` (lenient 3-arg + strict 2-arg overload) and `pageConversations`, so the sidebar and the Sessions admin page stay in lockstep.
- 3 new tests pin the guard on all three code paths; 2 existing assertions updated to assert on param values (`webchat:%`) instead of the LIKE keyword, since the new guard emits a NOT LIKE of its own.

## Why

conversationId ending in `:` leaks into the admin console via the existing `username LIKE 'webchat:%'` clause (issue #340), then 500/403s on open — the trailing `:` makes some reverse proxies (Zeabur / Tencent Cloud, in production) strip the path tail, landing a `GET /api/v1/conversations/<id>` on the `@DeleteMapping("/{conversationId}")` variant. The reverse-proxy behaviour is what surfaced as the user-visible 500, but the root cause is the malformed row being in the list at all.

Once these rows are filtered out of every admin-visible list, the bug stops reproducing — admins never get the malformed `conversationId` to click. `isConversationOwner` already rejects unknown ids with 403, so direct-access endpoints (`/{conversationId}/messages`, `/{conversationId}/status`, …) need no change.

The HTTP-layer defence (return 405 instead of 500 when a path/method mismatch does occur) is a separate PR — #370. Kept apart so each layer can be reviewed/reverted independently.

## Behaviour change to call out

Existing rows with `conversation_id LIKE '%:'` will **disappear from the admin sidebar and Sessions page**. They were already broken (every click was a 500); the only callers that can still reach them are direct API hits with a known id, which return 403 via `isConversationOwner` exactly as before.

Operators who want to actually delete the rows can run the SQL from issue #369.

## Test plan

- [x] `mvn test -Dtest='ConversationService*' -pl mateclaw-server -am` — 49 tests, 0 failures (3 new + 46 regression)
- [x] Manual: with the change deployed, an `admin` no longer sees `webchat:mc_webch:` in the conversation list

Closes the webchat-specific layer of #369. The 500→405 layer is #370.