### PR TITLE
fix(ui): URL-encode conversationId in path segments

### DIFF
--- a/mateclaw-ui/src/api/index.ts
+++ b/mateclaw-ui/src/api/index.ts
@@ -9,6 +9,17 @@ import type {
   GrantScope,
 } from '@/types'
 
+/**
+ * URL-encode a conversation id before interpolating it into a path. Some ids
+ * contain characters that the browser interprets as URL structural — notably
+ * `#`, which webchat emits as a hash marker when the visitorId+sessionId pair
+ * exceeds the conversation_id column width (see WebChatController#deriveConversationId:
+ * `webchat:<key8>:#<sha256[0..40]>`). Without encoding, everything after the
+ * `#` is treated as a fragment and never reaches the server, producing 405 on
+ * `@DeleteMapping` fallbacks and 403 from the owner check.
+ */
+const encId = (id: string) => encodeURIComponent(id)
+
 // Axios 实例
 export const http = axios.create({
   baseURL: '/api/v1',
@@ -156,9 +167,9 @@ export const chatApi = {
     })
   },
   stop: (conversationId: string) =>
-    http.post<{ stopped: boolean }>(`/chat/${conversationId}/stop`),
+    http.post<{ stopped: boolean }>(`/chat/${encId(conversationId)}/stop`),
   getPendingApprovals: (conversationId: string) =>
-    http.get(`/chat/${conversationId}/pending-approvals`),
+    http.get(`/chat/${encId(conversationId)}/pending-approvals`),
 }
 
 // ==================== Conversation ====================
@@ -172,17 +183,17 @@ export const conversationApi = {
   page: (params: { page?: number; size?: number; keyword?: string }) =>
     http.get('/conversations/page', { params }),
   listMessages: (conversationId: string, params?: { beforeId?: number; limit?: number }) =>
-    http.get(`/conversations/${conversationId}/messages`, { params }),
+    http.get(`/conversations/${encId(conversationId)}/messages`, { params }),
   getStatus: (conversationId: string) =>
-    http.get(`/conversations/${conversationId}/status`),
+    http.get(`/conversations/${encId(conversationId)}/status`),
   delete: (conversationId: string) =>
-    http.delete(`/conversations/${conversationId}`),
+    http.delete(`/conversations/${encId(conversationId)}`),
   clearMessages: (conversationId: string) =>
-    http.delete(`/conversations/${conversationId}/messages`),
+    http.delete(`/conversations/${encId(conversationId)}/messages`),
   rename: (conversationId: string, title: string) =>
-    http.put(`/conversations/${conversationId}/title`, { title }),
+    http.put(`/conversations/${encId(conversationId)}/title`, { title }),
   setPinned: (conversationId: string, pinned: boolean) =>
-    http.put(`/conversations/${conversationId}/pin`, { pinned }),
+    http.put(`/conversations/${encId(conversationId)}/pin`, { pinned }),
   /**
    * Pin this conversation to a specific (provider, model). Closes issue
    * #183 — lets the admin UI switch model for IM-channel conversations
@@ -190,7 +201,7 @@ export const conversationApi = {
    * not just for the Web channel. Both params required and non-empty.
    */
   setModel: (conversationId: string, modelProvider: string, modelName: string) =>
-    http.put(`/conversations/${conversationId}/model`, { modelProvider, modelName }),
+    http.put(`/conversations/${encId(conversationId)}/model`, { modelProvider, modelName }),
   batchDelete: (conversationIds: string[]) =>
     http.post('/conversations/batch-delete', { conversationIds }),
 }
@@ -1377,7 +1388,7 @@ export const goalApi = {
   }) => http.post<Goal>('/goals', data),
 
   findActive: (conversationId: string) =>
-    http.get<Goal | null>(`/goals/by-conversation/${conversationId}`),
+    http.get<Goal | null>(`/goals/by-conversation/${encId(conversationId)}`),
 
   get: (id: string) => http.get<Goal>(`/goals/${id}`),
 


### PR DESCRIPTION
## 问题

Admin 控制台无法打开某些 webchat 会话。控制台报错:

- `GET /api/v1/conversations/webchat:mc_webch:` → 405 Method Not Allowed
- `GET /api/v1/goals/by-conversation/webchat:mc_webch:` → 403 Not the owner

## 根因

`WebChatController#deriveConversationId` 在 `visitorId + sessionId` 拼出来的 id 超过 `conversation_id` 列宽 (VARCHAR 64) 时,把可变部分折叠成 SHA-256 哈希,并用 `#` 作前缀:

```
webchat:<key8>:#<sha256[0..40]>
```

`#` 是 URL fragment 分隔符。前端把 `conversationId` 直接插值进 URL 路径片段时,浏览器把 `#` 之后的部分当作 fragment,**根本不会发送到服务端**。所以服务端收到的 path 被截断成 `webchat:<key8>:`,进而:
- `/api/v1/conversations/webchat:<key8>:` 匹配 `@DeleteMapping("/{conversationId}")`,GET 不支持 → 405
- `/api/v1/goals/by-conversation/webchat:<key8>:` 匹配 owner 检查,因为 id 不存在(真实 id 是带 `#hash` 的) → 403

## 修复

前端加 `encId(id) = encodeURIComponent(id)` 帮助函数,并应用到所有把 `conversationId` 插值进 URL 路径的位置:

- `chat/${conversationId}/stop`、`chat/${conversationId}/pending-approvals`
- `conversations/${conversationId}{,/messages,/status,/title,/pin,/model}`
- `goals/by-conversation/${conversationId}`

服务端的 `@PathVariable` 解码器透明处理百分号编码,所以这是纯客户端修复,立刻恢复**所有**已存在的 `#` 前缀会话。

## 后续

后端的 `#` 前缀只是惯例,改成 URL-safe 字符(如 `_`)可以避免依赖前端编码,但本 PR 只做一件事——客户端编码——保证单一关注点。后端清理另开 PR。

## 测试

`vue-tsc --noEmit` 通过。手动验证:点击控制台里 `webchat:mc_webch:#546cae15...` 这类会话,现在能正常加载消息、goals、status,不再 405/403。