### PR TITLE
feat(webchat): expose agent-bound wiki pages to API-Key callers

### DIFF
--- a/mateclaw-server/src/main/java/vip/mate/agent/binding/service/AgentBindingService.java
+++ b/mateclaw-server/src/main/java/vip/mate/agent/binding/service/AgentBindingService.java
@@ -976,6 +976,32 @@ public class AgentBindingService implements AgentBindingResolver {
     }
 
     /**
+     * Effective KB ids the agent may see. Three states (mirror
+     * {@link #getBoundSkillIds}):
+     *
+     * <ul>
+     *   <li>{@code null} — no binding rows. Caller treats this as "no
+     *       agent-level restriction; inherit every KB in the agent's
+     *       workspace" (the default wiki-tool behavior).</li>
+     *   <li>{@code Set.of()} — rows exist but none are {@code enabled=true}.
+     *       Caller treats this as "explicitly scoped to zero KBs".</li>
+     *   <li>non-empty set — the explicit allowlist.</li>
+     * </ul>
+     */
+    @Override
+    public Set<Long> getBoundKbIds(Long agentId) {
+        List<AgentWikiKbBinding> bindings = listKbBindings(agentId);
+        if (bindings.isEmpty()) {
+            return null;
+        }
+        return bindings.stream()
+                .filter(b -> Boolean.TRUE.equals(b.getEnabled()))
+                .map(AgentWikiKbBinding::getKbId)
+                .filter(Objects::nonNull)
+                .collect(Collectors.toSet());
+    }
+
+    /**
      * Replace the agent's KB access scope. An empty / null list clears the
      * scope, returning the agent to workspace-wide (unrestricted) access.
      * Every incoming KB must live in the agent's workspace — pinning a KB

--- a/mateclaw-server/src/main/java/vip/mate/channel/webchat/WebChatController.java
+++ b/mateclaw-server/src/main/java/vip/mate/channel/webchat/WebChatController.java
@@ -77,6 +77,8 @@ public class WebChatController {
     private final vip.mate.audit.service.AuditEventService auditService;
     private final vip.mate.llm.routing.AgentBindingResolver agentBindingResolver;
     private final vip.mate.skill.repository.SkillMapper skillMapper;
+    private final vip.mate.wiki.repository.WikiPageMapper wikiPageMapper;
+    private final vip.mate.wiki.repository.WikiKnowledgeBaseMapper wikiKbMapper;
 
     /** Visitor-token TTL in seconds (7 days). Mirrors GeneratedFileCache's TTL. */
     static final long VISITOR_TOKEN_TTL_SECONDS = 7 * 24 * 3600L;
@@ -374,10 +376,167 @@ public class WebChatController {
                 .toList());
     }
 
+    /**
+     * 列出访客可见的 wiki 页面，供下游自建「`[[slug]]` 引用 picker」UI。
+     * <p>
+     * 鉴权链跟 {@link #listSkills} 一致：API Key 解析 channel + visitorToken
+     * HMAC 校验。{@code agentId} 可选，缺省回落到 channel 绑定的 agent；
+     * 必须属于该 channel 的 workspace（沿用 {@code /stream} 的反越权路径）。
+     * <p>
+     * 可见范围 = agent 绑定的 KB（无显式绑定时回落到 workspace 内全部 KB）
+     * 下的所有 page，排除 {@code pageType=synthesis}（LLM 中间产物）。
+     * 上限 {@value WEBCHAT_WIKI_PICKER_MAX_PAGES}：超出时强制要求 {@code keyword}。
+     * <p>
+     * 出参仅暴露展示级元数据（slug / title / summary / pageType / kbId /
+     * kbName），不包含正文、embedding、sourceRawIds 等内部字段。
+     */
+    @Operation(summary = "列出访客可见 wiki 页面（供 [[slug]] picker UI）")
+    @GetMapping("/wiki/pages")
+    public R<List<WebChatWikiPageView>> listWikiPages(
+            @RequestHeader("X-MC-Key") String apiKey,
+            @RequestHeader(value = "X-MC-Visitor-Token", required = false) String visitorToken,
+            @RequestParam(required = false) Long agentId,
+            @RequestParam String visitorId,
+            @RequestParam(required = false) String keyword) {
+        ChannelEntity channel = resolveChannel(apiKey);
+        if (channel == null) {
+            return R.fail(401, "Invalid API Key");
+        }
+        if (!verifyVisitorToken(visitorTokenSecret, channel.getId(), visitorId, visitorToken)) {
+            return R.fail(401, "Invalid or missing visitor token");
+        }
+        // Resolve the target agent — same anti-escalation rule as /stream and
+        // /skills: an explicit agentId must belong to the channel's workspace.
+        Long resolvedAgentId = channel.getAgentId();
+        if (agentId != null) {
+            var requested = agentService.getAgent(agentId);
+            if (requested == null) {
+                return R.fail(404, "Requested agent not found");
+            }
+            if (channel.getWorkspaceId() != null && requested.getWorkspaceId() != null
+                    && !channel.getWorkspaceId().equals(requested.getWorkspaceId())) {
+                return R.fail(403, "Requested agent does not belong to this channel's workspace");
+            }
+            resolvedAgentId = agentId;
+        }
+        if (resolvedAgentId == null) {
+            return R.ok(List.of());
+        }
+
+        // Resolve the KB scope: null = workspace-wide (every KB in the agent's
+        // workspace); non-empty set = explicit allowlist. Set.of() (rows exist
+        // but none enabled) means "agent is explicitly scoped to zero KBs" —
+        // surface as empty so the picker shows nothing rather than falling
+        // through to workspace-wide.
+        java.util.Set<Long> boundKbIds = agentBindingResolver.getBoundKbIds(resolvedAgentId);
+        Long workspaceId = channel.getWorkspaceId();
+        java.util.Set<Long> effectiveKbIds;
+        if (boundKbIds != null) {
+            if (boundKbIds.isEmpty()) {
+                return R.ok(List.of());
+            }
+            effectiveKbIds = boundKbIds;
+        } else {
+            // No explicit binding → fall back to every KB in the channel's
+            // workspace. Matches the wiki-tool behavior (an unscoped agent
+            // sees workspace-wide KBs).
+            effectiveKbIds = wikiKbMapper.selectList(
+                            new com.baomidou.mybatisplus.core.conditions.query.LambdaQueryWrapper<vip.mate.wiki.model.WikiKnowledgeBaseEntity>()
+                                    .eq(vip.mate.wiki.model.WikiKnowledgeBaseEntity::getWorkspaceId,
+                                            workspaceId == null ? 1L : workspaceId))
+                    .stream()
+                    .map(vip.mate.wiki.model.WikiKnowledgeBaseEntity::getId)
+                    .filter(java.util.Objects::nonNull)
+                    .collect(java.util.stream.Collectors.toSet());
+            if (effectiveKbIds.isEmpty()) {
+                return R.ok(List.of());
+            }
+        }
+
+        // Build the page query: KB scope + exclude hidden pageTypes + optional
+        // keyword filter on slug/title. Use a single LIKE with OR so a visitor
+        // typing "auth" matches either "auth-design" (slug) or "Auth Design" (title).
+        String trimmedKeyword = keyword == null ? null : keyword.trim();
+        boolean hasKeyword = trimmedKeyword != null && !trimmedKeyword.isEmpty();
+
+        // Cap check: if no keyword and total candidate count exceeds the cap,
+        // refuse — the caller must narrow with a keyword. Counting before
+        // selecting avoids materializing a huge list into memory.
+        // NOTE: the count wrapper is built WITHOUT ORDER BY — H2 in MySQL mode
+        // rejects "ORDER BY slug" on a COUNT(*) query (column must appear in
+        // GROUP BY). The select wrapper below adds ORDER BY slug.
+        if (!hasKeyword) {
+            long total = wikiPageMapper.selectCount(buildWikiPageFilterWrapper(effectiveKbIds, null));
+            if (total > WEBCHAT_WIKI_PICKER_MAX_PAGES) {
+                return R.fail(422, "Wiki page count (" + total
+                        + ") exceeds picker cap (" + WEBCHAT_WIKI_PICKER_MAX_PAGES
+                        + "); please provide a 'keyword' query parameter to narrow.");
+            }
+        }
+
+        List<vip.mate.wiki.model.WikiPageEntity> pages = wikiPageMapper.selectList(
+                buildWikiPageFilterWrapper(effectiveKbIds, hasKeyword ? trimmedKeyword : null)
+                        .orderByAsc(vip.mate.wiki.model.WikiPageEntity::getSlug));
+        if (pages.isEmpty()) {
+            return R.ok(List.of());
+        }
+
+        // Hydrate KB names so the picker UI can show "<kb>: <page title>" and
+        // the LLM can disambiguate when two KBs share a slug.
+        java.util.Map<Long, String> kbNames = wikiKbMapper.selectBatchIds(effectiveKbIds).stream()
+                .collect(java.util.stream.Collectors.toMap(
+                        vip.mate.wiki.model.WikiKnowledgeBaseEntity::getId,
+                        kb -> kb.getName() != null ? kb.getName() : "",
+                        (a, b) -> a));
+
+        return R.ok(pages.stream()
+                .map(p -> WebChatWikiPageView.from(p, kbNames.get(p.getKbId())))
+                .toList());
+    }
+
+    /**
+     * Build the WHERE-clause portion of the wiki-page picker query: KB scope +
+     * pageType-not-in-hidden + optional keyword LIKE on slug / title.
+     * Returned without ORDER BY so the caller can layer sorting (select) or
+     * nothing (count) on top — H2 in MySQL mode rejects ORDER BY on COUNT(*).
+     */
+    private com.baomidou.mybatisplus.core.conditions.query.LambdaQueryWrapper<vip.mate.wiki.model.WikiPageEntity>
+            buildWikiPageFilterWrapper(java.util.Set<Long> kbIds, String keyword) {
+        com.baomidou.mybatisplus.core.conditions.query.LambdaQueryWrapper<vip.mate.wiki.model.WikiPageEntity> w =
+                new com.baomidou.mybatisplus.core.conditions.query.LambdaQueryWrapper<vip.mate.wiki.model.WikiPageEntity>()
+                        .in(vip.mate.wiki.model.WikiPageEntity::getKbId, kbIds)
+                        .notIn(vip.mate.wiki.model.WikiPageEntity::getPageType, WEBCHAT_WIKI_HIDDEN_PAGE_TYPES);
+        if (keyword != null && !keyword.isEmpty()) {
+            String like = "%" + keyword + "%";
+            w.and(qq -> qq.like(vip.mate.wiki.model.WikiPageEntity::getSlug, like)
+                    .or().like(vip.mate.wiki.model.WikiPageEntity::getTitle, like));
+        }
+        return w;
+    }
+
     /** Cap on how many empty (message_count = 0) threads one visitor may hold on a
      *  channel at once. Guards against pathologic clients churning placeholder
      *  sessions without ever sending a message. */
     private static final int MAX_EMPTY_SESSIONS_PER_VISITOR = 5;
+
+    /**
+     * Upper bound on the page count the wiki-page picker will return without a
+     * keyword filter. Beyond this the caller MUST supply {@code keyword} —
+     * returning 500 pages to a visitor picker is both bandwidth-wasteful and
+     * unusable as a UI. Mirrors the slash-skill picker's "small list, search
+     * when too big" stance.
+     */
+    private static final int WEBCHAT_WIKI_PICKER_MAX_PAGES = 100;
+
+    /**
+     * Page types hidden from the visitor picker. {@code synthesis} pages are
+     * LLM-generated intermediate artifacts (compiled on demand by
+     * {@code wiki_compile_page}); they aren't curated source material and
+     * surfacing them to a downstream visitor is noise. Entity / concept /
+     * source pages are human-readable references the visitor can meaningfully
+     * point the LLM at.
+     */
+    private static final java.util.Set<String> WEBCHAT_WIKI_HIDDEN_PAGE_TYPES = java.util.Set.of("synthesis");
 
     /**
      * 显式创建一条访客会话线程（空会话）。
@@ -1474,6 +1633,38 @@ public class WebChatController {
             v.nameEn = s.getNameEn();
             v.description = s.getDescription();
             v.icon = s.getIcon();
+            return v;
+        }
+    }
+
+    /**
+     * Display-level projection of a wiki page for the visitor-facing
+     * {@code [[slug]]} picker. Carries the slug the LLM consumes (via
+     * {@code wiki_read_page(slug=…)}), the human-readable title/summary for
+     * picker UI, and the KB id + name for disambiguation when an agent is
+     * scoped to multiple KBs that may share a slug. Deliberately omits
+     * content / embedding / sourceRawIds / outgoingLinks — those stay
+     * admin-console-only.
+     */
+    @lombok.Data
+    public static class WebChatWikiPageView {
+        private Long kbId;
+        private String kbName;
+        /** Immutable slug — what the picker splices into the {@code [[slug]]} token; the LLM consumes it as {@code wiki_read_page(slug=…)}. */
+        private String slug;
+        private String title;
+        private String summary;
+        /** {@code entity} / {@code concept} / {@code source} / ... — never {@code synthesis} (filtered out upstream). Useful for picker grouping/icons. */
+        private String pageType;
+
+        static WebChatWikiPageView from(vip.mate.wiki.model.WikiPageEntity p, String kbName) {
+            WebChatWikiPageView v = new WebChatWikiPageView();
+            v.kbId = p.getKbId();
+            v.kbName = kbName;
+            v.slug = p.getSlug();
+            v.title = p.getTitle();
+            v.summary = p.getSummary();
+            v.pageType = p.getPageType();
             return v;
         }
     }

--- a/mateclaw-server/src/main/java/vip/mate/llm/routing/AgentBindingResolver.java
+++ b/mateclaw-server/src/main/java/vip/mate/llm/routing/AgentBindingResolver.java
@@ -4,8 +4,9 @@ import java.util.List;
 import java.util.Set;
 
 /**
- * Read access to an agent's skill / provider bindings, as needed by
- * {@link ProviderRouter} for capability-aware routing.
+ * Read access to an agent's skill / provider / wiki-kb bindings, as needed by
+ * {@link ProviderRouter} for capability-aware routing and by webchat
+ * endpoints that need to enumerate an agent's visible catalog.
  *
  * <p>Declared in the {@code llm} layer so the routing code depends only on
  * this abstraction. The {@code agent} layer supplies the implementation,
@@ -23,4 +24,14 @@ public interface AgentBindingResolver {
      * Provider ids the agent prefers, in priority order; empty when none.
      */
     List<String> getPreferredProviderIds(Long agentId);
+
+    /**
+     * Wiki knowledge-base ids bound to the agent, or {@code null} when the
+     * agent has no explicit KB scope (meaning "workspace-wide — every KB
+     * in the agent's workspace is visible"). Mirrors the three-state
+     * contract of {@link #getBoundSkillIds}: {@code null} = inherit
+     * default, {@code Set.of()} = explicitly scoped to nothing, non-empty
+     * = the explicit allowlist.
+     */
+    Set<Long> getBoundKbIds(Long agentId);
 }

--- a/mateclaw-server/src/main/java/vip/mate/wiki/tool/WikiTool.java
+++ b/mateclaw-server/src/main/java/vip/mate/wiki/tool/WikiTool.java
@@ -178,6 +178,10 @@ public class WikiTool {
             Use sectionHeading to read only one section by its heading text.
             The result includes a "sourceFiles" field listing the source documents this page was derived from.
             When using content from this page in your answer, cite the page title and source files.
+
+            Convention: a user message containing `[[<slug>]]` (e.g. `参考知识库页面 [[auth-design]]: ...`)
+            is a wiki-page reference inserted by the chat picker. Treat each `[[slug]]` as a request to
+            consult that page first — call this tool with the bare slug before answering.
             """)
     public String wiki_read_page(
             @ToolParam(description = "Agent ID") Long agentId,

--- a/mateclaw-server/src/main/resources/docs/en/webchat.md
+++ b/mateclaw-server/src/main/resources/docs/en/webchat.md
@@ -66,8 +66,9 @@ init({ apiKey: 'your-channel-api-key', server: 'https://<your-deployment>' })
 
 | Method | Path | Auth | Purpose |
 |---|---|---|---|
-| POST | `/stream` | API Key | SSE streaming chat (issues visitorToken) |
+| POST | `/stream` | API Key | SSE streaming chat (issues visitorToken); the body may include an optional `agentId` to override the channel's bound agent (must be in the same workspace as the channel) |
 | GET | `/config` | API Key | Get channel config (title/placeholder/...) |
+| GET | `/skills` | + visitorToken | List skills visible to this agent (for building your own slash picker UI) |
 | POST | `/sessions` | API Key | Explicitly create an empty session thread |
 | GET | `/sessions` | + visitorToken | List sessions (excludes archived by default) |
 | GET | `/sessions/page` | + visitorToken | Paginated + keyword search |
@@ -198,6 +199,37 @@ curl -X POST https://mate.example.com/api/v1/admin/webchat/revoked-visitor \
 ```
 
 After revocation, all of that visitor's management endpoints return 401 (`/stream` is unaffected and can re-issue a fresh token). Revocation state is briefly cached, so under a multi-instance deployment it takes up to ~10 minutes to fully propagate. Un-revoke via `DELETE` on the same endpoint.
+
+## Skill invocation (slash picker)
+
+The admin-console chat input shows a skill picker when you type `/`. This is a **pure frontend affordance** — selecting a skill rewrites the input box into a directive:
+
+- English: `Use the "<skill-name>" skill: <user message>`
+- Chinese: `使用「<技能名>」技能:<用户消息>`
+
+The directive goes out as a regular user message on `/stream`, and the LLM voluntarily calls the `load_skill` meta-tool when it sees it (see [skills.md](./skills.md#the-slash-menu)). The backend **does no `/` parsing**; webchat uses the exact same agent runtime as the admin console, so this path works out of the box for webchat callers.
+
+To build your own picker, first list the skills via the new endpoint:
+
+```bash
+curl https://mate.example.com/api/v1/channels/webchat/skills?visitorId=v1 \
+  -H "X-MC-Key: your-api-key" \
+  -H "X-MC-Visitor-Token: <token>"
+# returns [{"id":..., "name":"news-summary", "nameZh":"News Summary", "description":"...", "icon":"..."}]
+```
+
+The `agentId` query parameter is optional (falls back to the channel's bound agent). Only skills **explicitly bound to the agent AND enabled** are returned, sorted by slug. The response carries display-level metadata only — **no** SKILL.md content, configJson, or security scan results (those stay admin-console-only).
+
+After a user picks a skill, construct the message:
+
+```bash
+curl -N -X POST https://mate.example.com/api/v1/channels/webchat/stream \
+  -H "X-MC-Key: your-api-key" \
+  -H "Content-Type: application/json" \
+  -d '{"visitorId":"v1","message":"Use the \"news-summary\" skill: summarize the top 3 AI stories today"}'
+```
+
+> Note: the directive text relies on the LLM "obeying" and calling `load_skill`. Under complex tasks it occasionally drifts; for production, bind the target skill to the agent and reinforce the system prompt in `AGENTS.md`.
 
 ## curl examples
 

--- a/mateclaw-server/src/main/resources/docs/en/webchat.md
+++ b/mateclaw-server/src/main/resources/docs/en/webchat.md
@@ -69,6 +69,7 @@ init({ apiKey: 'your-channel-api-key', server: 'https://<your-deployment>' })
 | POST | `/stream` | API Key | SSE streaming chat (issues visitorToken); the body may include an optional `agentId` to override the channel's bound agent (must be in the same workspace as the channel) |
 | GET | `/config` | API Key | Get channel config (title/placeholder/...) |
 | GET | `/skills` | + visitorToken | List skills visible to this agent (for building your own slash picker UI) |
+| GET | `/wiki/pages` | + visitorToken | List wiki pages visible to this agent (for building your own `[[slug]]` reference picker UI) |
 | POST | `/sessions` | API Key | Explicitly create an empty session thread |
 | GET | `/sessions` | + visitorToken | List sessions (excludes archived by default) |
 | GET | `/sessions/page` | + visitorToken | Paginated + keyword search |
@@ -230,6 +231,58 @@ curl -N -X POST https://mate.example.com/api/v1/channels/webchat/stream \
 ```
 
 > Note: the directive text relies on the LLM "obeying" and calling `load_skill`. Under complex tasks it occasionally drifts; for production, bind the target skill to the agent and reinforce the system prompt in `AGENTS.md`.
+
+## Wiki knowledge-base reference (`[[slug]]` picker)
+
+The knowledge base has a picker parallel to the slash-skill one — using the **Obsidian / Wikipedia wikilink convention `[[slug]]`**. The user types `[[` in the input box to open a picker, selects a page, and a `[[<slug>]]` token is inserted. On submit the input is rewritten into a directive text, and the LLM calls `wiki_read_page(slug=...)` to read the referenced page before answering. The backend **does no `[[` parsing** — webchat uses the exact same agent runtime as the admin console.
+
+Directive text format (**exact**):
+
+- English: `Reference the wiki page [[<slug>]]: <user message>`
+- Chinese: `参考知识库页面 [[<slug>]]：<用户消息>`
+
+Multiple references are supported naturally (just list them):
+
+```
+Reference the wiki pages [[auth-design]], [[webchat-integration]]: how do these two work together?
+```
+
+To build your own picker, first list the pages via the new endpoint:
+
+```bash
+curl "https://mate.example.com/api/v1/channels/webchat/wiki/pages?visitorId=v1" \
+  -H "X-MC-Key: your-api-key" \
+  -H "X-MC-Visitor-Token: <token>"
+# returns [{"kbId":1,"kbName":"MateClaw Docs","slug":"webchat-integration",
+#           "title":"WebChat Integration Guide","summary":"...","pageType":"source"}, ...]
+```
+
+Optional query parameters:
+
+| Parameter | Required | Notes |
+|---|---|---|
+| `visitorId` | yes | Visitor ID |
+| `agentId` | no | Override the channel's bound agent; must be in the same workspace as the channel |
+| `keyword` | no | Filter, matches `slug` OR `title` (LIKE) |
+
+Behavior:
+
+- **Scope**: KBs explicitly bound to the agent (`mate_agent_wiki_kb`); with no bindings, falls back to every KB in the workspace (mirrors the wiki-tool default)
+- **Page filter**: excludes `pageType=synthesis` (LLM intermediate artifacts)
+- **100-page cap**: when exceeded (and no `keyword`), returns `422` asking the caller to narrow with a keyword
+- **Returned fields**: only `kbId / kbName / slug / title / summary / pageType`; **no** content, embedding, sourceRawIds, or outgoingLinks (admin-console-only)
+- **Ordering**: by `slug` ascending
+
+After a user picks a page, construct the message (English directive example):
+
+```bash
+curl -N -X POST https://mate.example.com/api/v1/channels/webchat/stream \
+  -H "X-MC-Key: your-api-key" \
+  -H "Content-Type: application/json" \
+  -d '{"visitorId":"v1","message":"Reference the wiki page [[webchat-integration]]: summarize the integration flow"}'
+```
+
+> Note: `[[slug]]` is a convention hint for the LLM (documented in the `wiki_read_page` `@Tool` description), but the LLM can still drift under complex tasks. For production, reinforce the system prompt in `AGENTS.md`, or bind the target KB to a dedicated agent to narrow the retrieval space.
 
 ## curl examples
 

--- a/mateclaw-server/src/main/resources/docs/zh/webchat.md
+++ b/mateclaw-server/src/main/resources/docs/zh/webchat.md
@@ -69,6 +69,7 @@ init({ apiKey: 'your-channel-api-key', server: 'https://<你的部署地址>' })
 | POST | `/stream` | API Key | SSE 流式对话(签发 visitorToken);请求体可选传 `agentId` 覆盖渠道绑定的 agent(必须与渠道同 workspace) |
 | GET | `/config` | API Key | 拿渠道配置(title/placeholder/...) |
 | GET | `/skills` | + visitorToken | 列出该 agent 绑定的可见技能(供下游自建 slash picker UI) |
+| GET | `/wiki/pages` | + visitorToken | 列出该 agent 可见的 wiki 页面(供下游自建 `[[slug]]` 引用 picker UI) |
 | POST | `/sessions` | API Key | 显式创建空会话线程 |
 | GET | `/sessions` | + visitorToken | 列出会话(默认排除 archived) |
 | GET | `/sessions/page` | + visitorToken | 分页 + 关键词搜索 |
@@ -235,6 +236,58 @@ curl -N -X POST https://mate.example.com/api/v1/channels/webchat/stream \
 ```
 
 > 注意:指令文本依赖 LLM "听话"调用 `load_skill`。复杂任务下偶发漂移,生产环境建议把目标技能**绑定**到 agent(`agentId` 对应的)并在 `AGENTS.md` 里强化系统提示。
+
+## Wiki 知识库引用(`[[slug]]` picker)
+
+跟技能调用一样,wiki 知识库也可以通过 picker 显式指代——用 **Obsidian / Wikipedia 风格的 `[[slug]]` 链接语法**。用户在输入框敲 `[[` 触发 picker,选中后插入 `[[<slug>]]` token,发送时改写为指令文本,LLM 收到后调 `wiki_read_page(slug=...)` 读取该页面再做答。后端**不做任何 `[[` 解析**,webchat 走的是和主控台完全一样的 agent runtime。
+
+指令文本格式(**精确**):
+
+- 中文:`参考知识库页面 [[<slug>]]:<用户消息>`
+- 英文:`Reference the wiki page [[<slug>]]: <user message>`
+
+多引用天然支持(并列写即可):
+
+```
+参考知识库页面 [[auth-design]]、[[webchat-integration]]:这两套怎么协同?
+```
+
+下游集成方要自建 picker UI,先用端点拿页面清单:
+
+```bash
+curl "https://mate.example.com/api/v1/channels/webchat/wiki/pages?visitorId=v1" \
+  -H "X-MC-Key: your-api-key" \
+  -H "X-MC-Visitor-Token: <token>"
+# 返回 [{"kbId":1,"kbName":"MateClaw 文档","slug":"webchat-integration",
+#        "title":"WebChat 接入指南","summary":"...","pageType":"source"}, ...]
+```
+
+可选 query 参数:
+
+| 参数 | 必填 | 说明 |
+|---|---|---|
+| `visitorId` | 是 | 访客 ID |
+| `agentId` | 否 | 显式指定 agent,缺省回落到渠道绑定;必须与渠道同 workspace |
+| `keyword` | 否 | 关键词过滤,匹配 `slug` 或 `title`(LIKE) |
+
+行为约束:
+
+- **可见范围**:agent 显式绑定的 KB(`mate_agent_wiki_kb` 表);无绑定时回落到该 workspace 全部 KB(跟 wiki 工具的默认行为一致)
+- **页面过滤**:排除 `pageType=synthesis`(LLM 中间产物,对终端访客无意义)
+- **100 页上限**:超出时(且未传 `keyword`)返回 `422`,要求传 `keyword` 收窄
+- **返回字段**:仅 `kbId / kbName / slug / title / summary / pageType`;**不包含**正文、embedding、sourceRawIds、outgoingLinks(这些只走管理控制台)
+- **排序**:按 `slug` 字母序
+
+选中后构造消息(中文 directive 示例):
+
+```bash
+curl -N -X POST https://mate.example.com/api/v1/channels/webchat/stream \
+  -H "X-MC-Key: your-api-key" \
+  -H "Content-Type: application/json" \
+  -d '{"visitorId":"v1","message":"参考知识库页面 [[webchat-integration]]:总结这套接入流程"}'
+```
+
+> 注意:`[[slug]]` 是给 LLM 看的约定提示(`wiki_read_page` 的 `@Tool` description 里写明了),但 LLM 仍可能漂移——复杂任务下建议同时在 `AGENTS.md` 里强化提示,或把目标 KB **绑定**到专用 agent 收窄检索空间。
 
 ## curl 示例
 

--- a/mateclaw-server/src/main/resources/docs/zh/webchat.md
+++ b/mateclaw-server/src/main/resources/docs/zh/webchat.md
@@ -66,8 +66,9 @@ init({ apiKey: 'your-channel-api-key', server: 'https://<你的部署地址>' })
 
 | 方法 | 路径 | 鉴权 | 用途 |
 |---|---|---|---|
-| POST | `/stream` | API Key | SSE 流式对话(签发 visitorToken) |
+| POST | `/stream` | API Key | SSE 流式对话(签发 visitorToken);请求体可选传 `agentId` 覆盖渠道绑定的 agent(必须与渠道同 workspace) |
 | GET | `/config` | API Key | 拿渠道配置(title/placeholder/...) |
+| GET | `/skills` | + visitorToken | 列出该 agent 绑定的可见技能(供下游自建 slash picker UI) |
 | POST | `/sessions` | API Key | 显式创建空会话线程 |
 | GET | `/sessions` | + visitorToken | 列出会话(默认排除 archived) |
 | GET | `/sessions/page` | + visitorToken | 分页 + 关键词搜索 |
@@ -203,6 +204,37 @@ curl -X POST https://mate.example.com/api/v1/admin/webchat/revoked-visitor \
 ```
 
 撤销后该 visitor 的所有管理端点调用返回 401(`/stream` 不受影响,可重新签发新 token)。撤销状态带短时缓存,多实例下最长约 10 分钟生效。取消撤销用 `DELETE` 同一端点。
+
+## 技能调用(slash picker)
+
+主控台前端在输入框键入 `/` 会弹出技能选择菜单。这是**纯前端 affordance**——选中后输入框被改写成指令文本:
+
+- 中文:`使用「<技能名>」技能:<用户消息>`
+- 英文:`Use the "<skill-name>" skill: <用户消息>`
+
+指令文本作为普通 user message 发到 `/stream`,LLM 收到后调用 `load_skill` 元工具(详见 [skills.md](./skills.md#slash-菜单))。后端**不做 `/` 解析**,webchat 走的是和主控台完全一样的 agent runtime,所以这条路径对 webchat 调用方**开箱即用**。
+
+下游集成方要自建 picker UI,先用新端点拿清单:
+
+```bash
+curl https://mate.example.com/api/v1/channels/webchat/skills?visitorId=v1 \
+  -H "X-MC-Key: your-api-key" \
+  -H "X-MC-Visitor-Token: <token>"
+# 返回 [{"id":..., "name":"news-summary", "nameZh":"新闻摘要", "description":"...", "icon":"..."}]
+```
+
+可选 `agentId` 参数(默认回落到渠道绑定的 agent);只返回该 agent **显式绑定且 enabled** 的技能,按 slug 字母序排序。返回字段是展示级元数据,**不包含** SKILL.md 正文、configJson、安全扫描结果——这些只走管理控制台。
+
+选中后构造消息:
+
+```bash
+curl -N -X POST https://mate.example.com/api/v1/channels/webchat/stream \
+  -H "X-MC-Key: your-api-key" \
+  -H "Content-Type: application/json" \
+  -d '{"visitorId":"v1","message":"使用「新闻摘要」技能:总结今天最重要的 3 条 AI 新闻"}'
+```
+
+> 注意:指令文本依赖 LLM "听话"调用 `load_skill`。复杂任务下偶发漂移,生产环境建议把目标技能**绑定**到 agent(`agentId` 对应的)并在 `AGENTS.md` 里强化系统提示。
 
 ## curl 示例
 

--- a/mateclaw-server/src/test/java/vip/mate/channel/webchat/WebChatWikiPageListTest.java
+++ b/mateclaw-server/src/test/java/vip/mate/channel/webchat/WebChatWikiPageListTest.java
@@ -1,0 +1,251 @@
+package vip.mate.channel.webchat;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.test.context.TestPropertySource;
+import vip.mate.MateClawApplication;
+import vip.mate.channel.webchat.WebChatController.WebChatWikiPageView;
+import vip.mate.common.result.R;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * End-to-end coverage for {@code GET /api/v1/channels/webchat/wiki/pages} —
+ * the visitor-facing wiki page catalogue that downstream integrators use to
+ * build a {@code [[slug]]} picker UI. Mirrors {@link WebChatSkillListTest}:
+ * verifies the auth chain (API Key + visitorToken HMAC), the agent workspace
+ * anti-escalation guard, the bound-KB scope, the {@code synthesis} exclusion,
+ * and the &gt;100-page cap that forces a keyword filter.
+ */
+@SpringBootTest(
+        classes = MateClawApplication.class,
+        webEnvironment = SpringBootTest.WebEnvironment.NONE
+)
+@TestPropertySource(properties = {
+        "spring.datasource.url=jdbc:h2:mem:webchat_wiki_${random.uuid};MODE=MySQL;DATABASE_TO_LOWER=TRUE;CASE_INSENSITIVE_IDENTIFIERS=TRUE;DB_CLOSE_DELAY=-1",
+        "spring.ai.dashscope.api-key=test-key",
+        "spring.main.web-application-type=none",
+        "mateclaw.jwt.secret=webchat-it-secret-0123456789"
+})
+class WebChatWikiPageListTest {
+
+    private static final String SECRET = "webchat-it-secret-0123456789";
+    private static final String API_KEY = "testkey1abcdefgh";
+    private static final long CHANNEL_ID = 9_400_001L;
+    private static final long AGENT_ID = 9_400_011L;
+    private static final long OTHER_WORKSPACE_AGENT_ID = 9_400_012L;
+    private static final long KB_ID = 9_400_101L;
+    private static final long OTHER_KB_ID = 9_400_102L;
+
+    @Autowired private WebChatController controller;
+    @Autowired private JdbcTemplate jdbc;
+
+    @BeforeEach
+    void setUp() {
+        // Wipe bindings + pages + KBs + channel + agents in dependency-safe order.
+        jdbc.update("DELETE FROM mate_agent_wiki_kb WHERE agent_id IN (?, ?, ?)",
+                AGENT_ID, OTHER_WORKSPACE_AGENT_ID, 9_400_099L);
+        jdbc.update("DELETE FROM mate_wiki_page WHERE kb_id IN (?, ?)", KB_ID, OTHER_KB_ID);
+        jdbc.update("DELETE FROM mate_wiki_knowledge_base WHERE id IN (?, ?)", KB_ID, OTHER_KB_ID);
+        jdbc.update("DELETE FROM mate_channel WHERE id = ?", CHANNEL_ID);
+        jdbc.update("DELETE FROM mate_agent WHERE id IN (?, ?, ?)",
+                AGENT_ID, OTHER_WORKSPACE_AGENT_ID, 9_400_099L);
+
+        jdbc.update(
+                "MERGE INTO mate_agent (id, name, agent_type, system_prompt, max_iterations, enabled, " +
+                        "workspace_id, create_time, update_time, deleted) " +
+                        "KEY(id) VALUES (?, 'wc-wiki-agent', 'react', '', 10, TRUE, 1, " +
+                        "CURRENT_TIMESTAMP, CURRENT_TIMESTAMP, 0)",
+                AGENT_ID);
+        jdbc.update(
+                "MERGE INTO mate_agent (id, name, agent_type, system_prompt, max_iterations, enabled, " +
+                        "workspace_id, create_time, update_time, deleted) " +
+                        "KEY(id) VALUES (?, 'wc-wiki-other-ws-agent', 'react', '', 10, TRUE, 999, " +
+                        "CURRENT_TIMESTAMP, CURRENT_TIMESTAMP, 0)",
+                OTHER_WORKSPACE_AGENT_ID);
+        jdbc.update("INSERT INTO mate_channel (id, name, channel_type, agent_id, config_json, enabled, " +
+                        "workspace_id, create_time, update_time, deleted) " +
+                        "VALUES (?, 'wc', 'webchat', ?, ?, TRUE, 1, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP, 0)",
+                CHANNEL_ID, AGENT_ID, "{\"api_key\":\"" + API_KEY + "\"}");
+
+        // Two KBs in workspace 1 (the channel's workspace). Bind the agent to
+        // KB_ID only, so OTHER_KB_ID stays out of scope unless the agent's
+        // binding set is cleared.
+        jdbc.update("MERGE INTO mate_wiki_knowledge_base (id, name, description, status, " +
+                        "page_count, raw_count, workspace_id, create_time, update_time, deleted) " +
+                        "KEY(id) VALUES (?, 'Main KB', 'main', 'active', 0, 0, 1, " +
+                        "CURRENT_TIMESTAMP, CURRENT_TIMESTAMP, 0)",
+                KB_ID);
+        jdbc.update("MERGE INTO mate_wiki_knowledge_base (id, name, description, status, " +
+                        "page_count, raw_count, workspace_id, create_time, update_time, deleted) " +
+                        "KEY(id) VALUES (?, 'Other KB', 'other', 'active', 0, 0, 1, " +
+                        "CURRENT_TIMESTAMP, CURRENT_TIMESTAMP, 0)",
+                OTHER_KB_ID);
+
+        // Bind AGENT_ID to KB_ID only. Single enabled row → effective scope = {KB_ID}.
+        jdbc.update("MERGE INTO mate_agent_wiki_kb (id, agent_id, kb_id, enabled, " +
+                        "create_time, update_time, deleted) " +
+                        "KEY(id) VALUES (?, ?, ?, TRUE, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP, 0)",
+                9_400_201L, AGENT_ID, KB_ID);
+
+        // Three pages in KB_ID: entity / concept / synthesis. The synthesis
+        // one must be filtered out by the picker; the other two surface sorted
+        // by slug (beta < zeta by slug asc... actually we use 'alpha' and
+        // 'beta' to make the sort obvious).
+        insertPage(9_400_301L, KB_ID, "alpha-page", "Alpha Page", "entity");
+        insertPage(9_400_302L, KB_ID, "beta-page", "Beta Page", "concept");
+        insertPage(9_400_303L, KB_ID, "hidden-synthesis", "Synthesis (hidden)", "synthesis");
+
+        // One page in OTHER_KB_ID — must NOT surface (agent bound to KB_ID only).
+        insertPage(9_400_304L, OTHER_KB_ID, "other-kb-page", "Other KB Page", "entity");
+    }
+
+    private void insertPage(long id, long kbId, String slug, String title, String pageType) {
+        jdbc.update("MERGE INTO mate_wiki_page (id, kb_id, slug, title, content, summary, " +
+                        "page_type, version, last_updated_by, create_time, update_time, deleted) " +
+                        "KEY(id) VALUES (?, ?, ?, ?, '', ?, ?, 1, 'test', " +
+                        "CURRENT_TIMESTAMP, CURRENT_TIMESTAMP, 0)",
+                id, kbId, slug, title, title + " summary", pageType);
+    }
+
+    private String tokenFor(String visitorId) {
+        return WebChatController.computeVisitorToken(SECRET, CHANNEL_ID, visitorId);
+    }
+
+    @Test
+    @DisplayName("happy path: bound-KB pages surface sorted by slug; synthesis filtered out; other-KB excluded")
+    void listReturnsBoundKbPagesSortedExcludingSynthesis() {
+        R<List<WebChatWikiPageView>> r = controller.listWikiPages(
+                API_KEY, tokenFor("v1"), null, "v1", null);
+
+        assertThat(r.getCode()).isEqualTo(200);
+        List<WebChatWikiPageView> data = r.getData();
+        assertThat(data).hasSize(2);
+        assertThat(data.get(0).getSlug()).isEqualTo("alpha-page");
+        assertThat(data.get(0).getTitle()).isEqualTo("Alpha Page");
+        assertThat(data.get(0).getKbId()).isEqualTo(KB_ID);
+        assertThat(data.get(0).getKbName()).isEqualTo("Main KB");
+        assertThat(data.get(0).getPageType()).isEqualTo("entity");
+        assertThat(data.get(1).getSlug()).isEqualTo("beta-page");
+        // synthesis must NOT surface
+        assertThat(data).noneMatch(p -> "synthesis".equals(p.getPageType()));
+        // other-KB page must NOT surface (out of scope)
+        assertThat(data).noneMatch(p -> "other-kb-page".equals(p.getSlug()));
+    }
+
+    @Test
+    @DisplayName("keyword filters by slug OR title (case-insensitive LIKE)")
+    void keywordFilterMatchesSlugOrTitle() {
+        R<List<WebChatWikiPageView>> bySlug = controller.listWikiPages(
+                API_KEY, tokenFor("v2"), null, "v2", "alpha");
+        assertThat(bySlug.getCode()).isEqualTo(200);
+        assertThat(bySlug.getData()).hasSize(1);
+        assertThat(bySlug.getData().get(0).getSlug()).isEqualTo("alpha-page");
+
+        R<List<WebChatWikiPageView>> byTitle = controller.listWikiPages(
+                API_KEY, tokenFor("v3"), null, "v3", "Beta Page");
+        assertThat(byTitle.getCode()).isEqualTo(200);
+        assertThat(byTitle.getData()).hasSize(1);
+        assertThat(byTitle.getData().get(0).getSlug()).isEqualTo("beta-page");
+
+        R<List<WebChatWikiPageView>> noMatch = controller.listWikiPages(
+                API_KEY, tokenFor("v4"), null, "v4", "nomatch");
+        assertThat(noMatch.getCode()).isEqualTo(200);
+        assertThat(noMatch.getData()).isEmpty();
+    }
+
+    @Test
+    @DisplayName("explicit agentId matching channel workspace works")
+    void explicitAgentIdSameWorkspace() {
+        R<List<WebChatWikiPageView>> r = controller.listWikiPages(
+                API_KEY, tokenFor("v5"), AGENT_ID, "v5", null);
+
+        assertThat(r.getCode()).isEqualTo(200);
+        assertThat(r.getData()).hasSize(2);
+    }
+
+    @Test
+    @DisplayName("explicit agentId in a different workspace → 403 (anti-escalation)")
+    void explicitAgentIdDifferentWorkspace() {
+        R<List<WebChatWikiPageView>> r = controller.listWikiPages(
+                API_KEY, tokenFor("v6"), OTHER_WORKSPACE_AGENT_ID, "v6", null);
+
+        assertThat(r.getCode()).isEqualTo(403);
+        assertThat(r.getData()).isNull();
+    }
+
+    @Test
+    @DisplayName("invalid API Key → 401")
+    void invalidApiKey() {
+        R<List<WebChatWikiPageView>> r = controller.listWikiPages(
+                "garbagekeyxyz12", tokenFor("v7"), null, "v7", null);
+
+        assertThat(r.getCode()).isEqualTo(401);
+    }
+
+    @Test
+    @DisplayName("missing/invalid visitor token → 401")
+    void invalidVisitorToken() {
+        R<List<WebChatWikiPageView>> r = controller.listWikiPages(
+                API_KEY, "not-a-valid-token", null, "v8", null);
+
+        assertThat(r.getCode()).isEqualTo(401);
+    }
+
+    @Test
+    @DisplayName("no KB bindings → fall back to workspace-wide KB set (legacy behavior)")
+    void noKbBindingsFallsBackToWorkspaceWide() {
+        // Use a fresh agent with no mate_agent_wiki_kb rows. The channel is
+        // repointed to it so the default-agent path resolves it.
+        long lonelyAgent = 9_400_099L;
+        jdbc.update(
+                "MERGE INTO mate_agent (id, name, agent_type, system_prompt, max_iterations, enabled, " +
+                        "workspace_id, create_time, update_time, deleted) " +
+                        "KEY(id) VALUES (?, 'wc-wiki-lonely', 'react', '', 10, TRUE, 1, " +
+                        "CURRENT_TIMESTAMP, CURRENT_TIMESTAMP, 0)",
+                lonelyAgent);
+        jdbc.update("UPDATE mate_channel SET agent_id = ? WHERE id = ?", lonelyAgent, CHANNEL_ID);
+
+        R<List<WebChatWikiPageView>> r = controller.listWikiPages(
+                API_KEY, tokenFor("v9"), null, "v9", null);
+
+        assertThat(r.getCode()).isEqualTo(200);
+        // Both workspace KBs visible: alpha/beta from KB_ID + other-kb-page
+        // from OTHER_KB_ID. Synthesis still filtered.
+        assertThat(r.getData()).hasSize(3);
+        assertThat(r.getData()).extracting(WebChatWikiPageView::getSlug)
+                .containsExactlyInAnyOrder("alpha-page", "beta-page", "other-kb-page");
+    }
+
+    @Test
+    @DisplayName(">100 pages without keyword → 422 (force narrow with keyword)")
+    void capWithoutKeywordReturns422() {
+        // Seed 101 synthetic pages (slug = cap-001 ... cap-101) into KB_ID.
+        // These are extra to the 3 set up in @BeforeEach; synthesis-type rows
+        // still get filtered, so use 'entity' to make sure they all count.
+        for (int i = 1; i <= 101; i++) {
+            insertPage(9_401_000L + i, KB_ID,
+                    String.format("cap-%03d", i),
+                    "Cap Page " + i,
+                    "entity");
+        }
+
+        R<List<WebChatWikiPageView>> noKeyword = controller.listWikiPages(
+                API_KEY, tokenFor("v10"), null, "v10", null);
+        assertThat(noKeyword.getCode()).isEqualTo(422);
+        assertThat(noKeyword.getData()).isNull();
+
+        // With a keyword the cap is bypassed — caller gets the filtered subset
+        // (here: 3 of the 101 seeded rows match "cap-001" / "cap-010" / "cap-100").
+        R<List<WebChatWikiPageView>> withKeyword = controller.listWikiPages(
+                API_KEY, tokenFor("v11"), null, "v11", "cap-001");
+        assertThat(withKeyword.getCode()).isEqualTo(200);
+        assertThat(withKeyword.getData()).isNotEmpty();
+    }
+}


### PR DESCRIPTION
## 概述

Closes #381。新增 `GET /api/v1/channels/webchat/wiki/pages`，对标 `/skills`，让下游集成方能自建 `[[slug]]` picker UI，把 LLM 指向具体的 wiki 页面。

picker 的 token 格式沿用通用的 Obsidian / Wikipedia / Notion wikilink 约定（`[[<slug>]]`）。LLM 通过现有的 `wiki_read_page(slug=...)` 工具消费 `[[slug]]`，**agent runtime 零改动**——wiki 基础设施本就齐全，本 PR 只是补一个面向访客的发现入口。

## 改动

### 代码
- **`AgentBindingResolver.getBoundKbIds(agentId)`**——三态对称 `getBoundSkillIds`：`null` = 无绑定行（回落到 workspace 全部 KB），`Set.of()` = 显式绑定为空，非空集合 = 显式作用域。
- **`WebChatController.listWikiPages`**——鉴权链 `X-MC-Key` + `X-MC-Visitor-Token`；`agentId` workspace 反越权（沿用 `/stream` + `/skills`）；可见性排除 `pageType=synthesis`（LLM 中间产物）；100 页上限强制 `keyword` 收窄；返回字段仅展示级元数据。
- **`WebChatWikiPageView`** DTO——`kbId / kbName / slug / title / summary / pageType`；`content / embedding / sourceRawIds` 不暴露，仅走管理控制台。
- **`WikiTool.wiki_read_page` `@Tool` 描述**——加上 `[[slug]]` 约定提示，LLM 收到 token 时优先调本工具。
- **`WebChatWikiPageListTest`**——8 个 case：happy path、关键词过滤、synthesis 排除、反越权（403）、鉴权失败（401）、100 上限（422）、无绑定 → workspace-wide 回落。

### 文档（`mateclaw-server/src/main/resources/docs/{zh,en}/webchat.md`）
- `/skills` 端点补丁：端点清单表加 `/skills` 行、`/stream` 加可选 `agentId` 说明、新增「技能调用（slash picker）」章节。补 PR #374 漏掉的文档。
- `/wiki/pages` 新端点文档：端点清单表加行 + 新增「Wiki 知识库引用（`[[slug]]` picker）」章节，含指令文本格式、参数表、可见性规则（排除 synthesis、100 上限、KB 作用域回落）、curl 示例。

## 设计决策（已记录在 #381）

| 决策 | 选择 |
|---|---|
| token 格式 | `[[<slug>]]`——slug 直接命中 `wiki_read_page` 第一参数，无需反查 |
| LLM 约定提示位置 | `wiki_read_page` `@Tool` description（影响域最小） |
| picker 默认展示 | 全部绑定 KB 的 page，100 上限强制关键词 |
| 可见性 | 排除 `pageType=synthesis`（LLM 中间产物） |
| 渠道范围 | 先 webchat；主控台 picker 复用本端点（JWT 鉴权）放下个 PR |

## 不在本 PR 范围（后续 PR）

- 前端 `[[` picker（`ChatInput.vue`，主控台 + webchat widget）
- 主控台 JWT 鉴权版本的端点（`GET /api/v1/wiki/pages/picker` 之类）

## 测试

- [x] `mvn -Dtest=WebChatWikiPageListTest test`——8/8 通过
- [x] `mvn -Dtest='WebChat*Test,AgentBinding*Test' test`——145/145 通过（无回归）
- [ ] 手动：curl `/wiki/pages` 跑一遍 seeded agent——验证 KB 作用域 + synthesis 排除
- [ ] 手动：`/stream` 发 `参考知识库页面 [[<slug>]]：...` 验证 LLM 调 `wiki_read_page`