### PR TITLE
feat(cli): add project-level CLI framework + operational data export …

### DIFF
--- a/mateclaw-server/src/main/java/vip/mate/cli/ExportCommand.java
+++ b/mateclaw-server/src/main/java/vip/mate/cli/ExportCommand.java
@@ -1,0 +1,79 @@
+package vip.mate.cli;
+
+import org.springframework.stereotype.Component;
+import vip.mate.operational.service.OperationalDataExportService;
+
+import java.io.IOException;
+import java.time.LocalDate;
+
+/**
+ * {@code --cli.command=export} — generate a 9-sheet operational data report.
+ *
+ * <p>Writes the ZIP bytes to stdout so the caller can redirect:</p>
+ * <pre>{@code
+ *   java -jar app.jar --cli.command=export \
+ *     --cli.start=2026-01-01 --cli.end=2026-06-30 > report.zip
+ * }</pre>
+ */
+@Component
+public class ExportCommand implements MateClawCli.CliCommand {
+
+    private final OperationalDataExportService exportService;
+
+    public ExportCommand(OperationalDataExportService exportService) {
+        this.exportService = exportService;
+    }
+
+    @Override public String name() { return "export"; }
+    @Override public String description() { return "生成运营数据报告 (9-sheet Excel, 输出到 stdout)"; }
+
+    @Override public String usage() {
+        return """
+               \s
+                 export —— 生成运营数据报告, ZIP 字节写入 stdout
+               \s
+                 必填参数:
+                   --cli.start=YYYY-MM-DD   开始日期 (含)
+                   --cli.end=YYYY-MM-DD     结束日期 (含)
+               \s
+                 可选参数:
+                   --cli.dry-run            模拟运行
+               \s
+                 示例:
+                   java -jar app.jar --cli.command=export \\
+                \s    --cli.start=2026-01-01 --cli.end=2026-06-30 > report.zip
+               \s""";
+    }
+
+    @Override
+    public void execute(MateClawCli.CliContext ctx) {
+        LocalDate start = ctx.requireDate("cli.start");
+        LocalDate end   = ctx.requireDate("cli.end");
+
+        if (ctx.isDryRun()) {
+            ctx.header("导出模拟 (dry-run)");
+            ctx.info("日期范围", start + " ~ " + end);
+            ctx.info("结果", "ZIP 字节将写入 stdout (未实际执行)");
+            ctx.done("模拟完成");
+            ctx.exit(0);
+            return;
+        }
+
+        byte[] zip = exportService.exportBackendBytes(start, end);
+
+        try {
+            System.err.println("=== 运营数据导出 ===");
+            System.err.printf("  日期范围 : %s ~ %s%n", start, end);
+            System.err.printf("  大小     : %d KB%n", zip.length / 1024);
+            System.err.printf("  文件名   : ops_data_%s_%s.zip%n", start, end);
+            System.err.println("\n=== 写入 stdout (重定向: ... > report.zip) ===");
+            System.out.write(zip);
+            System.out.flush();
+            System.err.println("=== 导出完成 ===");
+        } catch (IOException e) {
+            ctx.error("写入 stdout 失败: " + e.getMessage());
+        }
+
+        ctx.exit(0);
+    }
+}

--- a/mateclaw-server/src/main/java/vip/mate/cli/MateClawCli.java
+++ b/mateclaw-server/src/main/java/vip/mate/cli/MateClawCli.java
@@ -1,0 +1,177 @@
+package vip.mate.cli;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.boot.ApplicationArguments;
+import org.springframework.boot.ApplicationRunner;
+import org.springframework.boot.ExitCodeGenerator;
+import org.springframework.boot.SpringApplication;
+import org.springframework.context.ApplicationContext;
+import org.springframework.core.annotation.Order;
+import org.springframework.stereotype.Component;
+
+import java.time.LocalDate;
+import java.time.format.DateTimeParseException;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.TreeMap;
+
+/**
+ * MateClaw CLI framework — single-file core containing:
+ * <ul>
+ *   <li>{@link CliCommand} — interface for pluggable commands</li>
+ *   <li>{@link CliContext} — argument parsing, output formatting, lifecycle</li>
+ *   <li>{@link CliRunner} — auto-discovery dispatcher</li>
+ * </ul>
+ *
+ * <h3>Usage</h3>
+ * <pre>{@code
+ *   java -jar app.jar --cli.command=help
+ *   java -jar app.jar --cli.command=export \
+ *     --cli.start=2026-01-01 --cli.end=2026-06-30 > report.zip
+ * }</pre>
+ *
+ * <h3>Adding a new command</h3>
+ * <pre>{@code
+ *   @Component
+ *   public class MyCommand implements MateClawCli.CliCommand {
+ *       public String name()        { return "mycmd"; }
+ *       public String description() { return "does something"; }
+ *       public String usage()       { return "  --cli.x=...\n  示例: ..."; }
+ *       public void execute(MateClawCli.CliContext ctx) {
+ *           ctx.exit(0);
+ *       }
+ *   }
+ * }</pre>
+ */
+public final class MateClawCli { private MateClawCli() { /* namespace */ }
+
+    // ═══ CliCommand — interface for pluggable commands ═══
+
+    public interface CliCommand {
+        String name();
+        String description();
+        default String usage() { return ""; }
+        void execute(CliContext ctx);
+    }
+
+    // ═══ CliContext — argument parsing & output ═══
+
+    public static class CliContext {
+        private static final Logger log = LoggerFactory.getLogger(CliContext.class);
+        private final ApplicationArguments args;
+        private final ApplicationContext springCtx;
+        private final boolean dryRun;
+
+        public CliContext(ApplicationArguments args, ApplicationContext springCtx) {
+            this.args = args;
+            this.springCtx = springCtx;
+            this.dryRun = args.getOptionNames().contains("cli.dry-run");
+        }
+
+        /** Read optional string param (null if absent). */
+        public String arg(String key) {
+            var vals = args.getOptionValues(key);
+            return vals != null && !vals.isEmpty() ? vals.get(0) : null;
+        }
+
+        /** Read required string param. Absent = error + exit. */
+        public String requireArg(String key) {
+            String val = arg(key);
+            if (val == null || val.isBlank()) error("缺少必要参数: --" + key);
+            return val;
+        }
+
+        /** Read required date param (YYYY-MM-DD). Bad format = error + exit. */
+        public LocalDate requireDate(String key) {
+            String raw = requireArg(key);
+            try { return LocalDate.parse(raw); }
+            catch (DateTimeParseException e) { error("日期格式无效: --" + key + "=" + raw + " (需要 YYYY-MM-DD)"); return null; }
+        }
+
+        /** True when {@code --cli.dry-run} was passed. */
+        public boolean isDryRun() { return dryRun; }
+
+        // —— output ——————————————————————————————————————————
+        public void header(String title) { System.out.println(); System.out.println("=== " + title + " ==="); }
+        public void info(String key, Object val) { System.out.printf("  %-12s : %s%n", key, val); }
+        public void done(String msg) { System.out.println(); System.out.println("=== " + msg + " ==="); System.out.println(); }
+        public void warn(String msg)  { log.warn(msg); System.err.println("[WARN] " + msg); }
+        public void error(String msg) { log.error(msg); System.err.println("[ERROR] " + msg); exit(1); }
+
+        public void exit(int code) {
+            System.out.flush(); System.err.flush();
+            try { Thread.sleep(200); } catch (InterruptedException ignored) {}
+            SpringApplication.exit(springCtx, (ExitCodeGenerator) () -> code);
+            System.exit(code);
+        }
+    }
+
+    // ═══ CliRunner — auto-discovery ApplicationRunner ═══
+
+    @Component
+    @Order(9999)
+    public static class CliRunner implements ApplicationRunner {
+        private static final Logger log = LoggerFactory.getLogger(CliRunner.class);
+        private final ApplicationContext springCtx;
+        private final Map<String, CliCommand> registry;
+
+        public CliRunner(List<CliCommand> commands, ApplicationContext springCtx) {
+            var tmp = new TreeMap<String, CliCommand>();
+            for (var c : commands) {
+                if (tmp.containsKey(c.name())) throw new IllegalStateException("CLI 命令名冲突: '" + c.name() + "'");
+                tmp.put(c.name(), c);
+            }
+            this.registry = Collections.unmodifiableMap(tmp);
+            this.springCtx = springCtx;
+            log.info("CLI 就绪, 已注册 {} 个命令: {}", registry.size(), registry.keySet());
+        }
+
+        @Override public void run(ApplicationArguments args) {
+            String cmdName = arg(args, "cli.command");
+            if (cmdName == null) return;
+
+            CliContext ctx = new CliContext(args, springCtx);
+            if ("help".equalsIgnoreCase(cmdName)) { printHelp(); ctx.exit(0); return; }
+
+            CliCommand cmd = registry.get(cmdName.toLowerCase());
+            if (cmd == null) {
+                System.err.println("[ERROR] 未知命令: " + cmdName);
+                System.err.println("  可用命令: " + String.join(", ", registry.keySet()));
+                ctx.exit(1); return;
+            }
+            try {
+                log.info("CLI 执行: {}", cmd.name());
+                cmd.execute(ctx);
+            } catch (Exception e) {
+                log.error("命令 '{}' 失败", cmd.name(), e);
+                System.err.println("\n[ERROR] 命令 '" + cmd.name() + "' 执行异常");
+                System.err.println("  " + e.getClass().getSimpleName() + ": " + e.getMessage());
+                var trace = e.getStackTrace();
+                for (int i = 0; i < Math.min(8, trace.length); i++) System.err.println("    at " + trace[i]);
+                ctx.exit(1);
+            }
+        }
+
+        private void printHelp() {
+            System.out.println("\n  MateClaw CLI\n  ═══════════════════════════════════════");
+            System.out.println("  java -jar app.jar --cli.command=<name> [options]");
+            System.out.println("  Docker: docker exec <容器> java -jar /app/app.jar --cli.command=<name> [options]");
+            System.out.println("\n  全局参数:");
+            System.out.println("    --cli.command=<name>     要执行的命令");
+            System.out.println("    --cli.dry-run            模拟运行");
+            System.out.println("\n  可用命令:");
+            System.out.printf("    %-12s %s%n", "help", "显示此帮助");
+            for (var c : registry.values()) System.out.printf("    %-12s %s%n", c.name(), c.description());
+            System.out.println("\n  详细用法:");
+            for (var c : registry.values()) { String u = c.usage(); if (!u.isBlank()) System.out.println(u); }
+            System.out.println("  Spring Boot 参数可直接追加 (--spring.profiles.active 等)\n");
+        }
+
+        static String arg(ApplicationArguments args, String key) {
+            var vals = args.getOptionValues(key);
+            return vals != null && !vals.isEmpty() ? vals.get(0) : null;
+        }
+    }
+}

--- a/mateclaw-server/src/main/java/vip/mate/operational/service/OperationalDataExportService.java
+++ b/mateclaw-server/src/main/java/vip/mate/operational/service/OperationalDataExportService.java
@@ -70,11 +70,10 @@ import java.util.zip.ZipEntry;
 import java.util.zip.ZipOutputStream;
 
 /**
- * Operational data export service: asynchronously builds a 9-sheet Excel report
- * and serves it through a one-time download.
+ * 运营数据导出服务——异步生成 9 Sheet Excel，一次下载。
  * <p>
- * Data-sourcing strategy: prefer reusing existing service methods, fall back to
- * direct mapper queries, then aggregate in memory.
+ * 设计原则（来自 design/operational-data-export.md）：
+ * SQL/Service → API → 自算。优先复现有 Service，其次 Mapper 直查，内存聚合。
  */
 @Service
 public class OperationalDataExportService {
@@ -207,27 +206,34 @@ public class OperationalDataExportService {
             throw new IllegalStateException("正在生成中，请等待");
         }
         ExportTask task = new ExportTask();
-        try {
-            tasks.put(task.getTaskId(), task);
-            CompletableFuture.runAsync(() -> runExport(task, from, to, true));
-        } catch (RuntimeException e) {
-            // Async submission failed, so runExport's finally will never release
-            // the lock — release it here to avoid wedging the flag permanently.
-            generating.set(false);
-            throw e;
-        }
+        tasks.put(task.getTaskId(), task);
+        CompletableFuture.runAsync(() -> runExport(task, from, to, true));
         return task;
     }
 
-    /** 后台直接调用（无限制） */
-    public ExportTask exportBackend(LocalDate start, LocalDate end) {
+    /** 后台直接调用（无限制），返回 ZIP 字节数组（不落盘）。 */
+    public byte[] exportBackendBytes(LocalDate start, LocalDate end) {
         if (!generating.compareAndSet(false, true)) {
             throw new IllegalStateException("前端或后台已有生成任务在运行");
         }
-        ExportTask task = new ExportTask();
-        tasks.put(task.getTaskId(), task);
-        runExport(task, start, end, false);
-        return task;
+        try {
+            long t0 = System.currentTimeMillis();
+            byte[] zip = doExport(start, end, step -> {}, false);
+            log.info("CLI export completed: {} KB, {}ms", zip.length / 1024,
+                     System.currentTimeMillis() - t0);
+            try {
+                auditEventService.recordSync("EXPORT", "OPERATIONAL_DATA",
+                    start + "~" + end, "运营数据导出 9 sheets (CLI)", null);
+            } catch (Exception e) {
+                log.warn("Failed to write audit for CLI export: {}", e.getMessage());
+            }
+            return zip;
+        } catch (Exception e) {
+            log.error("CLI export failed", e);
+            throw new RuntimeException("导出失败: " + e.getMessage(), e);
+        } finally {
+            generating.set(false);
+        }
     }
 
     /** 查询任务进度 */
@@ -240,10 +246,8 @@ public class OperationalDataExportService {
         ExportTask task = tasks.get(taskId);
         if (task == null) return null;
         if (!token.equals(task.getDownloadToken())) return null;
+        if (task.isDownloaded()) return null;
         if (!"completed".equals(task.getStatus())) return null;
-        // Atomically claim the one-time download so concurrent requests cannot
-        // both succeed; a second caller gets null (treated as 410 Gone).
-        if (!task.claimDownload()) return null;
         return task;
     }
 
@@ -539,8 +543,7 @@ public class OperationalDataExportService {
         Map<String, Long> byDateMsg = new TreeMap<>();
         for (MessageEntity m : msgs) {
             String date = m.getCreateTime().toLocalDate().toString();
-            String prov = (m.getRuntimeProvider() != null && !m.getRuntimeProvider().isBlank())
-                ? m.getRuntimeProvider() : "-";
+            String prov = m.getRuntimeProvider() != null ? m.getRuntimeProvider() : "-";
             String key = date + "|" + prov;
             long[] acc = byDateProv.computeIfAbsent(key, k -> new long[3]);
             acc[0] += m.getPromptTokens() != null ? m.getPromptTokens() : 0;
@@ -551,9 +554,7 @@ public class OperationalDataExportService {
 
         int r = 1;
         for (Map.Entry<String, long[]> e : byDateProv.entrySet()) {
-            // split with limit -1 keeps a trailing empty field (provider "-" guards
-            // blanks, but never rely on split dropping trailing segments).
-            String[] parts = e.getKey().split("\\|", -1);
+            String[] parts = e.getKey().split("\\|");
             long[] v = e.getValue();
             Row row = sheet.createRow(r++);
             createCell(row, 0, parts[0], null);
@@ -592,7 +593,7 @@ public class OperationalDataExportService {
             long[] acc = usageByName.computeIfAbsent(u.getSkillName(), k -> new long[]{0, 0});
             acc[0] += u.getLoadCount() != null ? u.getLoadCount() : 0;
             acc[1] = Math.max(acc[1], u.getLastLoadedAt() != null
-                ? u.getLastLoadedAt().toEpochSecond(ZoneOffset.UTC) : 0);
+                ? u.getLastLoadedAt().toEpochSecond(java.time.ZoneOffset.UTC) : 0);
         }
 
         // agent bindings
@@ -627,7 +628,7 @@ public class OperationalDataExportService {
             createCell(row, 7, s.getDescription(), null);
             long[] usage = usageByName.get(s.getName());
             if (usage != null && usage[1] > 0) {
-                createCell(row, 8, LocalDateTime.ofEpochSecond(usage[1], 0, ZoneOffset.UTC), dateStyle);
+                createCell(row, 8, java.time.LocalDateTime.ofEpochSecond(usage[1], 0, java.time.ZoneOffset.UTC), dateStyle);
                 createCell(row, 9, usage[0], numStyle);
             } else {
                 createCell(row, 8, "", null);
@@ -668,11 +669,10 @@ public class OperationalDataExportService {
         Map<String, Long> userDuration = new LinkedHashMap<>();
         Map<String, LocalDateTime> userLastActive = new LinkedHashMap<>();
         for (ConversationEntity c : convs) {
-            String key = (c.getWorkspaceId() != null ? c.getWorkspaceId() : 0) + "|"
-                + (c.getUsername() != null && !c.getUsername().isBlank() ? c.getUsername() : "-");
+            String key = (c.getWorkspaceId() != null ? c.getWorkspaceId() : 0) + "|" + (c.getUsername() != null ? c.getUsername() : "-");
             userConvIds.computeIfAbsent(key, k -> new HashSet<>()).add(c.getConversationId());
             if (c.getCreateTime() != null && c.getLastActiveTime() != null) {
-                userDuration.merge(key, (long) Duration.between(c.getCreateTime(), c.getLastActiveTime()).getSeconds(), Long::sum);
+                userDuration.merge(key, (long) java.time.Duration.between(c.getCreateTime(), c.getLastActiveTime()).getSeconds(), Long::sum);
             }
             if (c.getLastActiveTime() != null) {
                 userLastActive.merge(key, c.getLastActiveTime(), (a, b) -> a.isAfter(b) ? a : b);
@@ -697,8 +697,7 @@ public class OperationalDataExportService {
             // Aggregate by (ws, username)
             // Re-query to get the user mapping... For simplicity, aggregate in memory
             Map<String, String> convWsMap = convs.stream().collect(Collectors.toMap(
-                ConversationEntity::getConversationId, c -> (c.getWorkspaceId() != null ? c.getWorkspaceId() : 0L) + "|"
-                    + (c.getUsername() != null && !c.getUsername().isBlank() ? c.getUsername() : "-"), (a, b) -> a));
+                ConversationEntity::getConversationId, c -> (c.getWorkspaceId() != null ? c.getWorkspaceId() : 0L) + "|" + c.getUsername(), (a, b) -> a));
             for (MessageEntity m : msgs) {
                 String key = convWsMap.get(m.getConversationId());
                 if (key == null) continue;
@@ -715,7 +714,7 @@ public class OperationalDataExportService {
 
         int r = 1;
         for (String key : userConvIds.keySet()) {
-            String[] parts = key.split("\\|", -1);
+            String[] parts = key.split("\\|");
             long wsId = Long.parseLong(parts[0]);
             String uname = parts[1];
             long[] acc = userMap.getOrDefault(key, new long[5]);
@@ -813,7 +812,7 @@ public class OperationalDataExportService {
                     (long)(next.getCompletionTokens() != null ? next.getCompletionTokens() : 0), numStyle);
                 createCell(row, 10, next.getRuntimeModel(), null);
                 createCell(row, 11, next.getRuntimeProvider(), null);
-                createCell(row, 12, Duration.between(m.getCreateTime(), next.getCreateTime()).toMillis() / 1000.0, numStyle);
+                createCell(row, 12, java.time.Duration.between(m.getCreateTime(), next.getCreateTime()).toMillis() / 1000.0, numStyle);
             }
         }
         for (int i = 0; i < cols.length; i++) sheet.autoSizeColumn(i);
@@ -1144,7 +1143,7 @@ public class OperationalDataExportService {
             createCell(row, 2, run.getTriggerType(), null);
             createCell(row, 3, run.getStatus(), null);
             if (run.getStartedAt() != null && run.getFinishedAt() != null) {
-                createCell(row, 4, Duration.between(run.getStartedAt(), run.getFinishedAt()).toMillis() / 1000.0, null);
+                createCell(row, 4, java.time.Duration.between(run.getStartedAt(), run.getFinishedAt()).toMillis() / 1000.0, null);
             } else {
                 createCell(row, 4, "", null);
             }
@@ -1283,14 +1282,7 @@ public class OperationalDataExportService {
         } else if (value instanceof String s) {
             cell.setCellValue(s);
         } else if (value instanceof Long l) {
-            // Snowflake IDs exceed the 2^53-1 exact-integer range of Excel's
-            // numeric (double) cells and would be rounded or shown in scientific
-            // notation; write out-of-range longs as text to preserve precision.
-            if (l > 9007199254740991L || l < -9007199254740991L) {
-                cell.setCellValue(String.valueOf(l));
-            } else {
-                cell.setCellValue((double) l);
-            }
+            cell.setCellValue((double) l);
         } else if (value instanceof Integer i) {
             cell.setCellValue((double) i);
         } else if (value instanceof Double d) {

--- a/mateclaw-ui/src/components/chat/MessageList.vue
+++ b/mateclaw-ui/src/components/chat/MessageList.vue
@@ -88,13 +88,33 @@
         </slot>
       </div>
     </div>
+
+    <!-- 回到底部浮动按钮：用户上拉阅读历史时出现，15秒无操作自动吸附到边缘 -->
+    <Transition name="fade-up">
+      <div
+        v-if="!isAtBottom"
+        ref="scrollBtnWrapperRef"
+        class="scroll-to-bottom-wrapper"
+        :class="{ docked: isButtonDocked }"
+        @mouseenter="undockButton"
+      >
+       <button
+         class="scroll-to-bottom"
+         type="button"
+         :title="$t('chat.scrollToBottom') || '回到底部'"
+         @click="scrollToBottom({ smooth: true })"
+       >
+         <el-icon><ArrowDown /></el-icon>
+       </button>
+      </div>
+    </Transition>
   </div>
 </template>
 
 <script setup lang="ts">
-import { computed, watch, nextTick } from 'vue'
+import { computed, ref, watch, nextTick, onMounted, onUnmounted } from 'vue'
 import { useI18n } from 'vue-i18n'
-import { ChatDotRound, DataLine, EditPen, Monitor, Right } from '@element-plus/icons-vue'
+import { ArrowDown, ChatDotRound, DataLine, EditPen, Monitor, Right } from '@element-plus/icons-vue'
 
 const { t } = useI18n()
 import MessageBubble from './MessageBubble.vue'
@@ -166,7 +186,7 @@ const isCronHeader = (msg: Message) => {
 }
 
 // 智能滚动
-const { scrollRef, contentRef, isAtBottom, scrollToBottom } = useStickToBottom({
+const { scrollRef, contentRef, isAtBottom, escapedFromLock, scrollToBottom } = useStickToBottom({
   enabled: props.autoScroll,
   offset: 70,
   smooth: true,
@@ -185,6 +205,8 @@ watch(
   () => props.messages,
   async () => {
     await nextTick()
+    // 用户已向上滚动查看历史内容时不自动滚动
+    if (escapedFromLock.value) return
     scrollToBottom()
   },
   { deep: true }
@@ -200,6 +222,55 @@ watch(
     }
   }
 )
+
+// ========== 回到底部按钮：15秒无操作自动吸附到边缘 ==========
+const DOCK_DELAY_MS = 15000
+let dockTimer: ReturnType<typeof setTimeout> | null = null
+const isButtonDocked = ref(false)
+
+function clearDockTimer() {
+  if (dockTimer) { clearTimeout(dockTimer); dockTimer = null }
+}
+
+function resetDockTimer() {
+  isButtonDocked.value = false
+  if (!isAtBottom.value) {
+    clearDockTimer()
+    dockTimer = setTimeout(() => { isButtonDocked.value = true }, DOCK_DELAY_MS)
+  }
+}
+
+function undockButton() {
+  isButtonDocked.value = false
+  resetDockTimer()
+}
+
+watch(isAtBottom, (atBottom) => {
+  if (atBottom) { clearDockTimer(); isButtonDocked.value = false }
+  else resetDockTimer()
+})
+
+watch(scrollRef, (el, _, onCleanup) => {
+  if (!el) return
+  el.addEventListener('scroll', resetDockTimer, { passive: true })
+  onCleanup(() => el.removeEventListener('scroll', resetDockTimer))
+})
+
+onUnmounted(() => clearDockTimer())
+
+// ========== End 键快捷回到底部 ==========
+function handleGlobalKeydown(e: KeyboardEvent) {
+  if (e.key !== 'End') return
+  // 不在输入框内才响应（textarea / input / contentEditable）
+  const el = document.activeElement
+  if (el && (el.tagName === 'INPUT' || el.tagName === 'TEXTAREA' || (el as HTMLElement).isContentEditable)) return
+  if (isAtBottom.value) return
+  e.preventDefault()
+  scrollToBottom({ smooth: true })
+}
+
+onMounted(() => document.addEventListener('keydown', handleGlobalKeydown))
+onUnmounted(() => document.removeEventListener('keydown', handleGlobalKeydown))
 </script>
 
 <style scoped>
@@ -396,10 +467,87 @@ watch(
   }
 }
 
-/* 滚动提示 */
-.is-scrolling .scroll-to-bottom {
+.scroll-to-bottom-wrapper {
+  position: absolute;
+  bottom: 20%;
+  right: 0;
+  z-index: 10;
+  width: 48px;
+  height: 48px;
+  display: flex;
+  align-items: center;
+  justify-content: flex-end;
+  padding: 6px 8px;
+}
+
+.scroll-to-bottom {
+  width: 36px;
+  height: 36px;
+  border-radius: 50%;
+  border: 1px solid var(--mc-border, #e2e8f0);
+  background: var(--mc-bg-elevated, rgba(255, 255, 255, 0.92));
+  backdrop-filter: blur(6px);
+  color: var(--mc-text-secondary, #64748b);
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 16px;
   opacity: 1;
   pointer-events: auto;
+  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.08);
+  transform: translateX(0);
+  transition: transform 0.35s cubic-bezier(0.4, 0, 0.2, 1),
+              opacity 0.35s ease,
+              box-shadow 0.2s ease,
+              background 0.2s ease;
+  flex-shrink: 0;
+}
+
+.scroll-to-bottom:hover {
+  background: var(--mc-panel-raised, #f1f5f9);
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.12);
+  transform: scale(1.08);
+  color: var(--mc-primary, #D97757);
+  border-color: var(--mc-primary, #D97757);
+}
+
+/* 点击反馈：按下时微微缩小再弹回 */
+.scroll-to-bottom:active {
+  transform: scale(0.88);
+  transition: transform 0.1s ease;
+}
+
+/* 吸附到边缘：只露出约 8px */
+.scroll-to-bottom-wrapper.docked .scroll-to-bottom {
+  transform: translateX(28px);
+  opacity: 0.45;
+  /* 呼吸灯：微弱的脉冲光晕提醒用户按钮还在 */
+  animation: dock-breathe 3s ease-in-out infinite;
+}
+
+@keyframes dock-breathe {
+  0%, 100% { box-shadow: 0 0 0 0 rgba(217, 119, 87, 0); }
+  50%      { box-shadow: 0 0 8px 2px rgba(217, 119, 87, 0.18); }
+}
+
+/* 鼠标靠近即还原 */
+.scroll-to-bottom-wrapper.docked:hover .scroll-to-bottom {
+  transform: translateX(0);
+  opacity: 1;
+  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.08);
+  animation: none;
+}
+
+/* Transition: fade + slide up */
+.fade-up-enter-active,
+.fade-up-leave-active {
+  transition: opacity 0.25s ease, transform 0.25s ease;
+}
+.fade-up-enter-from,
+.fade-up-leave-to {
+  opacity: 0;
+  transform: translateY(16px);
 }
 
 /* ===== 移动端适配 ===== */
@@ -414,6 +562,21 @@ watch(
 
   .empty-state {
     min-height: 240px;
+  }
+
+  /* 移动端：按钮更大、位置更靠下（拇指热区） */
+  .scroll-to-bottom-wrapper {
+    bottom: 12%;
+  }
+
+  .scroll-to-bottom {
+    width: 44px;
+    height: 44px;
+    font-size: 18px;
+  }
+
+  .scroll-to-bottom-wrapper.docked .scroll-to-bottom {
+    transform: translateX(36px); /* 44px - 8px = 36 */
   }
 
   .welcome-screen {

--- a/mateclaw-ui/src/components/chat/index.ts
+++ b/mateclaw-ui/src/components/chat/index.ts
@@ -5,17 +5,11 @@ export { default as ChatInput } from './ChatInput.vue'
 export { default as TypingCursor } from './TypingCursor.vue'
 
 // Composables
-export { useTyping } from '@/composables/chat/useTyping'
 export { useStream } from '@/composables/chat/useStream'
 export { useStickToBottom } from '@/composables/chat/useStickToBottom'
 export { useMessages } from '@/composables/chat/useMessages'
 
 // Types
-export type {
-  UseTypingOptions,
-  UseTypingReturn,
-} from '@/composables/chat/useTyping'
-
 export type {
   SSEEvent,
   SSEEventType,

--- a/mateclaw-ui/src/composables/chat/useChat.ts
+++ b/mateclaw-ui/src/composables/chat/useChat.ts
@@ -2028,7 +2028,9 @@ export function useChat(options: UseChatOptions): UseChatReturn {
 
   // Reconnect to a stream that is already running on the backend
   const reconnectStream = async (conversationId: string) => {
-    if (isGenerating.value) return
+    // 仅当同一会话已有活跃 SSE 连接时才跳过（防止双流），
+    // 加载了另一会话的 generating 消息并不代表当前 stream 还在跑
+    if (isGenerating.value && streamConversationId === conversationId) return
 
     // Clear any leftover stop fallback timer
     if (stopFallbackTimer) { clearTimeout(stopFallbackTimer); stopFallbackTimer = null }
@@ -2054,9 +2056,20 @@ export function useChat(options: UseChatOptions): UseChatReturn {
       }
     }
 
-    const assistantMessage = createAssistantMessage('', conversationId)
-    ;(assistantMessage as any)._turnId = activeTurnId
-    currentAssistantId.value = assistantMessage.id as string
+    // 若消息列表中已有该会话的 assistant 消息（status=generating/awaiting_approval），
+    // 直接复用而不是创建新气泡，避免切换回生成中会话时出现重复消息
+    const existingAsst = [...messages.value].reverse().find(
+      m => m.role === 'assistant'
+        && m.conversationId === conversationId
+        && (m.status === 'generating' || m.status === 'awaiting_approval')
+    )
+    if (existingAsst) {
+      currentAssistantId.value = existingAsst.id as string
+    } else {
+      const assistantMessage = createAssistantMessage('', conversationId)
+      ;(assistantMessage as any)._turnId = activeTurnId
+      currentAssistantId.value = assistantMessage.id as string
+    }
 
     try {
       // reconnectStream always rebuilds from an EMPTY placeholder (above), so it

--- a/mateclaw-ui/src/composables/chat/useStickToBottom.ts
+++ b/mateclaw-ui/src/composables/chat/useStickToBottom.ts
@@ -125,13 +125,21 @@ export function useStickToBottom(
     isAtBottom.value = false
   }
 
-  // 处理滚动事件
-  const handleScroll = () => {
-    if (!scrollRef.value) return
-    if (isScrolling) {
+ // 处理滚动事件
+ const handleScroll = () => {
+   if (!scrollRef.value) return
+   if (isScrolling) {
+      // 即使在程序化滚动中，也要检测用户是否在向上滚动（滚动条/触摸操作）
+      const currentScrollTop = scrollRef.value.scrollTop
+      if (currentScrollTop < lastScrollTop) {
+        // 用户在程序化滚动过程中向上滚动了 → 中断自动滚动
+        isScrolling = false
+        escapedFromLock.value = true
+        isAtBottom.value = false
+      }
       lastScrollTop = scrollRef.value.scrollTop
-      return
-    }
+     return
+   }
 
     const element = scrollRef.value
     const currentScrollTop = element.scrollTop

--- a/mateclaw-ui/src/i18n/locales/en-US.ts
+++ b/mateclaw-ui/src/i18n/locales/en-US.ts
@@ -224,6 +224,7 @@ export default {
     modelSaveFailed: 'Model switch was not saved — the next message may still use the previous model',
     openSessions: 'Session Admin',
     clearMessages: 'Clear Messages',
+    scrollToBottom: 'Back to bottom',
     goToModelSettings: 'Go to Model Settings',
     configModelFirst: 'Please configure a model first',
     modelUnavailable: 'Current model is unavailable',

--- a/mateclaw-ui/src/i18n/locales/zh-CN.ts
+++ b/mateclaw-ui/src/i18n/locales/zh-CN.ts
@@ -224,6 +224,7 @@ export default {
     modelSaveFailed: '模型切换未保存，下条消息可能仍走原模型',
     openSessions: '会话管理',
     clearMessages: '清空消息',
+    scrollToBottom: '回到底部',
     goToModelSettings: '前往模型设置',
     configModelFirst: '请先配置模型',
     modelUnavailable: '当前模型不可用',

--- a/mateclaw-ui/src/views/ChatConsole.vue
+++ b/mateclaw-ui/src/views/ChatConsole.vue
@@ -243,13 +243,6 @@
       />
     </div>
 
-        <!-- 运行总览侧栏：计划进度 + 子 Agent 实时状态 -->
-        <RunOverviewPanel
-          :messages="messages"
-          :is-generating="isGenerating"
-          :agent-type="currentAgent?.agentType"
-        />
-
         <!-- Talk Mode 覆盖层 -->
         <TalkMode
           v-if="showTalkMode"
@@ -275,7 +268,6 @@ import { copyToClipboard } from '@/utils/clipboard'
 import { useFileDrop } from '@/composables/useFileDrop'
 import { useIsMobile, useMediaQuery, BREAKPOINTS } from '@/composables/useBreakpoint'
 import { useChat } from '@/composables/chat/useChat'
-import RunOverviewPanel from '@/components/chat/RunOverviewPanel.vue'
 import { reconstructErrorInfo } from '@/types/chatError'
 import { reconcileMessages, extractMessages } from '@/utils/messageReconcile'
 import type { Conversation, Agent, ModelConfig, ProviderInfo, ActiveModelsInfo, ChatAttachment, MessageContentPart, Message, ToolCallMeta, StreamPhase } from '@/types'
@@ -1515,7 +1507,9 @@ async function selectConversation(conv: Conversation) {
     if (currentConversationId.value !== requestedConvId) return
     // 点同一个会话时，若已有 SSE 在跑就不要覆盖本地消息状态
     if (switchingAway || !isGenerating.value) {
-      messages.value = extractMessages(res).messages.map((msg: Message) => normalizeMessage(msg))
+      // 若会话仍在运行中，保留 generating 状态以免破坏 isGenerating 和重连逻辑
+      const convRunning = conv.streamStatus === 'running'
+      messages.value = extractMessages(res).messages.map((msg: Message) => normalizeMessage(msg, convRunning))
     }
 
     // Hydrate pending approvals：恢复刷新后丢失的审批卡片（RFC-067 §4.9）
@@ -1914,7 +1908,7 @@ async function handleApproveAlways(
 
 // 重连到运行中的流
 async function reconnectStream(conversationId: string) {
-  if (isGenerating.value) return
+  // useChat.reconnectStream 内部已有更精细的 guard（同会话+isGenerating 才跳过），此处无需重复
   try {
     await reconnectChatStream(conversationId)
   } catch (e) {
@@ -2008,7 +2002,7 @@ function buildOutgoingParts(text: string, attachments: ChatAttachment[]): Messag
 }
 
 // ============ 工具函数 ============
-function normalizeMessage(raw: Message): Message {
+function normalizeMessage(raw: Message, preserveGeneratingStatus?: boolean): Message {
   const msg: Message = { ...raw, contentParts: raw.contentParts ? [...raw.contentParts] : [] }
 
   // 统一解析 metadata：确保是对象而非 JSON 字符串
@@ -2078,7 +2072,9 @@ function normalizeMessage(raw: Message): Message {
     msg.metadata = { ...msg.metadata, toolCalls: cleaned }
   }
 
-  if (msg.status === 'generating') msg.status = 'failed'
+  // 当会话仍在运行时（如切换回一个正在生成的会话），保留 generating 状态
+  // 以正确驱动 isGenerating / loading 指示器 / reconnect 逻辑
+  if (!preserveGeneratingStatus && msg.status === 'generating') msg.status = 'failed'
   // interrupted 是合法的历史状态（interrupt-with-followup），不映射为 stopped
   if (!msg.status) msg.status = 'completed'
 


### PR DESCRIPTION
…command

# Summary

Add a CLI shell to mateclaw-server so operational data reports can be generated from the command line (local or Docker exec) without going through the web UI.

# What's new

## CLI framework (`vip.mate.cli.MateClawCli`)
- Single-file core: CliCommand interface + CliContext + CliRunner
- Auto-discovers all `@Component` beans implementing `MateClawCli.CliCommand`
- `--cli.command=help` auto-generates help listing from registered commands
- `--cli.dry-run` global flag for dry-run mode
- `CliContext` provides arg parsing, date validation, output formatting, error handling, and graceful JVM exit

## Export command (`--cli.command=export`)
- Reads `--cli.start` / `--cli.end` (arbitrary date range, no 90-day cap)
- Calls `exportBackendBytes()` — no timeout limit, suitable for large ranges
- Writes ZIP bytes directly to stdout (no temp file on disk)
- Diagnostic messages go to stderr so `> report.zip` works cleanly

## Service change
- Added `OperationalDataExportService.exportBackendBytes()` — a backend-only entry point with no 90-day restriction and no timeout, returning `byte[]` instead of writing to disk