### PR TITLE
feat(wiki): support plain-string shorthand for StageInstructions fields

### DIFF
--- a/mateclaw-server/src/main/java/vip/mate/wiki/profile/WikiPageTypeDef.java
+++ b/mateclaw-server/src/main/java/vip/mate/wiki/profile/WikiPageTypeDef.java
@@ -1,8 +1,14 @@
 package vip.mate.wiki.profile;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.core.JsonToken;
+import com.fasterxml.jackson.databind.DeserializationContext;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.fasterxml.jackson.databind.deser.std.StdDeserializer;
 import lombok.Data;
 
+import java.io.IOException;
 import java.util.LinkedHashMap;
 import java.util.Map;
 
@@ -43,10 +49,32 @@ public class WikiPageTypeDef {
 
     @Data
     @JsonIgnoreProperties(ignoreUnknown = true)
+    @JsonDeserialize(using = WikiPageTypeDef.StageInstructions.Deserializer.class)
     public static class StageInstructions {
         private String instructions;
         /** Optional template key referenced by the create stage. */
         private String template;
+
+        static class Deserializer extends StdDeserializer<StageInstructions> {
+            Deserializer() { super(StageInstructions.class); }
+
+            @Override
+            public StageInstructions deserialize(JsonParser p, DeserializationContext ctx) throws IOException {
+                StageInstructions s = new StageInstructions();
+                if (p.currentToken() == JsonToken.VALUE_STRING) {
+                    s.setInstructions(p.getText());
+                } else if (p.currentToken() == JsonToken.START_OBJECT) {
+                    while (p.nextToken() != JsonToken.END_OBJECT) {
+                        String field = p.currentName();
+                        p.nextToken();
+                        if ("instructions".equals(field)) s.setInstructions(p.getValueAsString());
+                        else if ("template".equals(field)) s.setTemplate(p.getText());
+                        else p.skipChildren();
+                    }
+                }
+                return s;
+            }
+        }
     }
 
     @Data


### PR DESCRIPTION
## 解决的问题

pageType profile 的 route / create / merge 字段通常只需要填一段 LLM prompt，不需要每次写完整 JSON 对象。

## 实现方案

为 `StageInstructions` 添加自定义 `StdDeserializer`，在反序列化时判断 token 类型：

- **VALUE_STRING** → 直接取字符串赋值给 `instructions`
- **START_OBJECT** → 正常解析 `instructions` 和 `template` 字段

两种格式完全等价，已有的完整对象配置不受影响。

## 验证

- 单元测试覆盖两种格式
- 已部署为 `1.5.6-SNAPSHOT` 在生产环境验证通过

Closes #423