### PR TITLE
fix(wiki): 处理配置页卡片溢出屏幕且无滚动条 (#429)

### DIFF
--- a/mateclaw-ui/src/views/Wiki/components/WikiWorkspace.vue
+++ b/mateclaw-ui/src/views/Wiki/components/WikiWorkspace.vue
@@ -187,7 +187,7 @@ async function onOpenPage(slug: string) {
 .tab-btn:hover { color: var(--mc-text-primary); }
 .tab-btn.active { color: var(--mc-primary); background: var(--mc-bg-elevated); box-shadow: 0 1px 4px rgba(0,0,0,0.08); font-weight: 600; }
 .tab-content { flex: 1; min-height: 0; overflow-y: auto; padding-right: 2px; }
-.tab-content--config { overflow: hidden; padding-right: 0; }
+.tab-content--config { overflow-y: auto; padding-right: 0; }
 .tab-content--graph { overflow: hidden; padding: 0; }
 
 .empty-state { display: flex; flex-direction: column; align-items: center; justify-content: center; gap: 12px; min-height: 200px; color: var(--mc-text-tertiary); text-align: center; }


### PR DESCRIPTION
Closes #429

## 问题
知识库管理视图的「处理配置」tab，内容超高时下方三张卡片（模型策略 / 处理规则 / 检索测试）溢出屏幕底部且无滚动条。

## 根因
`.tab-content--config` 被设为 `overflow: hidden`（照搬图谱栏），而内层 `.wiki-config` 无有界高度，自身 `overflow-y: auto` 永不触发。

## 修复
`.tab-content--config` 改为 `overflow-y: auto`，与通用 `.tab-content` 一致。≤980px 的 `@media` 分支（`overflow: visible`）保持移动端整页滚动。

纯 CSS，单行，无逻辑改动。

## 验证
管理视图 → 处理配置 → 压低窗口高度 → 滚动条出现，三张卡片可达。