### PR TITLE
fix(wiki): 处理配置 tab 选中后自动跳回「来源」 (#431)

### DIFF
--- a/mateclaw-ui/src/views/Wiki/components/RawMaterialPanel.vue
+++ b/mateclaw-ui/src/views/Wiki/components/RawMaterialPanel.vue
@@ -439,6 +439,14 @@ onBeforeUnmount(() => {
     clearInterval(fallbackTimer)
     fallbackTimer = null
   }
+  // Stop the per-raw job poller too. Without this the setTimeout chain keeps
+  // running after the panel unmounts (e.g. switching to the config tab while a
+  // raw is still processing), calling refreshCurrentKB() every 3s and snapping
+  // the user back to this tab.
+  if (jobPoller != null) {
+    clearTimeout(jobPoller)
+    jobPoller = null
+  }
 })
 
 // RFC-033: Job polling per raw material

--- a/mateclaw-ui/src/views/Wiki/components/WikiWorkspace.vue
+++ b/mateclaw-ui/src/views/Wiki/components/WikiWorkspace.vue
@@ -157,8 +157,15 @@ const tabs = computed<{ key: WikiTab; label: string }[]>(() => {
 
 // Snap to each view's default tab whenever the KB or the view mode changes, so
 // the user never lands on a stale tab (or one that doesn't exist in this mode).
+// Use an array of getters (not a single getter returning an array): the latter
+// returns a fresh array reference on every evaluation, so Vue's Object.is check
+// always reports a change and the callback fires on *any* currentKB
+// reassignment — including background refreshes (refreshCurrentKB) that keep the
+// same id. That would yank the user off the config tab back to 'raw' every time
+// a poll/SSE refresh reassigned the KB object. The array-of-getters form
+// compares each source individually, so it fires only on a real id/mode change.
 watch(
-  () => [store.currentKB?.id, store.workspaceMode],
+  [() => store.currentKB?.id, () => store.workspaceMode],
   () => { activeTab.value = store.workspaceMode === 'manage' ? 'raw' : 'pages' },
   { immediate: true },
 )


### PR DESCRIPTION
Closes #431

## 问题
管理视图点「处理配置」tab 后过几秒自动跳回「来源」，有素材处理中时尤其明显。

## 根因（两处叠加）
1. **tab 重置 watcher 误触发**（`WikiWorkspace.vue`）：`watch(() => [currentKB?.id, workspaceMode], …)` 单 getter 每次返回新数组，`Object.is` 恒判变化 → 任何 `currentKB` 重新赋值（含后台 `refreshCurrentKB`，id 不变）都会把 `activeTab` 拉回 `raw`。
2. **jobPoller 泄漏**（`RawMaterialPanel.vue`）：`onBeforeUnmount` 清了 SSE 和 60s 兜底定时器但漏清 `jobPoller`（3s setTimeout 链）。素材处理中离开来源 tab 后该轮询仍持续调 `refreshCurrentKB()`，反复触发上面的 watcher。

## 修复
- watcher 改为 array-of-getters：`[() => currentKB?.id, () => workspaceMode]`，逐项比较，仅 id/模式真正变化时触发。
- `onBeforeUnmount` 补清 `jobPoller`。

两处均为前端逻辑修复，无后端/接口改动。

## 验证
素材处理中 → 切到处理配置 tab → 停留 >10s 不再跳回；离开来源 tab 后 3s 轮询停止（不再有后台 refresh 请求）。