### PR TITLE
fix(chat): chat-upload path 存相对路径而非服务端绝对路径

### DIFF
--- a/mateclaw-server/src/main/java/vip/mate/channel/web/ChatController.java
+++ b/mateclaw-server/src/main/java/vip/mate/channel/web/ChatController.java
@@ -1103,8 +1103,8 @@ public class ChatController {
         response.setFileName(originalFilename);
         response.setStoredName(storedName);
         response.setUrl("/api/v1/chat/files/" + conversationId + "/" + storedName);
-        // 使用相对路径，避免暴露服务端绝对路径
-        response.setPath(uploadRoot.resolve(conversationId).resolve(storedName).toString());
+        // 用 root 相对路径，避免暴露服务端绝对路径（uploadRoot 现在恒为绝对路径）。
+        response.setPath(toRelativeUploadPath(uploadRoot, conversationId, storedName));
         response.setSize(file.getSize());
         response.setContentType(file.getContentType());
         return R.ok(response);
@@ -1498,6 +1498,31 @@ public class ChatController {
 
     static boolean isAssistantPersisted(MessageEntity savedAssistant) {
         return savedAssistant != null;
+    }
+
+    /**
+     * Build the value stored in {@code ChatUploadResponse.path} (and, downstream,
+     * the message content part): a root-relative path like
+     * {@code chat-uploads/{convId}/{storedName}}, never the absolute on-disk
+     * location.
+     * <p>
+     * {@code uploadRoot} is always absolute (the resolver normalizes it via
+     * {@code toAbsolutePath().normalize()}), and this field is purely
+     * informational — it is rendered into the LLM prompt ("附件: foo (path)") and
+     * returned to the client, while retrieval goes through the basename-based
+     * {@code ChatUploadResolver} plus the {@code /api/v1/chat/files/...} URL. So
+     * the absolute form must be avoided: it leaks the server's filesystem layout
+     * into the prompt/response and breaks if the deploy directory ever moves.
+     * <p>
+     * The path is made relative to {@code uploadRoot}'s parent so the trailing
+     * upload sub-directory name is preserved (e.g. {@code chat-uploads/...}), and
+     * separators are normalized to {@code /} so the value is stable across OSes.
+     */
+    static String toRelativeUploadPath(Path uploadRoot, String conversationId, String storedName) {
+        Path target = uploadRoot.resolve(conversationId).resolve(storedName);
+        Path base = uploadRoot.getParent();
+        Path relative = base != null ? base.relativize(target) : target;
+        return relative.toString().replace('\\', '/');
     }
 
     private MessageEntity saveEmptyAssistantPlaceholder(String conversationId, String status,

--- a/mateclaw-server/src/test/java/vip/mate/channel/web/ChatControllerUploadPathTest.java
+++ b/mateclaw-server/src/test/java/vip/mate/channel/web/ChatControllerUploadPathTest.java
@@ -1,0 +1,57 @@
+package vip.mate.channel.web;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.nio.file.Path;
+import java.nio.file.Paths;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Pins {@link ChatController#toRelativeUploadPath} to return a <em>root-relative</em>
+ * path, never the absolute server location.
+ * <p>
+ * Regression guard for the workspace-aware chat-uploads change: once the upload
+ * root became absolute (the resolver normalizes via {@code toAbsolutePath()}),
+ * the {@code path} field — which is rendered into the LLM prompt and returned to
+ * the client — started leaking the server's absolute filesystem layout. These
+ * tests lock the value back to {@code chat-uploads/{convId}/{storedName}}.
+ */
+class ChatControllerUploadPathTest {
+
+    @Test
+    @DisplayName("default root: returns chat-uploads/{convId}/{storedName}, not absolute")
+    void defaultRootIsRelative() {
+        // Mirrors the resolver's default root: absolute + normalized.
+        Path uploadRoot = Paths.get("data", "chat-uploads").toAbsolutePath().normalize();
+
+        String path = ChatController.toRelativeUploadPath(uploadRoot, "conv-1", "1777_a.txt");
+
+        assertThat(path).isEqualTo("chat-uploads/conv-1/1777_a.txt");
+        assertThat(Paths.get(path).isAbsolute()).isFalse();
+        assertThat(path).doesNotContain(uploadRoot.toString());
+    }
+
+    @Test
+    @DisplayName("workspace-scoped absolute root: still root-relative, no leak")
+    void scopedRootIsRelative() {
+        // An absolute workspace basePath somewhere outside the CWD.
+        Path uploadRoot = Paths.get("/srv/ws/alpha/chat-uploads").toAbsolutePath().normalize();
+
+        String path = ChatController.toRelativeUploadPath(uploadRoot, "conv-2", "9_b.pdf");
+
+        assertThat(path).isEqualTo("chat-uploads/conv-2/9_b.pdf");
+        assertThat(path).doesNotContain("/srv/ws/alpha");
+    }
+
+    @Test
+    @DisplayName("custom base-dir name is preserved (not hardcoded to chat-uploads)")
+    void customBaseDirNamePreserved() {
+        Path uploadRoot = Paths.get("/var/uploads").toAbsolutePath().normalize();
+
+        String path = ChatController.toRelativeUploadPath(uploadRoot, "conv-3", "f.bin");
+
+        assertThat(path).isEqualTo("uploads/conv-3/f.bin");
+    }
+}


### PR DESCRIPTION
> 关联 ISSUE: #452（本 PR 处理其中的 🟡 blocker 项）

## 背景

PR #422 把 chat-uploads 目录改成工作空间/Agent 感知后，上传根目录恒为**绝对路径**（`ChatUploadLocationResolver` 用 `toAbsolutePath().normalize()`，且 `ChatUploadAutoConfiguration` 把 `baseDir` 重写成绝对路径）。

但 `ChatController.upload` 仍然这样设置返回的 `path` 字段：

```java
// 使用相对路径，避免暴露服务端绝对路径
response.setPath(uploadRoot.resolve(conversationId).resolve(storedName).toString());
```

注释承诺"相对路径避免暴露绝对路径"，实际却存了绝对路径。该字段会：
1. 被渲染进 **LLM prompt**（`ChatController` 的 `附件: foo (path)` / `图片附件:` / `视频附件:`）；
2. 返回给前端，并按 #422 设计进入 `MessageContentPart`。

后果：服务端绝对文件系统布局泄漏进 prompt 和响应；改部署目录后历史消息里的绝对路径失效（相对路径本可移植）。

## 改动

抽出静态助手 `toRelativeUploadPath(uploadRoot, convId, storedName)`：
- 相对于 `uploadRoot` 的父目录做 `relativize`，保留尾部子目录名（如 `chat-uploads/{convId}/{storedName}`）；
- 分隔符归一化为 `/`，跨 OS 取值稳定。

检索逻辑不受影响：读取走基于 basename 的 `ChatUploadResolver` 与 `/api/v1/chat/files/...` URL，不依赖该字段。

## 测试

新增 `ChatControllerUploadPathTest`（3 用例）：默认根、绝对的 workspace-scoped 根、自定义 base-dir 名——断言结果为相对路径且不含绝对前缀。沿用本仓库"直接测 ChatController 静态助手"的既有范式（见 `ChatControllerPersistStatusTest`）。

## 兼容性

- `path` 取值从 `data/chat-uploads/{convId}/{storedName}`（#422 前的相对形式，但 #422 后变成了绝对）回到相对形式 `chat-uploads/{convId}/{storedName}`；该字段仅作信息展示（prompt 提示 + 客户端回显），非检索依赖，故无破坏性。
- 服务端点 URL 契约 `/api/v1/chat/files/{convId}/{storedName}` 不变，前端无需改动。

## 范围

仅处理 #452 的 🟡 blocker。其余 3 项 🟢 边角（tool 读写双作用域来源、首传落 default 根、缓存只覆盖一半热路径）留在 #452 作为 follow-up，保持本 PR 单一关注点。
