### PR TITLE
修复同一 Agent 多并发会话记忆混乱问题

### DIFF
--- a/mateclaw-server/src/main/java/vip/mate/agent/AgentGraphBuilder.java
+++ b/mateclaw-server/src/main/java/vip/mate/agent/AgentGraphBuilder.java
@@ -39,7 +39,6 @@ import vip.mate.llm.model.ModelConfigEntity;
 import vip.mate.llm.model.ModelFamily;
 import vip.mate.llm.model.ModelProtocol;
 import vip.mate.llm.model.ModelProviderEntity;
-import vip.mate.llm.routing.ProviderModelRef;
 import vip.mate.llm.routing.ProviderRouter;
 import vip.mate.llm.service.ModelConfigService;
 import vip.mate.llm.service.ModelProviderService;
@@ -1185,99 +1184,66 @@ public class AgentGraphBuilder {
         String primaryProviderId = primaryModelConfig != null ? primaryModelConfig.getProvider() : null;
         String primaryModelName = primaryModelConfig != null ? primaryModelConfig.getModelName() : null;
 
-        // RFC-090 §9.2 调整 C — lift providers that satisfy the bound-skill
-        // capability set (vision / video / audio) ahead of those that don't.
-        // Run before planning so the non-preferred tail inherits this order;
-        // the explicit preferred-model head keeps the user's declared order.
+        // RFC-009 PR-3: bias by agent preferences (if any). Listed providers win
+        // their declared order; everything else keeps the global priority order.
+        List<String> preferred = agentId == null
+                ? java.util.Collections.emptyList()
+                : agentBindingService.getPreferredProviderIds(agentId);
+        if (!preferred.isEmpty()) {
+            providers = reorderByPreferences(providers, preferred);
+            log.debug("[LlmFailover] agent={} preferences={} -> chain head reordered", agentId, preferred);
+        }
+
+        // RFC-090 §9.2 调整 C — second-pass reorder: lift providers
+        // that satisfy the bound-skill capability set (vision / video /
+        // audio) ahead of those that don't. Stable otherwise so the
+        // user-preferred order still wins among capable providers.
         try {
             providers = new ArrayList<>(providerRouter.reorderForCapabilities(agentId, providers));
         } catch (Exception e) {
             log.debug("[ProviderRouter] chain reorder failed: {}", e.getMessage());
         }
 
-        // Preferred-model chain: explicit (provider, model) entries lead in the
-        // user's order — the same provider may repeat with different models —
-        // then every non-preferred provider follows with its default model.
-        List<ProviderModelRef> preferred = agentId == null
-                ? java.util.Collections.emptyList()
-                : agentBindingService.getPreferredProviderModels(agentId);
-        List<String> globalProviderIds = providers.stream()
-                .map(ModelProviderEntity::getProviderId)
-                .toList();
-        List<ProviderModelRef> plan = planFallbackOrder(preferred, globalProviderIds);
-        if (!preferred.isEmpty()) {
-            log.debug("[LlmFailover] agent={} preferred-model chain={} -> plan={}", agentId, preferred, plan);
-        }
-
-        // Dedup by exact (provider, model) — seeded with the primary so we never
-        // rebuild the primary call, but OTHER models of the primary provider are
-        // still legitimate fallback entries.
         List<vip.mate.llm.failover.FallbackEntry> chain = new ArrayList<>();
-        Set<String> seen = new java.util.HashSet<>();
-        if (primaryProviderId != null && primaryModelName != null) {
-            seen.add(primaryProviderId + "::" + primaryModelName);
-        }
-        for (ProviderModelRef ref : plan) {
-            String pid = ref.providerId();
-            // RFC-009 Phase 4: skip providers known-bad at build time. The runtime
-            // walker re-checks pool membership per request, so a provider that
-            // re-enters the pool later still gets used (graph rebuilt on
+        for (ModelProviderEntity p : providers) {
+            // Don't put the primary provider's row into the fallback chain — same-instance
+            // skipping is also done in the runtime walker, but excluding here saves building
+            // a duplicate ChatModel at agent-build time.
+            if (primaryProviderId != null && primaryProviderId.equals(p.getProviderId())) {
+                log.debug("[LlmFailover] skipping primary provider {} in fallback chain", primaryProviderId);
+                continue;
+            }
+            // RFC-009 Phase 4: skip providers known-bad at build time. The runtime walker in
+            // NodeStreamingChatHelper re-checks pool membership per request, so a provider
+            // that re-enters the pool later still gets used (the graph is rebuilt on
             // ModelConfigChangedEvent).
-            if (providerPool != null && !providerPool.contains(pid)) {
-                log.debug("[LlmFailover] skipping provider {} — not in available pool", pid);
+            if (providerPool != null && !providerPool.contains(p.getProviderId())) {
+                log.debug("[LlmFailover] skipping provider {} — not in available pool",
+                        p.getProviderId());
                 continue;
             }
-            ModelConfigEntity fallbackConfig = resolveChainModel(ref);
+            ModelConfigEntity fallbackConfig = pickFallbackModel(p.getProviderId());
             if (fallbackConfig == null) {
-                log.debug("[LlmFailover] skipping {} — no usable chat model", pid);
+                log.debug("[LlmFailover] skipping provider {} — no enabled chat model",
+                        p.getProviderId());
                 continue;
             }
-            String key = pid + "::" + fallbackConfig.getModelName();
-            if (!seen.add(key)) {
-                // Exact (provider, model) already queued or equal to the primary.
+            if (primaryModelName != null && primaryModelName.equals(fallbackConfig.getModelName())) {
+                // Same model name picked for a different provider — exact same call, skip.
                 continue;
             }
             try {
                 ChatModel m = buildRuntimeChatModel(fallbackConfig, RetryTemplate.builder().maxAttempts(1).build());
-                chain.add(new vip.mate.llm.failover.FallbackEntry(pid, m));
-                log.info("[LlmFailover] chain[{}] = {}/{}", chain.size(), pid, fallbackConfig.getModelName());
+                chain.add(new vip.mate.llm.failover.FallbackEntry(p.getProviderId(), m));
+                log.info("[LlmFailover] chain[{}] = {}/{} (priority={})",
+                        chain.size(), p.getProviderId(), fallbackConfig.getModelName(),
+                        p.getFallbackPriority());
             } catch (Exception e) {
-                log.warn("[LlmFailover] skipping provider {} — chat model build failed: {}", pid, e.getMessage());
+                log.warn("[LlmFailover] skipping provider {} — chat model build failed: {}",
+                        p.getProviderId(), e.getMessage());
             }
         }
         return chain;
-    }
-
-    /**
-     * Resolve a planned chain entry to a concrete chat model. A pinned model
-     * ({@code modelId != null}) is used when it still exists and is enabled;
-     * otherwise we fall back to the provider's default chat model so a deleted
-     * or disabled pin keeps the provider in the chain.
-     */
-    private ModelConfigEntity resolveChainModel(ProviderModelRef ref) {
-        if (ref.modelId() != null) {
-            try {
-                ModelConfigEntity m = modelConfigService.getModel(ref.modelId());
-                // Honour the pin only when it is a usable chat model that actually
-                // belongs to this entry's provider. The FallbackEntry is keyed by
-                // ref.providerId() for cooldown/pool, so a model from a different
-                // provider would mis-key the chain; an embedding model would never
-                // serve as a chat fallback. Either case falls back to the
-                // provider's default chat model.
-                if (m != null && Boolean.TRUE.equals(m.getEnabled())
-                        && ref.providerId().equals(m.getProvider())
-                        && (m.getModelType() == null || "chat".equals(m.getModelType()))) {
-                    return m;
-                }
-                log.info("[LlmFailover] pinned model {} for provider {} not usable "
-                                + "(disabled / wrong provider / non-chat), using provider default",
-                        ref.modelId(), ref.providerId());
-            } catch (Exception e) {
-                log.info("[LlmFailover] pinned model {} for provider {} unresolved ({}), using provider default",
-                        ref.modelId(), ref.providerId(), e.getMessage());
-            }
-        }
-        return pickFallbackModel(ref.providerId());
     }
 
     /**
@@ -1309,40 +1275,33 @@ public class AgentGraphBuilder {
     }
 
     /**
-     * Plan the fallback order as a list of (provider, model) refs.
-     *
-     * <p>Head: the agent's explicit preference entries in declared order,
-     * model-granular — the same provider may appear more than once with
-     * different models. Exact (provider, model) duplicates are dropped.
-     *
-     * <p>Tail: every provider not named in the preferences, in the supplied
-     * global order, each using its default model ({@code modelId == null}).
-     *
-     * <p>Preference entries with a blank provider id are ignored. Package-private
-     * for unit testing — see {@code AgentGraphBuilderPreferenceTest}.
+     * Reorder a provider list by an agent's preference list. Listed provider
+     * ids come first in their preference order; any provider not in the
+     * preference list keeps its original position relative to other unlisted
+     * providers (stable partition). Preference entries that don't match any
+     * actual provider are silently dropped.
      */
-    static List<ProviderModelRef> planFallbackOrder(List<ProviderModelRef> preferred,
-                                                    List<String> globalProviderIds) {
-        List<ProviderModelRef> plan = new ArrayList<>();
-        Set<String> headEntryKeys = new java.util.HashSet<>();
-        Set<String> headProviderIds = new java.util.HashSet<>();
-        if (preferred != null) {
-            for (ProviderModelRef ref : preferred) {
-                if (ref == null || ref.providerId() == null || ref.providerId().isBlank()) continue;
-                String key = ref.providerId() + "::" + (ref.modelId() == null ? "" : ref.modelId());
-                if (!headEntryKeys.add(key)) continue; // exact (provider, model) dup
-                plan.add(ref);
-                headProviderIds.add(ref.providerId());
+    /** Package-private for unit testing — see {@code AgentGraphBuilderPreferenceTest}. */
+    static List<ModelProviderEntity> reorderByPreferences(List<ModelProviderEntity> providers,
+                                                          List<String> preferredOrder) {
+        Map<String, ModelProviderEntity> byId = new java.util.LinkedHashMap<>();
+        for (ModelProviderEntity p : providers) {
+            byId.put(p.getProviderId(), p);
+        }
+        List<ModelProviderEntity> reordered = new ArrayList<>(providers.size());
+        Set<String> placed = new java.util.HashSet<>();
+        for (String prefId : preferredOrder) {
+            ModelProviderEntity p = byId.get(prefId);
+            if (p != null && placed.add(prefId)) {
+                reordered.add(p);
             }
         }
-        if (globalProviderIds != null) {
-            for (String pid : globalProviderIds) {
-                if (pid == null || pid.isBlank()) continue;
-                if (headProviderIds.contains(pid)) continue; // already led by an explicit entry
-                plan.add(new ProviderModelRef(pid, null));
+        for (ModelProviderEntity p : providers) {
+            if (placed.add(p.getProviderId())) {
+                reordered.add(p);
             }
         }
-        return plan;
+        return reordered;
     }
 
     /**
@@ -1530,10 +1489,11 @@ public class AgentGraphBuilder {
                 adopting a KB article as the user's project.
 
                 ## Session Search
-                - `session_search(agentId, currentConversationId, mode, query, limit)` — search conversation history
+                - `session_search(agentId, mode, query, limit)` — search conversation history
                 - mode="recent": list recent conversations (titles, times, message counts)
                 - mode="search": keyword full-text search across past messages
                 - Use this to recall previous discussions, look up past decisions, or find context from earlier conversations
+                - Note: only completed conversations are searchable; in-progress concurrent conversations are excluded
 
                 ## Tool Usage Guidelines
                 When you have available tools, use them to access local system information, files, or execute commands.

--- a/mateclaw-server/src/main/java/vip/mate/agent/graph/plan/StateGraphPlanExecuteAgent.java
+++ b/mateclaw-server/src/main/java/vip/mate/agent/graph/plan/StateGraphPlanExecuteAgent.java
@@ -97,8 +97,8 @@ public class StateGraphPlanExecuteAgent extends BaseAgent implements StructuredS
             log.info("[{}] Plan-Execute replay stream: conversationId={}", agentName, conversationId);
             Map<String, Object> inputs = buildInitialState(userMessage, conversationId);
 
-            // 从 DB 恢复 awaiting_approval 状态的计划上下文
-            PlanningService.PlanResumeContext ctx = planningService.findAwaitingApprovalContext();
+            // 从 DB 恢复 awaiting_approval 状态的计划上下文（按 conversationId 过滤，避免并发会话误取）
+            PlanningService.PlanResumeContext ctx = planningService.findAwaitingApprovalContext(conversationId);
             if (ctx != null) {
                 inputs.put(PlanStateKeys.PLAN_ID, ctx.planId());
                 inputs.put(PlanStateKeys.PLAN_STEPS, ctx.steps());

--- a/mateclaw-server/src/main/java/vip/mate/memory/search/SessionSearchService.java
+++ b/mateclaw-server/src/main/java/vip/mate/memory/search/SessionSearchService.java
@@ -35,7 +35,9 @@ public class SessionSearchService {
 
     /**
      * Search messages across conversations for the given agent.
-     * Excludes the current conversation.
+     * Excludes the current conversation AND any conversation currently in
+     * 'running' stream status, so that concurrent sibling conversations of
+     * the same agent don't leak in-progress context into each other.
      */
     public List<SessionSearchResult> search(Long agentId, String currentConversationId,
                                             String query, int limit) {
@@ -43,28 +45,37 @@ public class SessionSearchService {
             return List.of();
         }
         int effectiveLimit = Math.min(Math.max(limit, 1), 50);
+        String excludeConvId = currentConversationId != null ? currentConversationId : "";
 
         try {
             if (isMySql()) {
-                return searchMySQL(agentId, currentConversationId, query, effectiveLimit);
+                return searchMySQL(agentId, excludeConvId, query, effectiveLimit);
             } else {
-                return searchH2(agentId, currentConversationId, query, effectiveLimit);
+                return searchH2(agentId, excludeConvId, query, effectiveLimit);
             }
         } catch (Exception e) {
             log.warn("[SessionSearch] Search failed, falling back to LIKE: {}", e.getMessage());
-            return searchH2(agentId, currentConversationId, query, effectiveLimit);
+            return searchH2(agentId, excludeConvId, query, effectiveLimit);
         }
     }
 
     /**
      * List recent conversations for the given agent.
+     * Excludes the current conversation and any conversation currently in
+     * 'running' stream status to avoid surfacing concurrent in-flight
+     * conversations.
      */
-    public List<Map<String, Object>> listRecent(Long agentId, int limit) {
+    public List<Map<String, Object>> listRecent(Long agentId, String currentConversationId, int limit) {
         int effectiveLimit = Math.min(Math.max(limit, 1), 50);
+        String excludeConvId = currentConversationId != null && !currentConversationId.isBlank()
+                ? currentConversationId : "";
+
         String sql = """
                 SELECT conversation_id, title, message_count, last_active_time, create_time
                 FROM mate_conversation
                 WHERE agent_id = ? AND deleted = 0
+                  AND (stream_status IS NULL OR stream_status != 'running')
+                  AND (? = '' OR conversation_id != ?)
                 ORDER BY last_active_time DESC
                 LIMIT ?
                 """;
@@ -77,13 +88,14 @@ public class SessionSearchService {
             row.put("lastActiveTime", toLocalDateTime(rs.getTimestamp("last_active_time")));
             row.put("createTime", toLocalDateTime(rs.getTimestamp("create_time")));
             return row;
-        }, agentId, effectiveLimit);
+        }, agentId, excludeConvId, excludeConvId, effectiveLimit);
     }
 
     // ==================== MySQL FULLTEXT ====================
 
     private List<SessionSearchResult> searchMySQL(Long agentId, String currentConversationId,
                                                    String query, int limit) {
+        // 排除当前会话 + 排除正在运行中的并发兄弟会话，避免上下文串台
         String sql = """
                 SELECT m.conversation_id, m.role, m.content, m.create_time,
                        c.title,
@@ -93,6 +105,7 @@ public class SessionSearchService {
                 WHERE c.agent_id = ? AND m.conversation_id != ?
                   AND m.role IN ('user', 'assistant')
                   AND m.deleted = 0 AND c.deleted = 0
+                  AND (c.stream_status IS NULL OR c.stream_status != 'running')
                   AND MATCH(m.content) AGAINST(? IN NATURAL LANGUAGE MODE)
                 ORDER BY relevance DESC
                 LIMIT ?
@@ -109,6 +122,7 @@ public class SessionSearchService {
         // Escape SQL LIKE special chars
         String escapedQuery = query.replace("%", "\\%").replace("_", "\\_");
 
+        // 排除当前会话 + 排除正在运行中的并发兄弟会话，避免上下文串台
         String sql = """
                 SELECT m.conversation_id, m.role, m.content, m.create_time, c.title
                 FROM mate_message m
@@ -116,6 +130,7 @@ public class SessionSearchService {
                 WHERE c.agent_id = ? AND m.conversation_id != ?
                   AND m.role IN ('user', 'assistant')
                   AND m.deleted = 0 AND c.deleted = 0
+                  AND (c.stream_status IS NULL OR c.stream_status != 'running')
                   AND LOWER(m.content) LIKE LOWER(CONCAT('%', ?, '%'))
                 ORDER BY m.create_time DESC
                 LIMIT ?

--- a/mateclaw-server/src/main/java/vip/mate/memory/search/SessionSearchTool.java
+++ b/mateclaw-server/src/main/java/vip/mate/memory/search/SessionSearchTool.java
@@ -4,9 +4,11 @@ import cn.hutool.json.JSONObject;
 import cn.hutool.json.JSONUtil;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.ai.chat.model.ToolContext;
 import org.springframework.ai.tool.annotation.Tool;
 import org.springframework.ai.tool.annotation.ToolParam;
 import org.springframework.stereotype.Component;
+import vip.mate.agent.context.ChatOrigin;
 
 import java.util.List;
 import java.util.Map;
@@ -17,6 +19,10 @@ import java.util.Map;
  * Two modes:
  * - "recent": list recent conversations (metadata only, no LLM cost)
  * - "search": keyword-based full-text search over message content
+ * <p>
+ * 会话隔离说明：currentConversationId 从 ToolContext.ChatOrigin 强制读取，
+ * 不再依赖 LLM 自传参数。搜索结果会排除当前会话以及正在运行中的并发兄弟会话，
+ * 避免同一 agent 的多个并发会话之间上下文串台。
  *
  * @author MateClaw Team
  */
@@ -33,13 +39,14 @@ public class SessionSearchTool {
             - "recent"：列出最近的会话（标题、时间、消息数），不需要 query 参数
             - "search"：按关键词全文搜索消息内容，返回匹配的消息片段
             适用于回忆之前讨论过的话题、查找历史决策、检索之前的上下文。
+            注意：只会搜索已完成的会话，不会返回当前正在运行中的其他会话内容。
             """)
     public String session_search(
             @ToolParam(description = "当前 Agent 的 ID") Long agentId,
-            @ToolParam(description = "当前会话 ID（用于排除当前会话）") String currentConversationId,
             @ToolParam(description = "搜索模式：recent 或 search") String mode,
             @ToolParam(description = "搜索关键词（mode=search 时必填）", required = false) String query,
-            @ToolParam(description = "返回结果数量上限，默认 10", required = false) Integer limit) {
+            @ToolParam(description = "返回结果数量上限，默认 10", required = false) Integer limit,
+            ToolContext toolContext) {
 
         if (agentId == null) {
             return error("agentId 不能为空");
@@ -48,11 +55,20 @@ public class SessionSearchTool {
             mode = "recent";
         }
 
+        // 从 ToolContext 强制读取当前会话 ID，避免 LLM 自传错误导致跨会话串台
+        String currentConversationId = "";
+        if (toolContext != null) {
+            String fromOrigin = ChatOrigin.from(toolContext).conversationId();
+            if (fromOrigin != null && !fromOrigin.isEmpty()) {
+                currentConversationId = fromOrigin;
+            }
+        }
+
         int effectiveLimit = limit != null && limit > 0 ? limit : 10;
 
         try {
             if ("recent".equalsIgnoreCase(mode.trim())) {
-                return handleRecent(agentId, effectiveLimit);
+                return handleRecent(agentId, currentConversationId, effectiveLimit);
             } else if ("search".equalsIgnoreCase(mode.trim())) {
                 if (query == null || query.isBlank()) {
                     return error("mode=search 时 query 不能为空");
@@ -67,8 +83,9 @@ public class SessionSearchTool {
         }
     }
 
-    private String handleRecent(Long agentId, int limit) {
-        List<Map<String, Object>> sessions = sessionSearchService.listRecent(agentId, limit);
+    private String handleRecent(Long agentId, String currentConversationId, int limit) {
+        List<Map<String, Object>> sessions = sessionSearchService.listRecent(
+                agentId, currentConversationId, limit);
 
         JSONObject result = new JSONObject();
         result.set("mode", "recent");
@@ -80,7 +97,7 @@ public class SessionSearchTool {
     private String handleSearch(Long agentId, String currentConversationId,
                                 String query, int limit) {
         List<SessionSearchResult> results = sessionSearchService.search(
-                agentId, currentConversationId != null ? currentConversationId : "", query, limit);
+                agentId, currentConversationId, query, limit);
 
         JSONObject result = new JSONObject();
         result.set("mode", "search");

--- a/mateclaw-server/src/main/java/vip/mate/planning/service/PlanningService.java
+++ b/mateclaw-server/src/main/java/vip/mate/planning/service/PlanningService.java
@@ -224,12 +224,24 @@ public class PlanningService {
     /**
      * 审批 replay 上下文：找到最近一条 running 且含 awaiting_approval 步骤的计划，
      * 返回恢复图执行所需的全部状态。
+     * <p>
+     * 必须传入 conversationId 以确保会话隔离 —— 同一 agent 的多个并发会话
+     * 可能同时存在 running 计划，若不按会话过滤会跨会话误取计划。
+     * conversationId 为 null 时（兼容历史调用方）回退到全局查询，但会打告警。
      */
-    public PlanResumeContext findAwaitingApprovalContext() {
-        PlanEntity plan = planMapper.selectOne(new LambdaQueryWrapper<PlanEntity>()
+    public PlanResumeContext findAwaitingApprovalContext(String conversationId) {
+        if (conversationId == null || conversationId.isBlank()) {
+            log.warn("[PlanningService] findAwaitingApprovalContext called without conversationId, " +
+                    "risk of cross-conversation plan pickup in concurrent scenarios");
+        }
+        LambdaQueryWrapper<PlanEntity> wrapper = new LambdaQueryWrapper<PlanEntity>()
                 .eq(PlanEntity::getStatus, "running")
                 .orderByDesc(PlanEntity::getCreateTime)
-                .last("LIMIT 1"));
+                .last("LIMIT 1");
+        if (conversationId != null && !conversationId.isBlank()) {
+            wrapper.eq(PlanEntity::getConversationId, conversationId);
+        }
+        PlanEntity plan = planMapper.selectOne(wrapper);
         if (plan == null) return null;
 
         List<SubPlanEntity> subPlans = subPlanMapper.selectList(


### PR DESCRIPTION
### 问题现象
同一 agent 开多个并发会话时（如 A1=查南京天气、A2=查北京天气），A2 在多轮 ReAct 执行中会"突然去查南京天气"，表现为 A1 会话的上下文泄漏到 A2 会话。

### 根因
经数据流深挖，定位到 2 个独立 bug（另 2 个设计层面问题本次不修）。

Bug 1：SessionSearchTool 跨会话搜索（最直接命中症状）
- SessionSearchService 的 SQL 仅排除当前会话，不排除正在运行中的并发兄弟会话
- currentConversationId 依赖 LLM 自传，可能传错/传空/乱传
- A2 遇到困难时 LLM 调用 session_search 回忆历史，SQL 返回 A1 的"南京下雨"内容，导致 A2 混淆 

- Bug 2：审批重放跨会话取计划（确凿 bug）
- PlanningService.findAwaitingApprovalContext() 无 conversationId 过滤
- 并发审批场景下，A1 审批重放时会误取 A2 的 running 计划，错误执行 A2 的步骤 

### 修复方案
修复 1：SessionSearchTool 会话隔离
- SessionSearchTool ：删除 LLM 自传的 currentConversationId 参数，新增 ToolContext 参数从 ChatOrigin 强制读取真实会话 ID
- SessionSearchService ： searchMySQL / searchH2 / listRecent 三处 SQL 新增 stream_status != 'running' 过滤，排除正在运行中的并发兄弟会话
- AgentGraphBuilder ：更新 system prompt 中 session_search 工具说明 

修复 2：审批重放跨会话计划隔离
- PlanningService.findAwaitingApprovalContext(String conversationId) ：增加 conversationId 参数与查询过滤
- StateGraphPlanExecuteAgent ：调用时传入当前 conversationId

### 效果
- B 会话再调用 session_search 时 ：SQL 会排除所有 stream_status='running' 的会话（包括 A 会话），只返回已完成的会话内容，A 的"南京天气"不再泄漏到 B。
- 审批重放时 ：按 conversationId 精确匹配计划，A1 不会误取 A2 的计划。

###未修复
bug 3：结构化记忆引入会话级隔离（改动较大，需评估）
问题： 当前 ownerKey = user:<requesterId> ，3 会话共享。如果改为 conversation:<conversationId> ，会破坏"用户长期记忆跨会话共享"的设计意图（用户画像、偏好等应跨会话）。
建议方案： 不改 ownerKey 机制，而是在 StructuredMemoryTool.remember_structured 的 system prompt 说明中 明确限制 只记住"长期有效的事实"，临时任务结果（如天气查询）不应写入。或在 type 枚举中新增 transient 类型，该类型按 conversationId 隔离，会话结束自动清除。
风险评估： 改动较大，涉及记忆分层设计。建议作为中长期优化，本次先修方案1和2。

bug4：Agent 实例 state 按 conversationId 隔离（可选）
改动点： BaseAgent.java:33 AtomicReference<AgentState> state 改为 Map<String, AtomicReference<AgentState>> （按 conversationId）。
风险评估： 影响所有 getState() / setState() 调用点，改动面广。且这只是状态显示问题，不影响记忆串台。建议暂不修，或在前端按 conversationId 单独查询状态。
-------------------------------------------------------------------------
说明：3、4改动较大，建议作者自己修复