### PR TITLE
fix(memory): bound mate_memory_recall.filename to VARCHAR(256) (#461)

### DIFF
--- a/mateclaw-server/src/main/java/vip/mate/memory/service/MemoryRecallService.java
+++ b/mateclaw-server/src/main/java/vip/mate/memory/service/MemoryRecallService.java
@@ -35,6 +35,22 @@ public class MemoryRecallService {
 
     private static final int MAX_QUERY_HASHES = 32;
 
+    /** mate_memory_recall.filename is VARCHAR(256). Bound the value here so an
+     *  over-long section key (path + '#' + H2 heading slug, see #461) can never
+     *  blow past the column. Truncating at the entry point keeps the select /
+     *  insert / update branches below operating on the same value, so the
+     *  dup-key concurrency fallback still matches. */
+    static final int MAX_FILENAME_LENGTH = 255;
+
+    /** Truncate {@code filename} to {@link #MAX_FILENAME_LENGTH}. Package-private
+     *  for direct unit testing. CJK chars live in the BMP, so {@code substring}
+     *  cannot split a surrogate pair. */
+    static String truncateFilename(String filename) {
+        return filename.length() > MAX_FILENAME_LENGTH
+                ? filename.substring(0, MAX_FILENAME_LENGTH)
+                : filename;
+    }
+
     /**
      * 记录一次文件召回
      */
@@ -42,6 +58,9 @@ public class MemoryRecallService {
         if (agentId == null || filename == null || filename.isBlank()) {
             return;
         }
+        // 写库前硬截断：覆盖所有调用路径（含 trackActiveRetrieval 透传的外部 filename），
+        // 防 filename 突破 VARCHAR(256) 导致写入失败（#461）
+        filename = truncateFilename(filename);
 
         // snippet preview 只取前 200 字符（避免对大文件做完整 SHA-256）
         String preview = snippetText != null && snippetText.length() > 200

--- a/mateclaw-server/src/main/java/vip/mate/memory/service/MemoryRecallTracker.java
+++ b/mateclaw-server/src/main/java/vip/mate/memory/service/MemoryRecallTracker.java
@@ -126,12 +126,20 @@ public class MemoryRecallTracker {
         return count;
     }
 
-    private String sanitizeSectionKey(String heading) {
+    /** Max length of a section slug — keeps the full key (path + '#' + slug)
+     *  well under the mate_memory_recall.filename VARCHAR(256) ceiling even
+     *  when an LLM writes an over-long H2 heading. CJK chars live in the BMP,
+     *  so {@code substring} can never split a surrogate pair here. */
+    static final int MAX_SECTION_SLUG = 200;
+
+    /** Package-private for direct unit testing of the slug/truncation logic. */
+    static String sanitizeSectionKey(String heading) {
         // "## Some Title" -> "some-title"
-        return heading.replaceFirst("^#+\\s*", "")
+        String slug = heading.replaceFirst("^#+\\s*", "")
                 .toLowerCase()
                 .replaceAll("[^a-z0-9\\u4e00-\\u9fff]+", "-")
                 .replaceAll("^-|-$", "");
+        return slug.length() > MAX_SECTION_SLUG ? slug.substring(0, MAX_SECTION_SLUG) : slug;
     }
 
     /**

--- a/mateclaw-server/src/main/resources/prompts/memory/summarize-system.txt
+++ b/mateclaw-server/src/main/resources/prompts/memory/summarize-system.txt
@@ -42,7 +42,7 @@ MEMORY.md 与 PROFILE.md 会被**无条件注入每一次对话的系统提示**
 
 字段说明：
 - `should_update`: 布尔值，是否有任何需要更新的内容。如果为 false，其余字段应为 null
-- `daily_entry`: 字符串或 null。要追加到今日 daily note 的内容（markdown 格式，以时间戳开头如 "## HH:mm ..."）
+- `daily_entry`: 字符串或 null。要追加到今日 daily note 的内容（markdown 格式，以时间戳开头如 "## HH:mm 简要事件标题"）。**二级标题（##）保持简短（不超过 30 字），只概括事件主题；事件细节、数字、过程写进标题下方的正文，不要堆进标题——过长的标题会导致下游索引截断。**
 - `memory_update`: 字符串或 null。MEMORY.md 的完整新内容（已合并现有内容，不是增量）。仅当有需要新增或修改的**跨项目稳定**信息时才填写
 - `profile_update`: 字符串或 null。PROFILE.md 的完整新内容（已合并现有内容，不是增量）。仅当用户身份/偏好有显著变化时才填写
 - `structured_entries`: 数组或 null。把适合按条目检索的**具体事实**路由到结构化记忆，每个元素形如 `{"type": "...", "key": "...", "content": "..."}`：

--- a/mateclaw-server/src/test/java/vip/mate/memory/service/MemoryRecallFilenameTruncationTest.java
+++ b/mateclaw-server/src/test/java/vip/mate/memory/service/MemoryRecallFilenameTruncationTest.java
@@ -1,0 +1,111 @@
+package vip.mate.memory.service;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * Guards the {@code mate_memory_recall.filename} VARCHAR(256) ceiling against
+ * over-long section keys (file path + '#' + a long H2 heading slug). See #461.
+ * <p>
+ * Two boundaries are covered as pure functions, no Spring context needed:
+ * <ul>
+ *   <li>{@link MemoryRecallTracker#sanitizeSectionKey} — slug-side cap</li>
+ *   <li>{@link MemoryRecallService#truncateFilename} — write-side cap</li>
+ * </ul>
+ */
+class MemoryRecallFilenameTruncationTest {
+
+    /** Repeated CJK filler so a heading can be grown past any threshold. */
+    private static final String CN = "用户要求设置每日财经早报定时任务，每天早上推送汇总报告到指定群组";
+
+    @Nested
+    @DisplayName("sanitizeSectionKey — slug-side cap")
+    class SanitizeSectionKey {
+
+        @Test
+        @DisplayName("normal CJK heading is slugified untouched (no false truncation)")
+        void normalCjkHeadingPreserved() {
+            String slug = MemoryRecallTracker.sanitizeSectionKey("## 08:30 用户设置每日财经早报定时任务");
+            // "## " stripped, ':' and spaces → '-', CJK kept; "08-30-用户设置每日财经早报定时任务"
+            assertEquals("08-30-用户设置每日财经早报定时任务", slug);
+            assertTrue(slug.length() <= MemoryRecallTracker.MAX_SECTION_SLUG);
+        }
+
+        @Test
+        @DisplayName("over-long CJK heading slug is capped at MAX_SECTION_SLUG and never throws")
+        void overLongCjkHeadingCapped() {
+            StringBuilder heading = new StringBuilder("## ");
+            while (heading.length() < MemoryRecallTracker.MAX_SECTION_SLUG + 200) {
+                heading.append(CN);
+            }
+            String slug = assertDoesNotThrow(() -> MemoryRecallTracker.sanitizeSectionKey(heading.toString()));
+            assertTrue(slug.length() <= MemoryRecallTracker.MAX_SECTION_SLUG,
+                    "slug must not exceed MAX_SECTION_SLUG, was " + slug.length());
+        }
+
+        @Test
+        @DisplayName("ascii-only heading collapses runs of non-alnum to a single '-'")
+        void asciiHeadingSlugified() {
+            assertEquals("some-title-here", MemoryRecallTracker.sanitizeSectionKey("## Some Title Here"));
+        }
+    }
+
+    @Nested
+    @DisplayName("truncateFilename — write-side cap")
+    class TruncateFilename {
+
+        @Test
+        @DisplayName("filename at/below the cap is returned unchanged")
+        void underCapUnchanged() {
+            String filename = "memory/2026-06-05.md#08-30-用户设置每日财经早报定时任务";
+            assertTrue(filename.length() <= MemoryRecallService.MAX_FILENAME_LENGTH);
+            assertSame(filename, MemoryRecallService.truncateFilename(filename),
+                    "under-cap values must pass through without copying");
+        }
+
+        @Test
+        @DisplayName("filename over the cap is truncated to MAX_FILENAME_LENGTH")
+        void overCapTruncated() {
+            StringBuilder filename = new StringBuilder("memory/2026-06-05.md#");
+            while (filename.length() < MemoryRecallService.MAX_FILENAME_LENGTH + 100) {
+                filename.append(CN);
+            }
+            String out = MemoryRecallService.truncateFilename(filename.toString());
+            assertEquals(MemoryRecallService.MAX_FILENAME_LENGTH, out.length(),
+                    "over-cap value must be exactly MAX_FILENAME_LENGTH");
+        }
+
+        @Test
+        @DisplayName("truncation keeps the date prefix intact (computeFreshness still parses it)")
+        void datePrefixPreserved() {
+            StringBuilder filename = new StringBuilder("memory/2026-06-05.md#");
+            while (filename.length() < MemoryRecallService.MAX_FILENAME_LENGTH + 100) {
+                filename.append(CN);
+            }
+            String out = MemoryRecallService.truncateFilename(filename.toString());
+            // The leading path/date — the only part computeFreshness uses — survives.
+            assertTrue(out.startsWith("memory/2026-06-05.md"), "date prefix must survive truncation");
+            int hash = out.indexOf('#');
+            assertTrue(hash > 0 && hash < out.length(), "section anchor must still be present");
+        }
+    }
+
+    @Test
+    @DisplayName("full daily-note section key stays under the DB column ceiling end-to-end")
+    void endToEndWithinColumnCeiling() {
+        // Reproduce MemoryRecallTracker's key assembly on an over-long heading.
+        String dailyFile = "memory/2026-06-05.md";
+        StringBuilder heading = new StringBuilder("## 08:30 ");
+        while (heading.length() < MemoryRecallTracker.MAX_SECTION_SLUG + 300) {
+            heading.append(CN);
+        }
+        String sectionKey = dailyFile + "#" + MemoryRecallTracker.sanitizeSectionKey(heading.toString());
+        // Even after the write-side fallback, the stored value must fit VARCHAR(256).
+        String stored = MemoryRecallService.truncateFilename(sectionKey);
+        assertTrue(stored.length() <= 255,
+                "stored filename must fit VARCHAR(256), was " + stored.length());
+    }
+}


### PR DESCRIPTION
Fixes #461

## 根因

`mate_memory_recall.filename` 是 `VARCHAR(256)`，但片段级召回追踪把 key 拼成 `文件路径 + '#' + H2标题slug`（`MemoryRecallTracker.java:121`）。`summarize-system.txt` 的 prompt 对 `##` 标题**没有长度约束**，LLM 偶尔把一整段事件细节写成标题，经 `sanitizeSectionKey()`（CJK 中文被原样保留、不截断）后，叠加文件路径前缀突破 256，写库报 `Data too long` / 字符串超长。`MemoryRecallService.recordRecall` 写入前也无截断。

详细分析见 #461。

## 改动（三层防护，治本 + 硬兜底）

| 层级 | 文件 | 改动 |
|---|---|---|
| 治本 · 源头 | `prompts/memory/summarize-system.txt` | 要求 `##` 标题保持简短（≤30 字），细节写进正文而非标题 |
| 硬兜底 · slug | `MemoryRecallTracker.java` | `sanitizeSectionKey` 返回值截断到 `MAX_SECTION_SLUG=200`，为 `路径(~25)+#(1)` 留足余量 |
| 最后防线 · 写库 | `MemoryRecallService.java` | `recordRecall` 入口截断到 `MAX_FILENAME_LENGTH=255`，覆盖所有调用路径 |

### 为什么第 2、3 层都要
- 第 2 层只管 tracker 自己产生的 daily-note section key；
- 但 `trackActiveRetrieval`（`MemoryRecallTracker.java:148`）**直接透传**工具调用传入的 filename 调 `recordRecall`，不走 `sanitizeSectionKey`，必须靠第 3 层统一兜底；
- `recordRecall` 是写入 `mate_memory_recall` 的**唯一入口**，截断放在入口处，保证方法内 select / insert / update 三个分支用同一个值，避免"查不到旧记录→又插入→又被截断"的失配，并发兜底（`DuplicateKeyException` 路径）也能正确匹配。

### 不改 schema
`VARCHAR(256)` 不动。系统其他读取方对 `#` 锚点都是"截断丢弃"处理（`MemoryRecallService.computeFreshness` 的 `indexOf('#')`、`FactController` 的 `split("#",2)`），截断 slug 不影响日期解析与召回/新鲜度计算。

## 验证

- 新增 `MemoryRecallFilenameTruncationTest`（纯 JUnit 5，不启动 Spring，对齐 `AlwaysOnFileBudgetTest` 风格）：**7 个用例全过**
  - `sanitizeSectionKey`：超长中文标题 slug ≤200 且不抛异常；正常中文标题不误截断（含 CJK）；ascii 标题折叠正确
  - `truncateFilename`：超 255 截断到 255；≤255 原样返回；截断后日期前缀存活（`computeFreshness` 仍能解析）
  - 端到端：daily-note section key 经两层截断后落库值 ≤256
- 既有 memory 包回归（`AlwaysOnFileBudgetTest`、`MemorySummarizationGateTest`、`MemoryHilServiceTest`、`DreamFlagGuardTest`、`StructuredMemoryPrefetchTest` 等）：**35 个全过，0 失败 0 错误**