### PR TITLE
feat(mcp): type on-behalf-of identity by channel/trust (#459)

### DIFF
--- a/mateclaw-server/src/main/java/vip/mate/agent/context/ChatOrigin.java
+++ b/mateclaw-server/src/main/java/vip/mate/agent/context/ChatOrigin.java
@@ -66,7 +66,16 @@ public record ChatOrigin(
          * can still mint absolute download links. Null for IM/cron origins, which
          * have no request host; those rely on {@code mateclaw.server.public-base-url}.
          */
-        @Nullable String baseUrl
+        @Nullable String baseUrl,
+        /**
+         * Immutable numeric id of the MateClaw user behind this request, when the
+         * requester is an <em>authenticated</em> account (JWT/PAT login via the
+         * web console). Null for non-account origins — webchat visitors, IM
+         * senders, cron — which carry no MateClaw user row. On-behalf-of identity
+         * forwarding uses this to tell "MateClaw authenticated this user" apart
+         * from "this is an external/anonymous identifier" (RFC: identity typing).
+         */
+        @Nullable Long requesterUserId
 ) {
 
     /** Key used when this origin is wrapped into a Spring AI {@link ToolContext}. */
@@ -74,7 +83,7 @@ public record ChatOrigin(
 
     /** Sentinel used by AgentService default overloads where no origin is supplied. */
     public static final ChatOrigin EMPTY =
-            new ChatOrigin(null, null, "", null, null, null, null, false, null, null, null, null);
+            new ChatOrigin(null, null, "", null, null, null, null, false, null, null, null, null, null);
 
     // ---------------- Factories per entry point ----------------
 
@@ -90,9 +99,25 @@ public record ChatOrigin(
                                  @Nullable Long workspaceId,
                                  @Nullable String workspaceBasePath,
                                  @Nullable String baseUrl) {
+        return web(conversationId, requesterId, workspaceId, workspaceBasePath, baseUrl, null);
+    }
+
+    /**
+     * Web-console origin that also carries the authenticated user's immutable
+     * numeric id. Use this overload from the authenticated web entry point so
+     * on-behalf-of identity forwarding can assert "MateClaw authenticated this
+     * user" rather than an external/anonymous identifier.
+     */
+    public static ChatOrigin web(@Nullable String conversationId,
+                                 @Nullable String requesterId,
+                                 @Nullable Long workspaceId,
+                                 @Nullable String workspaceBasePath,
+                                 @Nullable String baseUrl,
+                                 @Nullable Long requesterUserId) {
         return new ChatOrigin(null, conversationId,
                 requesterId != null ? requesterId : "",
-                workspaceId, workspaceBasePath, null, null, false, null, "web", null, baseUrl);
+                workspaceId, workspaceBasePath, null, null, false, null, "web", null, baseUrl,
+                requesterUserId);
     }
 
     public static ChatOrigin cron(@Nullable String conversationId,
@@ -101,7 +126,7 @@ public record ChatOrigin(
                                   @Nullable Long channelId,
                                   @Nullable ChannelTarget target) {
         return new ChatOrigin(null, conversationId, "system",
-                workspaceId, workspaceBasePath, channelId, target, true, null, null, null, null);
+                workspaceId, workspaceBasePath, channelId, target, true, null, null, null, null, null);
     }
 
     // ---------------- Wither-style updates ----------------
@@ -109,27 +134,27 @@ public record ChatOrigin(
     public ChatOrigin withAgent(@Nullable Long newAgentId) {
         return new ChatOrigin(newAgentId, conversationId, requesterId,
                 workspaceId, workspaceBasePath, channelId, channelTarget, cronOrigin,
-                senderName, channelType, chatId, baseUrl);
+                senderName, channelType, chatId, baseUrl, requesterUserId);
     }
 
     public ChatOrigin withWorkspace(@Nullable Long newWorkspaceId,
                                     @Nullable String newWorkspaceBasePath) {
         return new ChatOrigin(agentId, conversationId, requesterId,
                 newWorkspaceId, newWorkspaceBasePath, channelId, channelTarget, cronOrigin,
-                senderName, channelType, chatId, baseUrl);
+                senderName, channelType, chatId, baseUrl, requesterUserId);
     }
 
     public ChatOrigin withConversationId(@Nullable String newConversationId) {
         return new ChatOrigin(agentId, newConversationId, requesterId,
                 workspaceId, workspaceBasePath, channelId, channelTarget, cronOrigin,
-                senderName, channelType, chatId, baseUrl);
+                senderName, channelType, chatId, baseUrl, requesterUserId);
     }
 
     /** Carry a request-derived public base URL (see {@link #baseUrl()}). */
     public ChatOrigin withBaseUrl(@Nullable String newBaseUrl) {
         return new ChatOrigin(agentId, conversationId, requesterId,
                 workspaceId, workspaceBasePath, channelId, channelTarget, cronOrigin,
-                senderName, channelType, chatId, newBaseUrl);
+                senderName, channelType, chatId, newBaseUrl, requesterUserId);
     }
 
     /**
@@ -143,7 +168,7 @@ public record ChatOrigin(
                                   @Nullable String newChatId) {
         return new ChatOrigin(agentId, conversationId, requesterId,
                 workspaceId, workspaceBasePath, channelId, channelTarget, cronOrigin,
-                newSenderName, newChannelType, newChatId, baseUrl);
+                newSenderName, newChannelType, newChatId, baseUrl, requesterUserId);
     }
 
     // ---------------- Spring AI ToolContext interop ----------------

--- a/mateclaw-server/src/main/java/vip/mate/channel/ChannelChatOriginFactory.java
+++ b/mateclaw-server/src/main/java/vip/mate/channel/ChannelChatOriginFactory.java
@@ -44,7 +44,8 @@ public class ChannelChatOriginFactory {
                                             ? message.getChannelType()
                                             : channel.getChannelType(),
                 /* chatId            */ message.getChatId(),
-                /* baseUrl           */ null);   // IM origins have no request host; rely on public-base-url config
+                /* baseUrl           */ null,   // IM origins have no request host; rely on public-base-url config
+                /* requesterUserId   */ null);  // IM senders are external platform ids, not MateClaw accounts
     }
 
     /**

--- a/mateclaw-server/src/main/java/vip/mate/channel/web/ChatController.java
+++ b/mateclaw-server/src/main/java/vip/mate/channel/web/ChatController.java
@@ -556,7 +556,7 @@ public class ChatController {
                 // tools that need a workspace path read it from the agent (origin
                 // is enriched with workspaceBasePath in StateGraph buildInitialState).
                 vip.mate.agent.context.ChatOrigin webOrigin =
-                        memoryOrigin(conversationId, username, workspaceId, request.getEndUserId())
+                        memoryOrigin(conversationId, username, requesterUserIdOf(auth), workspaceId, request.getEndUserId())
                                 .withBaseUrl(requestBaseUrl);
                 Disposable disposable = agentService.chatStructuredStream(agentId, promptText, conversationId, username, request.getThinkingLevel(), webOrigin)
                         .doOnNext(delta -> {
@@ -1057,7 +1057,7 @@ public class ChatController {
         // Carry the web origin so per-owner memory recall (read) and the
         // post-conversation memory write below agree on the same owner key.
         vip.mate.agent.context.ChatOrigin webOrigin =
-                memoryOrigin(request.getConversationId(), username, workspaceId, request.getEndUserId());
+                memoryOrigin(request.getConversationId(), username, requesterUserIdOf(auth), workspaceId, request.getEndUserId());
         AgentService.ChatResult result = agentService.chatWithUsage(agentId, promptText, request.getConversationId(), webOrigin);
         String response = result.content();
         conversationService.saveMessage(request.getConversationId(), "assistant", response, null, "completed",
@@ -1170,17 +1170,33 @@ public class ChatController {
      * MateClaw user ({@code user:<username>}).
      */
     private vip.mate.agent.context.ChatOrigin memoryOrigin(String conversationId, String username,
-                                                           Long workspaceId, String endUserId) {
+                                                           Long requesterUserId, Long workspaceId,
+                                                           String endUserId) {
         // Resolve the public base URL here, on the request thread, so it can ride
         // the origin into async tool execution where no request is bound. Tools
         // then mint absolute download links without operator config.
         String baseUrl = resolveRequestBaseUrl();
         if (endUserId != null && !endUserId.isBlank()) {
+            // Third-party single-account integration: the requester is an external
+            // end-user id, not a MateClaw account — no requesterUserId to assert.
             return vip.mate.agent.context.ChatOrigin
                     .web(conversationId, endUserId.trim(), workspaceId, null, baseUrl)
                     .withSender(null, "api", null);
         }
-        return vip.mate.agent.context.ChatOrigin.web(conversationId, username, workspaceId, null, baseUrl);
+        // Authenticated web user: carry the immutable id so on-behalf-of identity
+        // forwarding can assert "MateClaw authenticated this user" (not an anon id).
+        return vip.mate.agent.context.ChatOrigin.web(conversationId, username, workspaceId, null, baseUrl, requesterUserId);
+    }
+
+    /**
+     * Extract the authenticated user's immutable numeric id from the
+     * {@link Authentication} details (stamped by {@code JwtAuthFilter} for both
+     * the JWT and PAT paths). Null when not authenticated or details absent.
+     */
+    private Long requesterUserIdOf(org.springframework.security.core.Authentication auth) {
+        if (auth == null) return null;
+        Object details = auth.getDetails();
+        return details instanceof Long id ? id : null;
     }
 
     /**

--- a/mateclaw-server/src/main/java/vip/mate/config/JwtAuthFilter.java
+++ b/mateclaw-server/src/main/java/vip/mate/config/JwtAuthFilter.java
@@ -79,6 +79,7 @@ public class JwtAuthFilter extends OncePerRequestFilter {
                     user.getUsername(), null,
                     List.of(new SimpleGrantedAuthority("ROLE_" + user.getRole().toUpperCase()))
             );
+            auth.setDetails(user.getId());   // immutable user id for on-behalf-of forwarding
             SecurityContextHolder.getContext().setAuthentication(auth);
             patService.recordUse(pat); // debounced inside the service
         } catch (Exception ignored) {
@@ -99,6 +100,7 @@ public class JwtAuthFilter extends OncePerRequestFilter {
                     username, null,
                     List.of(new SimpleGrantedAuthority("ROLE_" + user.getRole().toUpperCase()))
             );
+            auth.setDetails(user.getId());   // immutable user id for on-behalf-of forwarding
             SecurityContextHolder.getContext().setAuthentication(auth);
 
             // 滑动窗口续期：Token 接近过期时自动签发新 Token

--- a/mateclaw-server/src/main/java/vip/mate/skill/lifecycle/SkillConsolidationService.java
+++ b/mateclaw-server/src/main/java/vip/mate/skill/lifecycle/SkillConsolidationService.java
@@ -205,7 +205,7 @@ public class SkillConsolidationService {
 
     private ToolContext toolContext(String sourceConversationId) {
         ChatOrigin origin = new ChatOrigin(null, sourceConversationId, "", null, null,
-                null, null, false, null, null, null, null);
+                null, null, false, null, null, null, null, null);
         return new ToolContext(Map.of(ChatOrigin.CTX_KEY, origin));
     }
 

--- a/mateclaw-server/src/main/java/vip/mate/skill/reflection/SkillReflectionService.java
+++ b/mateclaw-server/src/main/java/vip/mate/skill/reflection/SkillReflectionService.java
@@ -214,7 +214,7 @@ public class SkillReflectionService {
      */
     private ToolContext buildToolContext(Long agentId, String conversationId) {
         ChatOrigin origin = new ChatOrigin(agentId, conversationId, "", null, null,
-                null, null, false, null, null, null, null);
+                null, null, false, null, null, null, null, null);
         return new ToolContext(Map.of(ChatOrigin.CTX_KEY, origin));
     }
 

--- a/mateclaw-server/src/main/java/vip/mate/tool/mcp/runtime/IdentityForwardingToolCallback.java
+++ b/mateclaw-server/src/main/java/vip/mate/tool/mcp/runtime/IdentityForwardingToolCallback.java
@@ -1,0 +1,107 @@
+package vip.mate.tool.mcp.runtime;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.ai.chat.model.ToolContext;
+import org.springframework.ai.tool.ToolCallback;
+import org.springframework.ai.tool.definition.ToolDefinition;
+import org.springframework.ai.tool.metadata.ToolMetadata;
+import vip.mate.tool.builtin.ToolExecutionContext;
+
+/**
+ * Wraps an MCP {@link ToolCallback} for a trusted server (opt-in via
+ * {@link McpIdentityForwardProperties}) and injects the authenticated caller's
+ * username into the call arguments under
+ * {@link McpIdentityForwardProperties#IDENTITY_ARG}, so the STDIO MCP server can
+ * forward it on-behalf-of to its downstream REST backend.
+ *
+ * <p>STDIO has no per-request header channel and the subprocess is shared by all
+ * users, so identity must ride <em>in-band, per call</em>. The username is read
+ * from {@link ToolExecutionContext} (trusted server-side context), never from
+ * the model — any LLM-supplied value of the reserved key is overwritten, so the
+ * model cannot spoof identity.
+ *
+ * <p>The wrapper is transparent in every other respect: tool definition,
+ * metadata, schema, and (when no user is in context) the call itself are
+ * forwarded verbatim. It sits <em>inside</em> {@link PrefixedNameToolCallback}
+ * so name prefixing and return-direct detection still see the raw delegate.
+ *
+ * @author MateClaw Team
+ */
+@Slf4j
+public final class IdentityForwardingToolCallback implements ToolCallback {
+
+    private static final ObjectMapper MAPPER = new ObjectMapper();
+
+    private final ToolCallback delegate;
+
+    public IdentityForwardingToolCallback(ToolCallback delegate) {
+        if (delegate == null) {
+            throw new IllegalArgumentException("delegate must not be null");
+        }
+        this.delegate = delegate;
+    }
+
+    @Override
+    public ToolDefinition getToolDefinition() {
+        return delegate.getToolDefinition();
+    }
+
+    @Override
+    public ToolMetadata getToolMetadata() {
+        return delegate.getToolMetadata();
+    }
+
+    @Override
+    public String call(String toolInput) {
+        return delegate.call(withIdentity(toolInput, ToolExecutionContext.username()));
+    }
+
+    @Override
+    public String call(String toolInput, ToolContext toolContext) {
+        return delegate.call(withIdentity(toolInput, ToolExecutionContext.username(toolContext)), toolContext);
+    }
+
+    /** Exposed for diagnostic / wrapping detection. */
+    public ToolCallback getDelegate() {
+        return delegate;
+    }
+
+    /**
+     * Merge the username into the JSON arguments under the reserved key,
+     * overwriting any value the model supplied. Returns the input unchanged
+     * when there is no authenticated user (don't fabricate identity — the MCP
+     * server decides whether to reject) or when the arguments are not a JSON
+     * object (nothing to merge into).
+     */
+    static String withIdentity(String toolInput, String username) {
+        if (username == null || username.isBlank()) {
+            return toolInput;
+        }
+        try {
+            ObjectNode node;
+            if (toolInput == null || toolInput.isBlank()) {
+                node = MAPPER.createObjectNode();
+            } else {
+                JsonNode parsed = MAPPER.readTree(toolInput);
+                if (!parsed.isObject()) {
+                    // Tool arguments are conventionally an object; anything else
+                    // (array/scalar) has nowhere to carry the reserved key, so
+                    // forward unchanged rather than corrupt the payload.
+                    log.warn("[McpIdentity] tool input is not a JSON object; forwarding without identity");
+                    return toolInput;
+                }
+                node = (ObjectNode) parsed;
+            }
+            node.put(McpIdentityForwardProperties.IDENTITY_ARG, username);
+            return MAPPER.writeValueAsString(node);
+        } catch (Exception e) {
+            // Malformed JSON would fail downstream anyway; don't mask it by
+            // rewriting — forward the original and let the call surface it.
+            log.warn("[McpIdentity] failed to inject identity into tool input: {}", e.getMessage());
+            return toolInput;
+        }
+    }
+}

--- a/mateclaw-server/src/main/java/vip/mate/tool/mcp/runtime/IdentityForwardingToolCallback.java
+++ b/mateclaw-server/src/main/java/vip/mate/tool/mcp/runtime/IdentityForwardingToolCallback.java
@@ -8,23 +8,25 @@ import org.springframework.ai.chat.model.ToolContext;
 import org.springframework.ai.tool.ToolCallback;
 import org.springframework.ai.tool.definition.ToolDefinition;
 import org.springframework.ai.tool.metadata.ToolMetadata;
-import vip.mate.tool.builtin.ToolExecutionContext;
 
 /**
  * Wraps an MCP {@link ToolCallback} for a trusted server (opt-in via
- * {@link McpIdentityForwardProperties}) and injects the authenticated caller's
- * username into the call arguments under
- * {@link McpIdentityForwardProperties#IDENTITY_ARG}, so the STDIO MCP server can
- * forward it on-behalf-of to its downstream REST backend.
+ * {@link McpIdentityForwardProperties}) and injects the caller's identity into
+ * the call arguments, so the STDIO MCP server can forward it on-behalf-of to its
+ * downstream REST backend.
+ *
+ * <p>What gets injected is decided by {@link McpIdentityForwardService}: either
+ * the plaintext username (under {@code __mateclaw_user__}) or a short-lived
+ * signed JWT (under {@code __mateclaw_token__}).
  *
  * <p>STDIO has no per-request header channel and the subprocess is shared by all
- * users, so identity must ride <em>in-band, per call</em>. The username is read
- * from {@link ToolExecutionContext} (trusted server-side context), never from
- * the model — any LLM-supplied value of the reserved key is overwritten, so the
- * model cannot spoof identity.
+ * users, so identity must ride <em>in-band, per call</em>. The identity is
+ * derived from the trusted server-side {@link ToolContext}, never from the model
+ * — any LLM-supplied value of the reserved key is overwritten, so the model
+ * cannot spoof identity.
  *
  * <p>The wrapper is transparent in every other respect: tool definition,
- * metadata, schema, and (when no user is in context) the call itself are
+ * metadata, schema, and (when there is no identity to inject) the call itself are
  * forwarded verbatim. It sits <em>inside</em> {@link PrefixedNameToolCallback}
  * so name prefixing and return-direct detection still see the raw delegate.
  *
@@ -36,12 +38,18 @@ public final class IdentityForwardingToolCallback implements ToolCallback {
     private static final ObjectMapper MAPPER = new ObjectMapper();
 
     private final ToolCallback delegate;
+    private final McpIdentityForwardService identityService;
+    private final String audience;
 
-    public IdentityForwardingToolCallback(ToolCallback delegate) {
-        if (delegate == null) {
-            throw new IllegalArgumentException("delegate must not be null");
+    public IdentityForwardingToolCallback(ToolCallback delegate,
+                                          McpIdentityForwardService identityService,
+                                          String audience) {
+        if (delegate == null || identityService == null) {
+            throw new IllegalArgumentException("delegate and identityService must not be null");
         }
         this.delegate = delegate;
+        this.identityService = identityService;
+        this.audience = audience;
     }
 
     @Override
@@ -56,12 +64,12 @@ public final class IdentityForwardingToolCallback implements ToolCallback {
 
     @Override
     public String call(String toolInput) {
-        return delegate.call(withIdentity(toolInput, ToolExecutionContext.username()));
+        return delegate.call(inject(toolInput, null));
     }
 
     @Override
     public String call(String toolInput, ToolContext toolContext) {
-        return delegate.call(withIdentity(toolInput, ToolExecutionContext.username(toolContext)), toolContext);
+        return delegate.call(inject(toolInput, toolContext), toolContext);
     }
 
     /** Exposed for diagnostic / wrapping detection. */
@@ -69,17 +77,19 @@ public final class IdentityForwardingToolCallback implements ToolCallback {
         return delegate;
     }
 
+    private String inject(String toolInput, ToolContext toolContext) {
+        return identityService.resolve(toolContext, audience)
+                .map(i -> withClaim(toolInput, i.key(), i.value()))
+                .orElse(toolInput);
+    }
+
     /**
-     * Merge the username into the JSON arguments under the reserved key,
-     * overwriting any value the model supplied. Returns the input unchanged
-     * when there is no authenticated user (don't fabricate identity — the MCP
-     * server decides whether to reject) or when the arguments are not a JSON
-     * object (nothing to merge into).
+     * Merge {@code (key, value)} into the JSON arguments, overwriting any value
+     * the model supplied for that key. Returns the input unchanged when the
+     * arguments are not a JSON object (nothing to merge into) or are malformed
+     * (let the call surface the error rather than mask it by rewriting).
      */
-    static String withIdentity(String toolInput, String username) {
-        if (username == null || username.isBlank()) {
-            return toolInput;
-        }
+    static String withClaim(String toolInput, String key, String value) {
         try {
             ObjectNode node;
             if (toolInput == null || toolInput.isBlank()) {
@@ -87,19 +97,14 @@ public final class IdentityForwardingToolCallback implements ToolCallback {
             } else {
                 JsonNode parsed = MAPPER.readTree(toolInput);
                 if (!parsed.isObject()) {
-                    // Tool arguments are conventionally an object; anything else
-                    // (array/scalar) has nowhere to carry the reserved key, so
-                    // forward unchanged rather than corrupt the payload.
                     log.warn("[McpIdentity] tool input is not a JSON object; forwarding without identity");
                     return toolInput;
                 }
                 node = (ObjectNode) parsed;
             }
-            node.put(McpIdentityForwardProperties.IDENTITY_ARG, username);
+            node.put(key, value);
             return MAPPER.writeValueAsString(node);
         } catch (Exception e) {
-            // Malformed JSON would fail downstream anyway; don't mask it by
-            // rewriting — forward the original and let the call surface it.
             log.warn("[McpIdentity] failed to inject identity into tool input: {}", e.getMessage());
             return toolInput;
         }

--- a/mateclaw-server/src/main/java/vip/mate/tool/mcp/runtime/McpClientManager.java
+++ b/mateclaw-server/src/main/java/vip/mate/tool/mcp/runtime/McpClientManager.java
@@ -65,15 +65,15 @@ public class McpClientManager {
 
     private final ApplicationEventPublisher eventPublisher;
 
-    private final McpIdentityForwardProperties identityForwardProperties;
+    private final McpIdentityForwardService identityForwardService;
 
     /** serverId -> server name, captured at build time for identity-forward opt-in matching. */
     private final ConcurrentHashMap<Long, String> serverNames = new ConcurrentHashMap<>();
 
     public McpClientManager(ApplicationEventPublisher eventPublisher,
-                            McpIdentityForwardProperties identityForwardProperties) {
+                            McpIdentityForwardService identityForwardService) {
         this.eventPublisher = eventPublisher;
-        this.identityForwardProperties = identityForwardProperties;
+        this.identityForwardService = identityForwardService;
     }
 
     /** serverId -> connection result info */
@@ -197,8 +197,11 @@ public class McpClientManager {
                 SyncMcpToolCallbackProvider provider = new SyncMcpToolCallbackProvider(entry.getValue());
                 ToolCallback[] cbs = provider.getToolCallbacks();
                 if (cbs != null && cbs.length > 0) {
-                    boolean forwardIdentity = identityForwardProperties.forwardsTo(serverId, serverNames.get(serverId));
-                    List<ToolCallback> wrapped = wrapServerCallbacks(serverId, cbs, forwardIdentity);
+                    String serverName = serverNames.get(serverId);
+                    McpIdentityForwardService idSvc =
+                            identityForwardService.forwardsTo(serverId, serverName) ? identityForwardService : null;
+                    String audience = idSvc != null ? identityForwardService.audienceFor(serverId, serverName) : null;
+                    List<ToolCallback> wrapped = wrapServerCallbacks(serverId, cbs, idSvc, audience);
                     lastGoodCallbacks.put(serverId, wrapped);
                     allCallbacks.addAll(wrapped);
                     continue;
@@ -250,16 +253,19 @@ public class McpClientManager {
      * real {@link McpSyncClient}.
      */
     static List<ToolCallback> wrapServerCallbacks(long serverId, ToolCallback[] cbs) {
-        return wrapServerCallbacks(serverId, cbs, false);
+        return wrapServerCallbacks(serverId, cbs, null, null);
     }
 
     /**
-     * @param forwardIdentity when {@code true}, each callback is additionally
-     *        wrapped in {@link IdentityForwardingToolCallback} (inside the prefix
-     *        wrapper) so the authenticated username rides along with the call.
-     *        Driven by {@link McpIdentityForwardProperties} opt-in per server.
+     * @param identitySvc when non-null, each callback is additionally wrapped in
+     *        {@link IdentityForwardingToolCallback} (inside the prefix wrapper) so
+     *        the caller's identity rides along with the call. Driven by
+     *        {@link McpIdentityForwardService} opt-in per server; {@code null}
+     *        means this server does not forward identity.
+     * @param audience the token audience for this server (ignored in plaintext mode).
      */
-    static List<ToolCallback> wrapServerCallbacks(long serverId, ToolCallback[] cbs, boolean forwardIdentity) {
+    static List<ToolCallback> wrapServerCallbacks(long serverId, ToolCallback[] cbs,
+                                                  McpIdentityForwardService identitySvc, String audience) {
         List<String> rawNames = new ArrayList<>(cbs.length);
         for (ToolCallback cb : cbs) {
             rawNames.add(cb.getToolDefinition() != null ? cb.getToolDefinition().name() : null);
@@ -285,7 +291,9 @@ public class McpClientManager {
                         serverId, raw, d.prefixedName(), d.unavailableReason());
                 continue;
             }
-            ToolCallback inner = forwardIdentity ? new IdentityForwardingToolCallback(cb) : cb;
+            ToolCallback inner = identitySvc != null
+                    ? new IdentityForwardingToolCallback(cb, identitySvc, audience)
+                    : cb;
             out.add(new PrefixedNameToolCallback(d.prefixedName(), inner));
         }
         return out;

--- a/mateclaw-server/src/main/java/vip/mate/tool/mcp/runtime/McpClientManager.java
+++ b/mateclaw-server/src/main/java/vip/mate/tool/mcp/runtime/McpClientManager.java
@@ -65,8 +65,15 @@ public class McpClientManager {
 
     private final ApplicationEventPublisher eventPublisher;
 
-    public McpClientManager(ApplicationEventPublisher eventPublisher) {
+    private final McpIdentityForwardProperties identityForwardProperties;
+
+    /** serverId -> server name, captured at build time for identity-forward opt-in matching. */
+    private final ConcurrentHashMap<Long, String> serverNames = new ConcurrentHashMap<>();
+
+    public McpClientManager(ApplicationEventPublisher eventPublisher,
+                            McpIdentityForwardProperties identityForwardProperties) {
         this.eventPublisher = eventPublisher;
+        this.identityForwardProperties = identityForwardProperties;
     }
 
     /** serverId -> connection result info */
@@ -190,7 +197,8 @@ public class McpClientManager {
                 SyncMcpToolCallbackProvider provider = new SyncMcpToolCallbackProvider(entry.getValue());
                 ToolCallback[] cbs = provider.getToolCallbacks();
                 if (cbs != null && cbs.length > 0) {
-                    List<ToolCallback> wrapped = wrapServerCallbacks(serverId, cbs);
+                    boolean forwardIdentity = identityForwardProperties.forwardsTo(serverId, serverNames.get(serverId));
+                    List<ToolCallback> wrapped = wrapServerCallbacks(serverId, cbs, forwardIdentity);
                     lastGoodCallbacks.put(serverId, wrapped);
                     allCallbacks.addAll(wrapped);
                     continue;
@@ -242,6 +250,16 @@ public class McpClientManager {
      * real {@link McpSyncClient}.
      */
     static List<ToolCallback> wrapServerCallbacks(long serverId, ToolCallback[] cbs) {
+        return wrapServerCallbacks(serverId, cbs, false);
+    }
+
+    /**
+     * @param forwardIdentity when {@code true}, each callback is additionally
+     *        wrapped in {@link IdentityForwardingToolCallback} (inside the prefix
+     *        wrapper) so the authenticated username rides along with the call.
+     *        Driven by {@link McpIdentityForwardProperties} opt-in per server.
+     */
+    static List<ToolCallback> wrapServerCallbacks(long serverId, ToolCallback[] cbs, boolean forwardIdentity) {
         List<String> rawNames = new ArrayList<>(cbs.length);
         for (ToolCallback cb : cbs) {
             rawNames.add(cb.getToolDefinition() != null ? cb.getToolDefinition().name() : null);
@@ -267,7 +285,8 @@ public class McpClientManager {
                         serverId, raw, d.prefixedName(), d.unavailableReason());
                 continue;
             }
-            out.add(new PrefixedNameToolCallback(d.prefixedName(), cb));
+            ToolCallback inner = forwardIdentity ? new IdentityForwardingToolCallback(cb) : cb;
+            out.add(new PrefixedNameToolCallback(d.prefixedName(), inner));
         }
         return out;
     }
@@ -362,6 +381,11 @@ public class McpClientManager {
      *                side-effect free.
      */
     private McpSyncClient buildClient(McpServerEntity server, boolean managed) {
+        if (server.getId() != null && server.getName() != null) {
+            // Remember the name so identity-forward opt-in can be matched by name
+            // (not just numeric id) when callbacks are wrapped.
+            serverNames.put(server.getId(), server.getName());
+        }
         McpClientTransport transport = switch (server.getTransport()) {
             case "stdio" -> buildStdioTransport(server, managed);
             case "sse" -> buildSseTransport(server);

--- a/mateclaw-server/src/main/java/vip/mate/tool/mcp/runtime/McpIdentityForwardProperties.java
+++ b/mateclaw-server/src/main/java/vip/mate/tool/mcp/runtime/McpIdentityForwardProperties.java
@@ -1,0 +1,81 @@
+package vip.mate.tool.mcp.runtime;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.stereotype.Component;
+
+import java.util.Collections;
+import java.util.LinkedHashSet;
+import java.util.Set;
+
+/**
+ * Opt-in list of MCP servers that receive the calling user's identity.
+ *
+ * <p>When a server is listed here, every tool call routed to it is wrapped by
+ * {@link IdentityForwardingToolCallback}, which injects the authenticated
+ * username into the call arguments under {@link #IDENTITY_ARG}. The STDIO MCP
+ * server then forwards that to its downstream REST backend (on-behalf-of),
+ * typically alongside a static backend API key it holds itself.
+ *
+ * <p><b>Why opt-in, and per server.</b> A single STDIO subprocess is shared by
+ * every user (the client pool is keyed by server id), so identity can only
+ * travel <em>in-band per call</em> — never via the process environment, which is
+ * fixed at spawn. And injecting the username into <em>every</em> MCP server's
+ * calls would leak it to any third-party server an operator adds. So forwarding
+ * is off by default and enabled per trusted server.
+ *
+ * <p>Configuration ({@code application.yml}):
+ * <pre>
+ * mateclaw:
+ *   mcp:
+ *     identity-forward:
+ *       servers:
+ *         - my-internal-api        # MCP server name (as configured in mate_mcp_server)
+ *         - 1000000042             # or the numeric server id
+ * </pre>
+ *
+ * <p><b>Trust model.</b> The username is plaintext and injected by trusted Java
+ * (not the LLM — any LLM-supplied value of the same key is overwritten). This
+ * fits a REST backend on a trusted network that authenticates the MCP service
+ * by API key and treats the forwarded user as on-behalf-of. For stronger
+ * isolation, mint a short-lived signed token instead of forwarding the raw
+ * username (future work; see the design issue).
+ *
+ * @author MateClaw Team
+ */
+@Component
+@ConfigurationProperties(prefix = "mateclaw.mcp.identity-forward")
+public class McpIdentityForwardProperties {
+
+    /**
+     * Reserved tool-argument key carrying the authenticated username. Chosen to
+     * be collision-unlikely with real tool parameters; the MCP server reads and
+     * strips it. Kept in sync with the Python server contract.
+     */
+    public static final String IDENTITY_ARG = "__mateclaw_user__";
+
+    /** Server names (as in mate_mcp_server) or numeric ids that opt in. */
+    private Set<String> servers = Collections.emptySet();
+
+    public Set<String> getServers() {
+        return servers;
+    }
+
+    public void setServers(Set<String> servers) {
+        this.servers = servers != null ? new LinkedHashSet<>(servers) : Collections.emptySet();
+    }
+
+    /**
+     * @return {@code true} iff the configured set contains either the server's
+     *         numeric id (as a string) or its name. Either argument may be
+     *         {@code null}; the other is still checked.
+     */
+    public boolean forwardsTo(Long serverId, String serverName) {
+        if (servers.isEmpty()) {
+            return false;
+        }
+        if (serverId != null && servers.contains(String.valueOf(serverId))) {
+            return true;
+        }
+        return serverName != null && servers.contains(serverName);
+    }
+}

--- a/mateclaw-server/src/main/java/vip/mate/tool/mcp/runtime/McpIdentityForwardProperties.java
+++ b/mateclaw-server/src/main/java/vip/mate/tool/mcp/runtime/McpIdentityForwardProperties.java
@@ -5,23 +5,35 @@ import org.springframework.stereotype.Component;
 
 import java.util.Collections;
 import java.util.LinkedHashSet;
+import java.util.Map;
 import java.util.Set;
 
 /**
- * Opt-in list of MCP servers that receive the calling user's identity.
+ * Opt-in configuration for forwarding the calling user's identity to MCP servers.
  *
- * <p>When a server is listed here, every tool call routed to it is wrapped by
- * {@link IdentityForwardingToolCallback}, which injects the authenticated
- * username into the call arguments under {@link #IDENTITY_ARG}. The STDIO MCP
- * server then forwards that to its downstream REST backend (on-behalf-of),
- * typically alongside a static backend API key it holds itself.
+ * <p>When a server is listed in {@link #servers}, every tool call routed to it is
+ * wrapped by {@link IdentityForwardingToolCallback}, which injects the caller's
+ * identity into the call arguments. Two trust models:
+ *
+ * <ul>
+ *   <li><b>Plaintext</b> (default, {@code token.enabled=false}) — injects the
+ *       username under {@link #USER_ARG}. The REST backend trusts whatever the
+ *       MCP service forwards; only fits a trusted network where the backend
+ *       authenticates the MCP service by API key.</li>
+ *   <li><b>Signed token</b> ({@code token.enabled=true}) — injects a short-lived
+ *       RS256 JWT under {@link #TOKEN_ARG} (sub=user, aud=server, short exp),
+ *       minted by {@link McpIdentityForwardService} with MateClaw's private key.
+ *       The REST backend <em>verifies</em> it with the public key, so it trusts
+ *       the signature — not the MCP service, the Python script, or the transport.
+ *       This is the cross-trust-boundary baseline.</li>
+ * </ul>
  *
  * <p><b>Why opt-in, and per server.</b> A single STDIO subprocess is shared by
  * every user (the client pool is keyed by server id), so identity can only
  * travel <em>in-band per call</em> — never via the process environment, which is
- * fixed at spawn. And injecting the username into <em>every</em> MCP server's
- * calls would leak it to any third-party server an operator adds. So forwarding
- * is off by default and enabled per trusted server.
+ * fixed at spawn. And forwarding identity to <em>every</em> MCP server would leak
+ * it to any third-party server an operator adds. So it is off by default and
+ * enabled per trusted server.
  *
  * <p>Configuration ({@code application.yml}):
  * <pre>
@@ -29,16 +41,16 @@ import java.util.Set;
  *   mcp:
  *     identity-forward:
  *       servers:
- *         - my-internal-api        # MCP server name (as configured in mate_mcp_server)
- *         - 1000000042             # or the numeric server id
+ *         - my-internal-api          # MCP server name (mate_mcp_server) or numeric id
+ *       token:
+ *         enabled: true              # off =&gt; plaintext username (back-compat)
+ *         issuer: mateclaw
+ *         ttl-seconds: 60
+ *         key-id: mateclaw-mcp-1
+ *         private-key-pem: ${MCP_IDFWD_PRIVATE_KEY_PEM:}   # PKCS#8 PEM, RS256
+ *         audiences:                 # optional name/id -&gt; aud; default aud = server name
+ *           my-internal-api: my-internal-api
  * </pre>
- *
- * <p><b>Trust model.</b> The username is plaintext and injected by trusted Java
- * (not the LLM — any LLM-supplied value of the same key is overwritten). This
- * fits a REST backend on a trusted network that authenticates the MCP service
- * by API key and treats the forwarded user as on-behalf-of. For stronger
- * isolation, mint a short-lived signed token instead of forwarding the raw
- * username (future work; see the design issue).
  *
  * @author MateClaw Team
  */
@@ -47,14 +59,22 @@ import java.util.Set;
 public class McpIdentityForwardProperties {
 
     /**
-     * Reserved tool-argument key carrying the authenticated username. Chosen to
-     * be collision-unlikely with real tool parameters; the MCP server reads and
-     * strips it. Kept in sync with the Python server contract.
+     * Reserved tool-argument key carrying the plaintext username (plaintext
+     * trust model). Collision-unlikely with real tool parameters; the MCP
+     * server reads and strips it.
      */
-    public static final String IDENTITY_ARG = "__mateclaw_user__";
+    public static final String USER_ARG = "__mateclaw_user__";
+
+    /**
+     * Reserved tool-argument key carrying the signed JWT (token trust model).
+     * The MCP server forwards it as a bearer token; the REST backend verifies.
+     */
+    public static final String TOKEN_ARG = "__mateclaw_token__";
 
     /** Server names (as in mate_mcp_server) or numeric ids that opt in. */
     private Set<String> servers = Collections.emptySet();
+
+    private Token token = new Token();
 
     public Set<String> getServers() {
         return servers;
@@ -62,6 +82,14 @@ public class McpIdentityForwardProperties {
 
     public void setServers(Set<String> servers) {
         this.servers = servers != null ? new LinkedHashSet<>(servers) : Collections.emptySet();
+    }
+
+    public Token getToken() {
+        return token;
+    }
+
+    public void setToken(Token token) {
+        this.token = token != null ? token : new Token();
     }
 
     /**
@@ -77,5 +105,47 @@ public class McpIdentityForwardProperties {
             return true;
         }
         return serverName != null && servers.contains(serverName);
+    }
+
+    /**
+     * Audience claim for a server's minted tokens: an explicit mapping (by name
+     * or id) when configured, otherwise the server name (or id as string). Lets
+     * the backend reject a token minted for a different server.
+     */
+    public String audienceFor(Long serverId, String serverName) {
+        Map<String, String> aud = token.getAudiences();
+        if (serverName != null && aud.containsKey(serverName)) {
+            return aud.get(serverName);
+        }
+        if (serverId != null && aud.containsKey(String.valueOf(serverId))) {
+            return aud.get(String.valueOf(serverId));
+        }
+        return serverName != null ? serverName : String.valueOf(serverId);
+    }
+
+    /** Signed-token (JWT) settings for the token trust model. */
+    public static class Token {
+        private boolean enabled = false;
+        private String issuer = "mateclaw";
+        private long ttlSeconds = 60;
+        private String keyId = "mateclaw-mcp-1";
+        /** PKCS#8 PEM of the RS256 private key. Required when {@link #enabled}. */
+        private String privateKeyPem = "";
+        private Map<String, String> audiences = Collections.emptyMap();
+
+        public boolean isEnabled() { return enabled; }
+        public void setEnabled(boolean enabled) { this.enabled = enabled; }
+        public String getIssuer() { return issuer; }
+        public void setIssuer(String issuer) { this.issuer = issuer; }
+        public long getTtlSeconds() { return ttlSeconds; }
+        public void setTtlSeconds(long ttlSeconds) { this.ttlSeconds = ttlSeconds; }
+        public String getKeyId() { return keyId; }
+        public void setKeyId(String keyId) { this.keyId = keyId; }
+        public String getPrivateKeyPem() { return privateKeyPem; }
+        public void setPrivateKeyPem(String privateKeyPem) { this.privateKeyPem = privateKeyPem; }
+        public Map<String, String> getAudiences() { return audiences; }
+        public void setAudiences(Map<String, String> audiences) {
+            this.audiences = audiences != null ? audiences : Collections.emptyMap();
+        }
     }
 }

--- a/mateclaw-server/src/main/java/vip/mate/tool/mcp/runtime/McpIdentityForwardService.java
+++ b/mateclaw-server/src/main/java/vip/mate/tool/mcp/runtime/McpIdentityForwardService.java
@@ -1,0 +1,146 @@
+package vip.mate.tool.mcp.runtime;
+
+import io.jsonwebtoken.Jwts;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.ai.chat.model.ToolContext;
+import org.springframework.stereotype.Service;
+import vip.mate.tool.builtin.ToolExecutionContext;
+
+import java.security.KeyFactory;
+import java.security.PrivateKey;
+import java.security.spec.PKCS8EncodedKeySpec;
+import java.time.Duration;
+import java.time.Instant;
+import java.util.Base64;
+import java.util.Date;
+import java.util.Optional;
+import java.util.UUID;
+
+/**
+ * Resolves what identity to inject into an opt-in MCP server's tool call, and
+ * (in token mode) mints the signed assertion.
+ *
+ * <p>Two modes, per {@link McpIdentityForwardProperties}:
+ * <ul>
+ *   <li><b>plaintext</b> — returns {@code (__mateclaw_user__, username)}.</li>
+ *   <li><b>token</b> — returns {@code (__mateclaw_token__, <RS256 JWT>)} with
+ *       {@code sub}=username, {@code aud}=server audience, short {@code exp}. The
+ *       REST backend verifies the signature with the matching public key, so it
+ *       need not trust the MCP service or the transport.</li>
+ * </ul>
+ *
+ * <p>The {@code sub} carries the MateClaw user identifier
+ * ({@code ChatOrigin.requesterId}). If your backend keys authorization on an
+ * immutable numeric id, resolve username→id before minting (left as a refinement
+ * so this layer stays decoupled from the user store).
+ *
+ * <p>Fail-closed: when token mode is enabled but the signing key is missing or
+ * unparseable, nothing is injected (the call goes out without identity and the
+ * backend rejects it) rather than silently downgrading to plaintext.
+ *
+ * @author MateClaw Team
+ */
+@Slf4j
+@Service
+public class McpIdentityForwardService {
+
+    private final McpIdentityForwardProperties properties;
+
+    /** Lazily parsed signing key; {@code null} until first use / when unavailable. */
+    private volatile PrivateKey signingKey;
+    private volatile boolean keyParseAttempted;
+
+    public McpIdentityForwardService(McpIdentityForwardProperties properties) {
+        this.properties = properties;
+    }
+
+    public boolean forwardsTo(Long serverId, String serverName) {
+        return properties.forwardsTo(serverId, serverName);
+    }
+
+    public String audienceFor(Long serverId, String serverName) {
+        return properties.audienceFor(serverId, serverName);
+    }
+
+    /** The (key, value) to merge into the call arguments, or empty to inject nothing. */
+    public record Injection(String key, String value) {}
+
+    /**
+     * Resolve the identity injection for a call. Empty when there is no
+     * authenticated user (never fabricate identity), or when token mode is
+     * enabled but the key is unavailable (fail-closed).
+     */
+    public Optional<Injection> resolve(ToolContext ctx, String audience) {
+        String user = ToolExecutionContext.username(ctx);
+        if (user == null || user.isBlank()) {
+            return Optional.empty();
+        }
+        if (!properties.getToken().isEnabled()) {
+            return Optional.of(new Injection(McpIdentityForwardProperties.USER_ARG, user));
+        }
+        String jwt = mint(user, audience);
+        if (jwt == null) {
+            return Optional.empty();   // fail-closed: token mode but no key
+        }
+        return Optional.of(new Injection(McpIdentityForwardProperties.TOKEN_ARG, jwt));
+    }
+
+    /** Mint a short-lived RS256 JWT, or {@code null} if the key is unavailable. */
+    private String mint(String subject, String audience) {
+        PrivateKey key = signingKey();
+        if (key == null) {
+            return null;
+        }
+        McpIdentityForwardProperties.Token t = properties.getToken();
+        Instant now = Instant.now();
+        try {
+            return Jwts.builder()
+                    .header().keyId(t.getKeyId()).and()
+                    .issuer(t.getIssuer())
+                    .subject(subject)
+                    .audience().add(audience).and()
+                    .id(UUID.randomUUID().toString())
+                    .issuedAt(Date.from(now))
+                    .expiration(Date.from(now.plus(Duration.ofSeconds(Math.max(1, t.getTtlSeconds())))))
+                    .signWith(key, Jwts.SIG.RS256)
+                    .compact();
+        } catch (Exception e) {
+            log.error("[McpIdentity] failed to mint identity token: {}", e.getMessage());
+            return null;
+        }
+    }
+
+    private PrivateKey signingKey() {
+        PrivateKey k = signingKey;
+        if (k != null) {
+            return k;
+        }
+        if (keyParseAttempted) {
+            return null;   // already tried and failed; don't spam parsing
+        }
+        synchronized (this) {
+            if (signingKey != null) {
+                return signingKey;
+            }
+            keyParseAttempted = true;
+            String pem = properties.getToken().getPrivateKeyPem();
+            if (pem == null || pem.isBlank()) {
+                log.error("[McpIdentity] token mode enabled but mateclaw.mcp.identity-forward.token.private-key-pem is empty; "
+                        + "identity tokens will NOT be issued (fail-closed)");
+                return null;
+            }
+            try {
+                String body = pem.replaceAll("-----BEGIN (.*)-----", "")
+                        .replaceAll("-----END (.*)-----", "")
+                        .replaceAll("\\s", "");
+                byte[] der = Base64.getDecoder().decode(body);
+                signingKey = KeyFactory.getInstance("RSA")
+                        .generatePrivate(new PKCS8EncodedKeySpec(der));
+                log.info("[McpIdentity] loaded RS256 signing key (kid={})", properties.getToken().getKeyId());
+            } catch (Exception e) {
+                log.error("[McpIdentity] failed to parse private-key-pem (expect PKCS#8 RSA): {}", e.getMessage());
+            }
+            return signingKey;
+        }
+    }
+}

--- a/mateclaw-server/src/main/java/vip/mate/tool/mcp/runtime/McpIdentityForwardService.java
+++ b/mateclaw-server/src/main/java/vip/mate/tool/mcp/runtime/McpIdentityForwardService.java
@@ -4,6 +4,7 @@ import io.jsonwebtoken.Jwts;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.ai.chat.model.ToolContext;
 import org.springframework.stereotype.Service;
+import vip.mate.agent.context.ChatOrigin;
 import vip.mate.tool.builtin.ToolExecutionContext;
 
 import java.security.KeyFactory;
@@ -20,19 +21,31 @@ import java.util.UUID;
  * Resolves what identity to inject into an opt-in MCP server's tool call, and
  * (in token mode) mints the signed assertion.
  *
- * <p>Two modes, per {@link McpIdentityForwardProperties}:
+ * <p><b>Identity typing.</b> Not every requester is a MateClaw-authenticated
+ * account. The resolved identity is typed so the REST backend can tell
+ * "MateClaw authenticated this user" apart from "this is an external/anonymous
+ * identifier" (see RFC: on-behalf-of identity typing):
  * <ul>
- *   <li><b>plaintext</b> — returns {@code (__mateclaw_user__, username)}.</li>
- *   <li><b>token</b> — returns {@code (__mateclaw_token__, <RS256 JWT>)} with
- *       {@code sub}=username, {@code aud}=server audience, short {@code exp}. The
- *       REST backend verifies the signature with the matching public key, so it
- *       need not trust the MCP service or the transport.</li>
+ *   <li><b>authenticated</b> — web-console login (JWT/PAT). {@code sub} = the
+ *       user's immutable numeric id (carried on {@link ChatOrigin#requesterUserId()}).
+ *       The backend may authorize on-behalf-of freely.</li>
+ *   <li><b>anonymous</b> — webchat visitor / third-party {@code endUserId}. No
+ *       MateClaw account backs it; {@code sub} = the visitor id. The backend must
+ *       treat this as unauthenticated and decide for itself whether/how to serve.</li>
+ *   <li><b>external</b> — IM sender (feishu/wecom/…). {@code sub} = the platform
+ *       sender id; same caveat as anonymous.</li>
+ *   <li><b>none</b> — cron / system / unattributed. Nothing is injected (fail-closed):
+ *       we never assert identity on behalf of a non-user.</li>
  * </ul>
  *
- * <p>The {@code sub} carries the MateClaw user identifier
- * ({@code ChatOrigin.requesterId}). If your backend keys authorization on an
- * immutable numeric id, resolve username→id before minting (left as a refinement
- * so this layer stays decoupled from the user store).
+ * <p>Two transport modes carry the typed identity, per {@link McpIdentityForwardProperties}:
+ * <ul>
+ *   <li><b>plaintext</b> — injects {@code <trust>:<subject>} under {@link McpIdentityForwardProperties#USER_ARG}.</li>
+ *   <li><b>token</b> — injects an RS256 JWT under {@link McpIdentityForwardProperties#TOKEN_ARG}
+ *       with {@code sub}, {@code trust}, {@code channel_type}, {@code aud}, short {@code exp}.
+ *       The REST backend verifies the signature with the matching public key, so it
+ *       need not trust the MCP service or the transport.</li>
+ * </ul>
  *
  * <p>Fail-closed: when token mode is enabled but the signing key is missing or
  * unparseable, nothing is injected (the call goes out without identity and the
@@ -43,6 +56,11 @@ import java.util.UUID;
 @Slf4j
 @Service
 public class McpIdentityForwardService {
+
+    /** Trust levels carried in the JWT {@code trust} claim / plaintext prefix. */
+    static final String TRUST_AUTHENTICATED = "authenticated";
+    static final String TRUST_ANONYMOUS = "anonymous";
+    static final String TRUST_EXTERNAL = "external";
 
     private final McpIdentityForwardProperties properties;
 
@@ -65,20 +83,70 @@ public class McpIdentityForwardService {
     /** The (key, value) to merge into the call arguments, or empty to inject nothing. */
     public record Injection(String key, String value) {}
 
+    /** A typed identity resolved from the request origin. Empty = inject nothing. */
+    record ResolvedIdentity(String subject, String trust, String channelType) {
+        static final ResolvedIdentity NONE = new ResolvedIdentity(null, null, null);
+        boolean present() { return subject != null && !subject.isBlank(); }
+    }
+
     /**
-     * Resolve the identity injection for a call. Empty when there is no
-     * authenticated user (never fabricate identity), or when token mode is
-     * enabled but the key is unavailable (fail-closed).
+     * Classify the requester behind a tool call into a typed identity. Returns
+     * {@link ResolvedIdentity#NONE} for cron / system / unattributed origins
+     * (never assert identity on behalf of a non-user).
+     *
+     * <p>Source channel is read from {@link ChatOrigin} (carried on the
+     * {@link ToolContext}); when the context carries no origin it falls back to
+     * the legacy {@link ToolExecutionContext} username (treated as web/authenticated
+     * only if non-blank — preserves the original contract for the ThreadLocal path).
+     */
+    ResolvedIdentity classify(ToolContext ctx) {
+        ChatOrigin origin = ChatOrigin.from(ctx);
+        // Cron / system / unattributed: never forward identity.
+        if (origin.cronOrigin() || "system".equals(origin.requesterId())) {
+            return ResolvedIdentity.NONE;
+        }
+        String channel = origin.channelType();
+        // Authenticated web account: MateClaw vouches for this user. Prefer the
+        // immutable numeric id when available (web-console login); fall back to
+        // the username when only the ThreadLocal path supplied identity.
+        if (channel == null || channel.isBlank() || "web".equals(channel)) {
+            if (origin.requesterUserId() != null) {
+                return new ResolvedIdentity(String.valueOf(origin.requesterUserId()),
+                        TRUST_AUTHENTICATED, "web");
+            }
+            String user = ToolExecutionContext.username(ctx);
+            return user != null && !user.isBlank()
+                    ? new ResolvedIdentity(user, TRUST_AUTHENTICATED, "web")
+                    : ResolvedIdentity.NONE;
+        }
+        // webchat visitor ("api") or IM sender (feishu/wecom/…): external id,
+        // no MateClaw account — forward with an explicit trust downgrade so the
+        // backend knows it is NOT an authenticated MateClaw user.
+        String requester = origin.requesterId();
+        if (requester == null || requester.isBlank()) {
+            return ResolvedIdentity.NONE;
+        }
+        String trust = "api".equals(channel) ? TRUST_ANONYMOUS : TRUST_EXTERNAL;
+        return new ResolvedIdentity(requester, trust, channel);
+    }
+
+    /**
+     * Resolve the identity injection for a call. Empty when the origin carries
+     * no usable identity (cron / system / anonymous-without-id), or when token
+     * mode is enabled but the key is unavailable (fail-closed).
      */
     public Optional<Injection> resolve(ToolContext ctx, String audience) {
-        String user = ToolExecutionContext.username(ctx);
-        if (user == null || user.isBlank()) {
+        ResolvedIdentity id = classify(ctx);
+        if (!id.present()) {
             return Optional.empty();
         }
         if (!properties.getToken().isEnabled()) {
-            return Optional.of(new Injection(McpIdentityForwardProperties.USER_ARG, user));
+            // Plaintext: prefix the value with the trust level so the backend
+            // can tell authenticated from anonymous/external without a JWT.
+            return Optional.of(new Injection(McpIdentityForwardProperties.USER_ARG,
+                    id.trust() + ":" + id.subject()));
         }
-        String jwt = mint(user, audience);
+        String jwt = mint(id, audience);
         if (jwt == null) {
             return Optional.empty();   // fail-closed: token mode but no key
         }
@@ -86,7 +154,7 @@ public class McpIdentityForwardService {
     }
 
     /** Mint a short-lived RS256 JWT, or {@code null} if the key is unavailable. */
-    private String mint(String subject, String audience) {
+    private String mint(ResolvedIdentity id, String audience) {
         PrivateKey key = signingKey();
         if (key == null) {
             return null;
@@ -97,8 +165,10 @@ public class McpIdentityForwardService {
             return Jwts.builder()
                     .header().keyId(t.getKeyId()).and()
                     .issuer(t.getIssuer())
-                    .subject(subject)
+                    .subject(id.subject())
                     .audience().add(audience).and()
+                    .claim("trust", id.trust())
+                    .claim("channel_type", id.channelType())
                     .id(UUID.randomUUID().toString())
                     .issuedAt(Date.from(now))
                     .expiration(Date.from(now.plus(Duration.ofSeconds(Math.max(1, t.getTtlSeconds())))))

--- a/mateclaw-server/src/main/resources/docs/en/mcp.md
+++ b/mateclaw-server/src/main/resources/docs/en/mcp.md
@@ -448,12 +448,80 @@ if __name__ == "__main__":
 > `__mateclaw_user__` as an optional parameter (as above) or strict validation
 > will reject it.
 
-### Trust model
+### Two trust models
 
-The injected value is a **plaintext username** — appropriate when REST is on a
-trusted network and authenticates the MCP service by API key, treating the
-forwarded user as on-behalf-of. For stronger isolation, mint a short-lived
-**signed token** (JWT) instead of the raw username and validate it at REST.
+**① Plaintext (default)**: injects the plaintext username. Fits a trusted
+network where the backend authenticates the MCP service by API key and treats
+the forwarded user as on-behalf-of. The backend trusts the raw string.
+
+**② Signed token (recommended across a trust boundary)**: injects a short-lived
+**RS256 JWT** that MateClaw signs with a private key (reserved key becomes
+**`__mateclaw_token__`**); the REST backend **verifies it with the public key**,
+so it trusts the signature — not the MCP service, the Python script, or the
+transport.
+
+```yaml
+mateclaw:
+  mcp:
+    identity-forward:
+      servers:
+        - my-internal-api
+      token:
+        enabled: true
+        issuer: mateclaw
+        ttl-seconds: 60                 # short, tens of seconds
+        key-id: mateclaw-mcp-1
+        private-key-pem: ${MCP_IDFWD_PRIVATE_KEY_PEM:}   # PKCS#8 PEM (RS256 private key)
+        audiences:                      # optional; default aud = server name
+          my-internal-api: https://api.internal
+```
+
+Generate the key pair (private → MateClaw, public → REST backend):
+
+```bash
+openssl genpkey -algorithm RSA -pkcs8 -out mcp-idfwd-private.pem
+openssl pkey -in mcp-idfwd-private.pem -pubout -out mcp-idfwd-public.pem
+# private-key-pem takes the private key body (PEM headers optional; stripped on parse)
+```
+
+Token claims: `iss`, `sub`=user, `aud`=this server, `iat`, `exp` (short), `jti`.
+`aud` + short `exp` bound replay to tens of seconds and to one backend. **When
+token mode is on but no key is configured, it fails closed** (no token minted,
+nothing injected — the backend rejects) rather than silently downgrading to
+plaintext.
+
+> `sub` carries the MateClaw user identifier (`ChatOrigin.requesterId`). If your
+> backend authorizes on an immutable numeric id, resolve username→id before
+> minting (kept decoupled from the user store here).
+
+The MCP server (Python) only forwards — it does not verify:
+
+```python
+@mcp.tool()
+def query_orders(keyword: str, __mateclaw_token__: str | None = None) -> str:
+    if not __mateclaw_token__:
+        raise ValueError("missing identity token")
+    headers = {"Authorization": f"Bearer {__mateclaw_token__}"}   # forward to REST
+    return httpx.get(f"{REST_BASE}/orders", params={"q": keyword}, headers=headers, timeout=30).text
+```
+
+REST backend verifies (pseudocode):
+
+```python
+import jwt  # PyJWT
+claims = jwt.decode(token, public_key_pem, algorithms=["RS256"],
+                    issuer="mateclaw", audience="https://api.internal")
+user = claims["sub"]            # trusted only after signature verification
+# → per-user authorization; invalid/expired → 401
+```
+
+> Public-key distribution: for now an operator configures the public key on the
+> REST side out-of-band. A JWKS endpoint for auto-distribution + rotation is a
+> natural follow-up.
+>
+> Relationship to the API key: you can keep the API key as service/channel auth
+> ("this MCP service may talk to the backend") plus the JWT as the user
+> assertion — two clean layers — or let the JWT carry both.
 
 ---
 

--- a/mateclaw-server/src/main/resources/docs/en/mcp.md
+++ b/mateclaw-server/src/main/resources/docs/en/mcp.md
@@ -383,6 +383,80 @@ Keeps secrets out of the database.
 
 ---
 
+## Forwarding the user's identity to an MCP server (on-behalf-of)
+
+A STDIO MCP server is **one shared subprocess per configuration**, used by every
+user; its environment is fixed at spawn and STDIO has no per-request header
+channel like HTTP. So per-user identity **cannot travel via env** — it must ride
+in-band with each tool call.
+
+MateClaw can inject the **authenticated username** into every tool call for a
+chosen server, so the server can call its downstream REST backend on behalf of
+that user.
+
+### Enable (opt-in, per server)
+
+Off by default — injecting into every server would leak the username to any
+third-party MCP server. Enable per server by **name or id**:
+
+```yaml
+mateclaw:
+  mcp:
+    identity-forward:
+      servers:
+        - my-internal-api      # server name in mate_mcp_server
+        - 1000000042           # or the numeric server id
+```
+
+### Data contract
+
+When enabled, MateClaw injects the reserved argument **`__mateclaw_user__`**
+(value = authenticated username) into each tool call's JSON arguments. It is
+injected by trusted server code, **never by the LLM** — any model-supplied value
+of the same key is overwritten, so the model cannot spoof identity. When there is
+no authenticated user, nothing is injected (identity is never fabricated).
+
+The MCP server reads and strips the key, then calls REST with it plus its own
+backend API key (e.g. an `X-On-Behalf-Of` header):
+
+```python
+# FastMCP example: MCP server as a Python CLI script (STDIO)
+import os, httpx
+from mcp.server.fastmcp import FastMCP
+
+mcp = FastMCP("my-internal-api")
+REST_BASE = os.environ["REST_BASE"]
+API_KEY = os.environ["BACKEND_API_KEY"]      # service-level key (authenticates the MCP service)
+
+@mcp.tool()
+def query_orders(keyword: str, __mateclaw_user__: str | None = None) -> str:
+    if not __mateclaw_user__:
+        raise ValueError("missing injected identity")   # reject identity-less calls
+    headers = {
+        "Authorization": f"ApiKey {API_KEY}",            # service identity
+        "X-On-Behalf-Of": __mateclaw_user__,             # the acting user
+    }
+    r = httpx.get(f"{REST_BASE}/orders", params={"q": keyword}, headers=headers, timeout=30)
+    r.raise_for_status()
+    return r.text
+
+if __name__ == "__main__":
+    mcp.run()   # STDIO
+```
+
+> If a tool's input schema is `additionalProperties: false`, declare
+> `__mateclaw_user__` as an optional parameter (as above) or strict validation
+> will reject it.
+
+### Trust model
+
+The injected value is a **plaintext username** — appropriate when REST is on a
+trusted network and authenticates the MCP service by API key, treating the
+forwarded user as on-behalf-of. For stronger isolation, mint a short-lived
+**signed token** (JWT) instead of the raw username and validate it at REST.
+
+---
+
 ## Troubleshooting
 
 ### "Command not found" (stdio)

--- a/mateclaw-server/src/main/resources/docs/zh/mcp.md
+++ b/mateclaw-server/src/main/resources/docs/zh/mcp.md
@@ -379,6 +379,64 @@ API 响应里 `headers_json` 和 `env_json` 的值自动**脱敏**。`args_json`
 
 ---
 
+## 透传用户身份给 MCP server（on-behalf-of）
+
+STDIO MCP server 是**每个配置一个共享子进程**，所有用户共用；env 在子进程启动时一次性注入、之后不可变，STDIO 也没有 HTTP 那种 per-request header 通道。所以**不能用 env 传 per-user 身份**——身份必须随每次工具调用在带内传递。
+
+MateClaw 支持把**认证用户名**注入到每次工具调用的参数里，让 MCP server 代表该用户调用底层 REST 后端。
+
+### 开启（opt-in，按 server）
+
+默认关闭——全量注入会把用户名泄漏给任意第三方 MCP server。用允许清单按 **server 名或 id** 开启：
+
+```yaml
+mateclaw:
+  mcp:
+    identity-forward:
+      servers:
+        - my-internal-api      # mate_mcp_server 里的 server 名
+        - 1000000042           # 或数字 server id
+```
+
+### 数据契约
+
+开启后，MateClaw 在调用该 server 的每个工具时，往参数 JSON 里注入保留字段 **`__mateclaw_user__`**（值=认证用户名）。该值由受信服务端注入、**不经 LLM**；若 LLM 伪造了同名字段会被覆盖，因此模型无法冒充身份。无认证用户时不注入（不伪造身份）。
+
+MCP server 侧读出该字段、剥掉，再连同自己持有的后端 API Key 一起调 REST（如 `X-On-Behalf-Of` header）：
+
+```python
+# FastMCP 示例：MCP server 用 Python 命令行脚本（STDIO）
+import os, httpx
+from mcp.server.fastmcp import FastMCP
+
+mcp = FastMCP("my-internal-api")
+REST_BASE = os.environ["REST_BASE"]          # 后端地址
+API_KEY = os.environ["BACKEND_API_KEY"]      # 服务级 API Key（认证 MCP 服务本身）
+
+@mcp.tool()
+def query_orders(keyword: str, __mateclaw_user__: str | None = None) -> str:
+    if not __mateclaw_user__:
+        raise ValueError("missing injected identity")   # 拒绝无身份调用
+    headers = {
+        "Authorization": f"ApiKey {API_KEY}",            # 服务身份
+        "X-On-Behalf-Of": __mateclaw_user__,             # 代表的用户
+    }
+    r = httpx.get(f"{REST_BASE}/orders", params={"q": keyword}, headers=headers, timeout=30)
+    r.raise_for_status()
+    return r.text
+
+if __name__ == "__main__":
+    mcp.run()   # STDIO
+```
+
+> 工具的入参 schema 若是 `additionalProperties: false`，记得像上面那样把 `__mateclaw_user__` 声明为可选参数，否则严格校验会拒绝。
+
+### 信任模型
+
+注入的是**明文用户名**——适合 REST 在内网、且后端用 API Key 认证 MCP 服务、把转发的用户当 on-behalf-of 的场景。需要更强隔离时应改为 MateClaw 签发**短时签名 token**（JWT）而非明文用户名，由 REST 验签。
+
+---
+
 ## 故障排查
 
 ### "命令找不到"（stdio）

--- a/mateclaw-server/src/main/resources/docs/zh/mcp.md
+++ b/mateclaw-server/src/main/resources/docs/zh/mcp.md
@@ -431,9 +431,64 @@ if __name__ == "__main__":
 
 > 工具的入参 schema 若是 `additionalProperties: false`，记得像上面那样把 `__mateclaw_user__` 声明为可选参数，否则严格校验会拒绝。
 
-### 信任模型
+### 两种信任模型
 
-注入的是**明文用户名**——适合 REST 在内网、且后端用 API Key 认证 MCP 服务、把转发的用户当 on-behalf-of 的场景。需要更强隔离时应改为 MateClaw 签发**短时签名 token**（JWT）而非明文用户名，由 REST 验签。
+**① 明文（默认）**：注入明文用户名。适合 REST 在内网、且后端用 API Key 认证 MCP 服务、把转发用户当 on-behalf-of 的场景。后端裸信这个字符串。
+
+**② 签名 token（推荐用于跨信任边界）**：注入一个 MateClaw 用私钥现签的**短时 RS256 JWT**（保留字段换成 **`__mateclaw_token__`**），REST 后端用**公钥验签**——它信任的是签名，而非 MCP 服务/Python/传输。
+
+```yaml
+mateclaw:
+  mcp:
+    identity-forward:
+      servers:
+        - my-internal-api
+      token:
+        enabled: true
+        issuer: mateclaw
+        ttl-seconds: 60                 # 短时，几十秒
+        key-id: mateclaw-mcp-1
+        private-key-pem: ${MCP_IDFWD_PRIVATE_KEY_PEM:}   # PKCS#8 PEM（RS256 私钥）
+        audiences:                      # 可选；默认 aud = server 名
+          my-internal-api: https://api.internal
+```
+
+生成密钥对（私钥配给 MateClaw，公钥配给 REST 后端）：
+
+```bash
+openssl genpkey -algorithm RSA -pkcs8 -out mcp-idfwd-private.pem
+openssl pkey -in mcp-idfwd-private.pem -pubout -out mcp-idfwd-public.pem
+# private-key-pem 用私钥内容（带不带 PEM 头都行，解析时会剥掉）
+```
+
+token 的 claims：`iss`、`sub`=用户、`aud`=该 server、`iat`、`exp`（短）、`jti`。`aud`+短 `exp` 把重放限制在几十秒内、且只对这一个后端。**token 模式开启但没配私钥时 fail-closed**（不签、不注入，后端自然拒绝），不会偷偷退回明文。
+
+> `sub` 携带的是 MateClaw 用户标识（`ChatOrigin.requesterId`）。若后端按不可变数字 id 鉴权，可在签发前把用户名解析成 id（本层刻意不耦合用户存储）。
+
+MCP server（Python）只透传、不验签：
+
+```python
+@mcp.tool()
+def query_orders(keyword: str, __mateclaw_token__: str | None = None) -> str:
+    if not __mateclaw_token__:
+        raise ValueError("missing identity token")
+    headers = {"Authorization": f"Bearer {__mateclaw_token__}"}   # 直接透传给 REST
+    return httpx.get(f"{REST_BASE}/orders", params={"q": keyword}, headers=headers, timeout=30).text
+```
+
+REST 后端验签（伪代码）：
+
+```python
+import jwt  # PyJWT
+claims = jwt.decode(token, public_key_pem, algorithms=["RS256"],
+                    issuer="mateclaw", audience="https://api.internal")
+user = claims["sub"]            # 验签通过才相信
+# → 按 user 做 per-user 授权；验签失败/过期 → 401
+```
+
+> 公钥分发：当前由运维把上面生成的公钥配到 REST 侧（带外）。后续可加一个 JWKS 端点自动分发+轮换。
+>
+> 与 API Key 的关系：可保留 API Key 作"服务/通道认证"（这台 MCP 服务被允许跟后端说话）+ JWT 作"用户断言"，双层更清晰；也可让 JWT 一肩挑。
 
 ---
 

--- a/mateclaw-server/src/test/java/vip/mate/agent/context/ChatOriginSenderFieldsTest.java
+++ b/mateclaw-server/src/test/java/vip/mate/agent/context/ChatOriginSenderFieldsTest.java
@@ -41,7 +41,7 @@ class ChatOriginSenderFieldsTest {
     void withSenderPreservesOtherFields() {
         ChatOrigin original = new ChatOrigin(
                 7L, "conv-1", "u123", 5L, "/ws", 9L, null, false,
-                null, null, null, null);
+                null, null, null, null, null);
         ChatOrigin enriched = original.withSender("Alice", "wecom", "g-1");
 
         // All non-sender fields unchanged
@@ -80,7 +80,7 @@ class ChatOriginSenderFieldsTest {
         ChatOrigin origin = new ChatOrigin(
                 7L, "feishu:oc_42", "ou_xyz", 5L, "/data/ws/5",
                 9L, null, false,
-                "Alice", "feishu", "oc_42", null);
+                "Alice", "feishu", "oc_42", null, null);
 
         String json = om.writeValueAsString(origin);
         ChatOrigin restored = om.readValue(json, ChatOrigin.class);

--- a/mateclaw-server/src/test/java/vip/mate/agent/context/ChatOriginTest.java
+++ b/mateclaw-server/src/test/java/vip/mate/agent/context/ChatOriginTest.java
@@ -28,7 +28,7 @@ class ChatOriginTest {
     void roundTripThroughToolContext_preservesAllFields() {
         ChannelTarget target = new ChannelTarget("user-42", "thread-abc", "bot-001");
         ChatOrigin original = new ChatOrigin(7L, "wechat:42", "u123", 5L,
-                "/data/ws/5", 9L, target, false, null, null, null, null);
+                "/data/ws/5", 9L, target, false, null, null, null, null, null);
 
         ToolContext ctx = original.toToolContext();
         ChatOrigin restored = ChatOrigin.from(ctx);
@@ -75,7 +75,7 @@ class ChatOriginTest {
     void jsonSerialization_isStableAndForwardCompatible() throws Exception {
         ObjectMapper om = new ObjectMapper();
         ChatOrigin origin = new ChatOrigin(7L, "wechat:42", "u123", 5L,
-                "/data/ws/5", 9L, new ChannelTarget("user-42", "thread-abc", "bot-001"), false, null, null, null, null);
+                "/data/ws/5", 9L, new ChannelTarget("user-42", "thread-abc", "bot-001"), false, null, null, null, null, null);
 
         String json = om.writeValueAsString(origin);
         ChatOrigin restored = om.readValue(json, ChatOrigin.class);

--- a/mateclaw-server/src/test/java/vip/mate/agent/context/RuntimeContextInjectorModelTest.java
+++ b/mateclaw-server/src/test/java/vip/mate/agent/context/RuntimeContextInjectorModelTest.java
@@ -65,7 +65,7 @@ class RuntimeContextInjectorModelTest {
     void imOriginHasSenderAndModel() {
         ChatOrigin origin = new ChatOrigin(
                 7L, "feishu:oc_abc", "ou_xyz", 5L, "/data/ws/5",
-                9L, null, false, "Alice", "feishu", "oc_abc", null);
+                9L, null, false, "Alice", "feishu", "oc_abc", null, null);
 
         String ctx = RuntimeContextInjector.buildContextMessage(
                 "/data/ws/5", null, origin, "gpt-4o", "openai");

--- a/mateclaw-server/src/test/java/vip/mate/agent/context/RuntimeContextInjectorSenderTest.java
+++ b/mateclaw-server/src/test/java/vip/mate/agent/context/RuntimeContextInjectorSenderTest.java
@@ -28,7 +28,7 @@ class RuntimeContextInjectorSenderTest {
                 /* senderName */ "Alice",
                 /* channelType */ "feishu",
                 /* chatId */ "oc_abc",
-                /* baseUrl */ null);
+                /* baseUrl */ null, null);
 
         String ctx = RuntimeContextInjector.buildContextMessage("/data/ws/5", null, origin);
 
@@ -45,7 +45,7 @@ class RuntimeContextInjectorSenderTest {
         ChatOrigin origin = new ChatOrigin(
                 7L, "feishu:ou_xyz", "ou_xyz", 5L, "/data/ws/5",
                 9L, null, false,
-                "Alice", "feishu", null, null);
+                "Alice", "feishu", null, null, null);
 
         String ctx = RuntimeContextInjector.buildContextMessage("/data/ws/5", null, origin);
 
@@ -102,7 +102,7 @@ class RuntimeContextInjectorSenderTest {
     void blankSenderName() {
         ChatOrigin origin = new ChatOrigin(
                 7L, null, "ou_xyz", null, null, null, null, false,
-                /* senderName */ "  ", "feishu", null, null);
+                /* senderName */ "  ", "feishu", null, null, null);
 
         String ctx = RuntimeContextInjector.buildContextMessage(null, null, origin);
 

--- a/mateclaw-server/src/test/java/vip/mate/approval/ApprovalReplayContinuityTest.java
+++ b/mateclaw-server/src/test/java/vip/mate/approval/ApprovalReplayContinuityTest.java
@@ -45,7 +45,7 @@ class ApprovalReplayContinuityTest {
                 /* senderName */ "Alice",
                 /* channelType */ "wecom",
                 /* chatId */ "group-a",
-                /* baseUrl */ null);
+                /* baseUrl */ null, null);
 
         String json = objectMapper.writeValueAsString(original);
         ChatOrigin restored = workflow.restoreChatOrigin(json);

--- a/mateclaw-server/src/test/java/vip/mate/cron/service/CronJobRunnerPromptTest.java
+++ b/mateclaw-server/src/test/java/vip/mate/cron/service/CronJobRunnerPromptTest.java
@@ -42,7 +42,7 @@ class CronJobRunnerPromptTest {
                 /* senderName */ null,
                 /* channelType */ "feishu",
                 /* chatId */ "group-a",
-                /* baseUrl */ null);
+                /* baseUrl */ null, null);
         String prompt = CronJobRunner.buildCronPrompt("提醒喝水", channelOrigin);
 
         assertTrue(prompt.contains("[定时任务执行说明]"));

--- a/mateclaw-server/src/test/java/vip/mate/tool/builtin/DelegateAsyncTaskOutputAttributionTest.java
+++ b/mateclaw-server/src/test/java/vip/mate/tool/builtin/DelegateAsyncTaskOutputAttributionTest.java
@@ -195,7 +195,7 @@ class DelegateAsyncTaskOutputAttributionTest {
 
     private ToolContext makeCtx(String requester, String conversationId) {
         ChatOrigin origin = new ChatOrigin(
-                1L, conversationId, requester, null, null, null, null, false, null, null, null, null);
+                1L, conversationId, requester, null, null, null, null, false, null, null, null, null, null);
         Map<String, Object> map = new HashMap<>();
         map.put(ChatOrigin.CTX_KEY, origin);
         return new ToolContext(map);

--- a/mateclaw-server/src/test/java/vip/mate/tool/builtin/DelegateAsyncToolTest.java
+++ b/mateclaw-server/src/test/java/vip/mate/tool/builtin/DelegateAsyncToolTest.java
@@ -388,7 +388,7 @@ class DelegateAsyncToolTest {
 
     private ToolContext makeCtx(String requester, String conversationId) {
         ChatOrigin origin = new ChatOrigin(
-                1L, conversationId, requester, null, null, null, null, false, null, null, null, null);
+                1L, conversationId, requester, null, null, null, null, false, null, null, null, null, null);
         Map<String, Object> map = new HashMap<>();
         map.put(ChatOrigin.CTX_KEY, origin);
         return new ToolContext(map);

--- a/mateclaw-server/src/test/java/vip/mate/tool/mcp/runtime/IdentityForwardingToolCallbackTest.java
+++ b/mateclaw-server/src/test/java/vip/mate/tool/mcp/runtime/IdentityForwardingToolCallbackTest.java
@@ -1,0 +1,84 @@
+package vip.mate.tool.mcp.runtime;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import vip.mate.tool.builtin.ToolExecutionContext;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Unit tests for {@link IdentityForwardingToolCallback#withIdentity} — the
+ * in-band identity injection that lets a STDIO MCP server forward the caller to
+ * its REST backend. Pure string/JSON behavior, runs everywhere.
+ */
+class IdentityForwardingToolCallbackTest {
+
+    private static final ObjectMapper MAPPER = new ObjectMapper();
+    private static final String KEY = McpIdentityForwardProperties.IDENTITY_ARG;
+
+    @AfterEach
+    void clearContext() {
+        ToolExecutionContext.clear();
+    }
+
+    @Test
+    @DisplayName("injects username into JSON args under the reserved key")
+    void injectsUsername() throws Exception {
+        String out = IdentityForwardingToolCallback.withIdentity("{\"q\":\"hi\"}", "alice");
+        JsonNode n = MAPPER.readTree(out);
+        assertThat(n.get("q").asText()).isEqualTo("hi");
+        assertThat(n.get(KEY).asText()).isEqualTo("alice");
+    }
+
+    @Test
+    @DisplayName("overwrites an LLM-supplied value of the reserved key (no spoofing)")
+    void overwritesLlmSuppliedIdentity() throws Exception {
+        String out = IdentityForwardingToolCallback.withIdentity(
+                "{\"q\":\"hi\",\"" + KEY + "\":\"attacker\"}", "alice");
+        assertThat(MAPPER.readTree(out).get(KEY).asText()).isEqualTo("alice");
+    }
+
+    @Test
+    @DisplayName("blank/empty input becomes a fresh object carrying the identity")
+    void emptyInputGetsObject() throws Exception {
+        for (String in : new String[]{null, "", "   "}) {
+            String out = IdentityForwardingToolCallback.withIdentity(in, "bob");
+            assertThat(MAPPER.readTree(out).get(KEY).asText()).isEqualTo("bob");
+        }
+    }
+
+    @Test
+    @DisplayName("no authenticated user → input forwarded unchanged (never fabricate identity)")
+    void noUserLeavesInputUnchanged() {
+        assertThat(IdentityForwardingToolCallback.withIdentity("{\"q\":\"hi\"}", null)).isEqualTo("{\"q\":\"hi\"}");
+        assertThat(IdentityForwardingToolCallback.withIdentity("{\"q\":\"hi\"}", "  ")).isEqualTo("{\"q\":\"hi\"}");
+    }
+
+    @Test
+    @DisplayName("non-object args (array/scalar) are forwarded unchanged, not corrupted")
+    void nonObjectInputUnchanged() {
+        assertThat(IdentityForwardingToolCallback.withIdentity("[1,2,3]", "alice")).isEqualTo("[1,2,3]");
+        assertThat(IdentityForwardingToolCallback.withIdentity("\"plain\"", "alice")).isEqualTo("\"plain\"");
+    }
+
+    @Test
+    @DisplayName("malformed JSON is forwarded unchanged (surfaces downstream, not masked)")
+    void malformedJsonUnchanged() {
+        assertThat(IdentityForwardingToolCallback.withIdentity("{not json", "alice")).isEqualTo("{not json");
+    }
+
+    @Test
+    @DisplayName("opt-in matching: by id or name, empty set never forwards")
+    void optInMatching() {
+        McpIdentityForwardProperties p = new McpIdentityForwardProperties();
+        assertThat(p.forwardsTo(42L, "svc")).isFalse();           // empty set
+        p.setServers(java.util.Set.of("svc"));
+        assertThat(p.forwardsTo(42L, "svc")).isTrue();            // by name
+        assertThat(p.forwardsTo(42L, "other")).isFalse();
+        p.setServers(java.util.Set.of("42"));
+        assertThat(p.forwardsTo(42L, "other")).isTrue();          // by id
+    }
+}

--- a/mateclaw-server/src/test/java/vip/mate/tool/mcp/runtime/IdentityForwardingToolCallbackTest.java
+++ b/mateclaw-server/src/test/java/vip/mate/tool/mcp/runtime/IdentityForwardingToolCallbackTest.java
@@ -2,72 +2,58 @@ package vip.mate.tool.mcp.runtime;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
-import vip.mate.tool.builtin.ToolExecutionContext;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
 /**
- * Unit tests for {@link IdentityForwardingToolCallback#withIdentity} — the
- * in-band identity injection that lets a STDIO MCP server forward the caller to
- * its REST backend. Pure string/JSON behavior, runs everywhere.
+ * Unit tests for {@link IdentityForwardingToolCallback#withClaim} — the in-band
+ * JSON merge that carries identity to a STDIO MCP server. Pure string/JSON
+ * behavior; identity resolution (plaintext vs token) is tested in
+ * {@link McpIdentityForwardServiceTest}.
  */
 class IdentityForwardingToolCallbackTest {
 
     private static final ObjectMapper MAPPER = new ObjectMapper();
-    private static final String KEY = McpIdentityForwardProperties.IDENTITY_ARG;
-
-    @AfterEach
-    void clearContext() {
-        ToolExecutionContext.clear();
-    }
+    private static final String KEY = McpIdentityForwardProperties.USER_ARG;
 
     @Test
-    @DisplayName("injects username into JSON args under the reserved key")
-    void injectsUsername() throws Exception {
-        String out = IdentityForwardingToolCallback.withIdentity("{\"q\":\"hi\"}", "alice");
-        JsonNode n = MAPPER.readTree(out);
+    @DisplayName("merges the claim into JSON args under the given key")
+    void mergesClaim() throws Exception {
+        JsonNode n = MAPPER.readTree(IdentityForwardingToolCallback.withClaim("{\"q\":\"hi\"}", KEY, "alice"));
         assertThat(n.get("q").asText()).isEqualTo("hi");
         assertThat(n.get(KEY).asText()).isEqualTo("alice");
     }
 
     @Test
     @DisplayName("overwrites an LLM-supplied value of the reserved key (no spoofing)")
-    void overwritesLlmSuppliedIdentity() throws Exception {
-        String out = IdentityForwardingToolCallback.withIdentity(
-                "{\"q\":\"hi\",\"" + KEY + "\":\"attacker\"}", "alice");
+    void overwritesLlmSuppliedValue() throws Exception {
+        String out = IdentityForwardingToolCallback.withClaim(
+                "{\"q\":\"hi\",\"" + KEY + "\":\"attacker\"}", KEY, "alice");
         assertThat(MAPPER.readTree(out).get(KEY).asText()).isEqualTo("alice");
     }
 
     @Test
-    @DisplayName("blank/empty input becomes a fresh object carrying the identity")
+    @DisplayName("blank/empty input becomes a fresh object carrying the claim")
     void emptyInputGetsObject() throws Exception {
         for (String in : new String[]{null, "", "   "}) {
-            String out = IdentityForwardingToolCallback.withIdentity(in, "bob");
+            String out = IdentityForwardingToolCallback.withClaim(in, KEY, "bob");
             assertThat(MAPPER.readTree(out).get(KEY).asText()).isEqualTo("bob");
         }
     }
 
     @Test
-    @DisplayName("no authenticated user → input forwarded unchanged (never fabricate identity)")
-    void noUserLeavesInputUnchanged() {
-        assertThat(IdentityForwardingToolCallback.withIdentity("{\"q\":\"hi\"}", null)).isEqualTo("{\"q\":\"hi\"}");
-        assertThat(IdentityForwardingToolCallback.withIdentity("{\"q\":\"hi\"}", "  ")).isEqualTo("{\"q\":\"hi\"}");
-    }
-
-    @Test
     @DisplayName("non-object args (array/scalar) are forwarded unchanged, not corrupted")
     void nonObjectInputUnchanged() {
-        assertThat(IdentityForwardingToolCallback.withIdentity("[1,2,3]", "alice")).isEqualTo("[1,2,3]");
-        assertThat(IdentityForwardingToolCallback.withIdentity("\"plain\"", "alice")).isEqualTo("\"plain\"");
+        assertThat(IdentityForwardingToolCallback.withClaim("[1,2,3]", KEY, "alice")).isEqualTo("[1,2,3]");
+        assertThat(IdentityForwardingToolCallback.withClaim("\"plain\"", KEY, "alice")).isEqualTo("\"plain\"");
     }
 
     @Test
     @DisplayName("malformed JSON is forwarded unchanged (surfaces downstream, not masked)")
     void malformedJsonUnchanged() {
-        assertThat(IdentityForwardingToolCallback.withIdentity("{not json", "alice")).isEqualTo("{not json");
+        assertThat(IdentityForwardingToolCallback.withClaim("{not json", KEY, "alice")).isEqualTo("{not json");
     }
 
     @Test

--- a/mateclaw-server/src/test/java/vip/mate/tool/mcp/runtime/McpClientManagerSnapshotTest.java
+++ b/mateclaw-server/src/test/java/vip/mate/tool/mcp/runtime/McpClientManagerSnapshotTest.java
@@ -37,7 +37,7 @@ class McpClientManagerSnapshotTest {
     @SuppressWarnings("unchecked")
     void staleListToolsServesSnapshotAndRequestsReconnect() throws Exception {
         ApplicationEventPublisher publisher = mock(ApplicationEventPublisher.class);
-        McpClientManager manager = new McpClientManager(publisher);
+        McpClientManager manager = new McpClientManager(publisher, new McpIdentityForwardProperties());
 
         // A client whose connection went stale: every listTools() throws.
         McpSyncClient deadClient = mock(McpSyncClient.class);

--- a/mateclaw-server/src/test/java/vip/mate/tool/mcp/runtime/McpClientManagerSnapshotTest.java
+++ b/mateclaw-server/src/test/java/vip/mate/tool/mcp/runtime/McpClientManagerSnapshotTest.java
@@ -37,7 +37,8 @@ class McpClientManagerSnapshotTest {
     @SuppressWarnings("unchecked")
     void staleListToolsServesSnapshotAndRequestsReconnect() throws Exception {
         ApplicationEventPublisher publisher = mock(ApplicationEventPublisher.class);
-        McpClientManager manager = new McpClientManager(publisher, new McpIdentityForwardProperties());
+        McpClientManager manager = new McpClientManager(publisher,
+                new McpIdentityForwardService(new McpIdentityForwardProperties()));
 
         // A client whose connection went stale: every listTools() throws.
         McpSyncClient deadClient = mock(McpSyncClient.class);

--- a/mateclaw-server/src/test/java/vip/mate/tool/mcp/runtime/McpIdentityForwardServiceTest.java
+++ b/mateclaw-server/src/test/java/vip/mate/tool/mcp/runtime/McpIdentityForwardServiceTest.java
@@ -4,21 +4,29 @@ import io.jsonwebtoken.Claims;
 import io.jsonwebtoken.Jwts;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
+import org.springframework.ai.chat.model.ToolContext;
+import vip.mate.agent.context.ChatOrigin;
 import vip.mate.tool.builtin.ToolExecutionContext;
 
 import java.security.KeyPair;
 import java.security.KeyPairGenerator;
 import java.util.Base64;
 import java.util.Date;
+import java.util.Map;
 import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
 /**
- * Tests {@link McpIdentityForwardService}: plaintext vs signed-token resolution,
- * fail-closed when token mode lacks a key, and that a minted token verifies
- * against the public key with the right claims.
+ * Tests {@link McpIdentityForwardService}: identity typing across channels,
+ * plaintext vs signed-token resolution, and fail-closed behaviour.
+ *
+ * <p>The core of this suite is the {@code trust}/{@code channel_type} typing —
+ * making sure an authenticated MateClaw user, a webchat visitor, an IM sender,
+ * and a cron run are forwarded with distinguishable, non-fabricated identities
+ * (see RFC: on-behalf-of identity typing, issue #459 review).
  */
 class McpIdentityForwardServiceTest {
 
@@ -31,50 +39,149 @@ class McpIdentityForwardServiceTest {
         return new McpIdentityForwardService(p);
     }
 
-    @Test
-    @DisplayName("plaintext mode: injects username under USER_ARG")
-    void plaintext() {
-        ToolExecutionContext.set("c1", "alice");
-        var p = new McpIdentityForwardProperties();
-        Optional<McpIdentityForwardService.Injection> inj = svc(p).resolve(null, "my-api");
-        assertThat(inj).isPresent();
-        assertThat(inj.get().key()).isEqualTo(McpIdentityForwardProperties.USER_ARG);
-        assertThat(inj.get().value()).isEqualTo("alice");
+    /** Build a ToolContext carrying the given origin, mirroring ToolExecutionExecutor. */
+    private static ToolContext ctx(ChatOrigin origin) {
+        return new ToolContext(Map.of(ChatOrigin.CTX_KEY, origin));
     }
 
-    @Test
-    @DisplayName("no authenticated user: nothing injected")
-    void noUser() {
-        var p = new McpIdentityForwardProperties();
-        assertThat(svc(p).resolve(null, "my-api")).isEmpty();
+    private static KeyPair rsaKeyPair() {
+        try {
+            return KeyPairGenerator.getInstance("RSA").genKeyPair();
+        } catch (Exception e) {
+            throw new IllegalStateException(e);
+        }
     }
 
-    @Test
-    @DisplayName("token mode but no key: fail-closed (nothing injected)")
-    void tokenModeNoKey() {
-        ToolExecutionContext.set("c1", "alice");
-        var p = new McpIdentityForwardProperties();
-        p.getToken().setEnabled(true);   // no private-key-pem
-        assertThat(svc(p).resolve(null, "my-api")).isEmpty();
-    }
-
-    @Test
-    @DisplayName("token mode: mints an RS256 JWT that verifies with the public key")
-    void tokenMintAndVerify() throws Exception {
-        KeyPair kp = KeyPairGenerator.getInstance("RSA").genKeyPair();   // 2048 default
+    /** Token-mode config signed with {@code kp}'s private key. */
+    private static McpIdentityForwardProperties tokenProps(KeyPair kp) {
         var p = new McpIdentityForwardProperties();
         p.getToken().setEnabled(true);
         p.getToken().setIssuer("mateclaw");
         p.getToken().setTtlSeconds(60);
         p.getToken().setPrivateKeyPem(Base64.getEncoder().encodeToString(kp.getPrivate().getEncoded()));
+        return p;
+    }
 
-        ToolExecutionContext.set("c1", "alice");
-        Optional<McpIdentityForwardService.Injection> inj = svc(p).resolve(null, "my-api");
+    // ==================== Identity typing across channels ====================
 
+    @Nested
+    @DisplayName("classify: identity typing per channel")
+    class Classify {
+
+        @Test
+        @DisplayName("authenticated web user → sub=userId, trust=authenticated")
+        void authenticatedWebUser() {
+            ChatOrigin origin = ChatOrigin.web("c1", "alice", 1L, null, null, 42L);
+            McpIdentityForwardService.ResolvedIdentity id = svc(new McpIdentityForwardProperties()).classify(ctx(origin));
+            assertThat(id.subject()).isEqualTo("42");
+            assertThat(id.trust()).isEqualTo(McpIdentityForwardService.TRUST_AUTHENTICATED);
+            assertThat(id.channelType()).isEqualTo("web");
+        }
+
+        @Test
+        @DisplayName("webchat visitor (channelType=api) → trust=anonymous, sub=visitorId")
+        void webchatVisitor() {
+            // webchat sets requesterId=visitorId and channelType=api via withSender
+            ChatOrigin origin = ChatOrigin.web("c1", "visitor-xyz", 1L, null)
+                    .withSender(null, "api", null);
+            McpIdentityForwardService.ResolvedIdentity id = svc(new McpIdentityForwardProperties()).classify(ctx(origin));
+            assertThat(id.subject()).isEqualTo("visitor-xyz");
+            assertThat(id.trust()).isEqualTo(McpIdentityForwardService.TRUST_ANONYMOUS);
+            assertThat(id.channelType()).isEqualTo("api");
+        }
+
+        @Test
+        @DisplayName("IM sender (channelType=feishu) → trust=external")
+        void imSender() {
+            ChatOrigin origin = new ChatOrigin(null, "c1", "im_user_1", 1L, null,
+                    9L, null, false, "张三", "feishu", "grp1", null, null);
+            McpIdentityForwardService.ResolvedIdentity id = svc(new McpIdentityForwardProperties()).classify(ctx(origin));
+            assertThat(id.subject()).isEqualTo("im_user_1");
+            assertThat(id.trust()).isEqualTo(McpIdentityForwardService.TRUST_EXTERNAL);
+            assertThat(id.channelType()).isEqualTo("feishu");
+        }
+
+        @Test
+        @DisplayName("cron origin → NONE (never assert identity for a non-user)")
+        void cronOrigin() {
+            ChatOrigin origin = ChatOrigin.cron("c1", 1L, null, 9L, null);
+            assertThat(svc(new McpIdentityForwardProperties()).classify(ctx(origin)))
+                    .isEqualTo(McpIdentityForwardService.ResolvedIdentity.NONE);
+        }
+
+        @Test
+        @DisplayName("system requesterId → NONE")
+        void systemRequester() {
+            // An origin whose requesterId is "system" but cronOrigin=false (defensive)
+            ChatOrigin origin = new ChatOrigin(null, "c1", "system", 1L, null,
+                    null, null, false, null, null, null, null, null);
+            assertThat(svc(new McpIdentityForwardProperties()).classify(ctx(origin)))
+                    .isEqualTo(McpIdentityForwardService.ResolvedIdentity.NONE);
+        }
+
+        @Test
+        @DisplayName("web origin without userId falls back to ThreadLocal username (legacy path)")
+        void webOriginLegacyThreadLocal() {
+            ToolExecutionContext.set("c1", "alice");
+            // 5-arg web(): no requesterUserId → falls back to ThreadLocal
+            ChatOrigin origin = ChatOrigin.web("c1", "alice", 1L, null, null);
+            McpIdentityForwardService.ResolvedIdentity id = svc(new McpIdentityForwardProperties()).classify(ctx(origin));
+            assertThat(id.subject()).isEqualTo("alice");
+            assertThat(id.trust()).isEqualTo(McpIdentityForwardService.TRUST_AUTHENTICATED);
+        }
+    }
+
+    // ==================== Resolution: plaintext & token modes ====================
+
+    @Test
+    @DisplayName("plaintext mode: injects '<trust>:<subject>' under USER_ARG")
+    void plaintextTyped() {
+        ChatOrigin origin = ChatOrigin.web("c1", "alice", 1L, null, null, 42L);
+        var p = new McpIdentityForwardProperties();
+        Optional<McpIdentityForwardService.Injection> inj = svc(p).resolve(ctx(origin), "my-api");
+        assertThat(inj).isPresent();
+        assertThat(inj.get().key()).isEqualTo(McpIdentityForwardProperties.USER_ARG);
+        assertThat(inj.get().value()).isEqualTo("authenticated:42");
+    }
+
+    @Test
+    @DisplayName("plaintext mode: anonymous visitor carries trust=anonymous prefix")
+    void plaintextAnonymous() {
+        ChatOrigin origin = ChatOrigin.web("c1", "visitor-xyz", 1L, null).withSender(null, "api", null);
+        Optional<McpIdentityForwardService.Injection> inj =
+                svc(new McpIdentityForwardProperties()).resolve(ctx(origin), "my-api");
+        assertThat(inj).isPresent();
+        assertThat(inj.get().value()).startsWith("anonymous:visitor-xyz");
+    }
+
+    @Test
+    @DisplayName("no usable identity (cron): nothing injected")
+    void noIdentity() {
+        ChatOrigin origin = ChatOrigin.cron("c1", 1L, null, 9L, null);
+        assertThat(svc(new McpIdentityForwardProperties()).resolve(ctx(origin), "my-api")).isEmpty();
+    }
+
+    @Test
+    @DisplayName("token mode but no key: fail-closed (nothing injected)")
+    void tokenModeNoKey() {
+        ChatOrigin origin = ChatOrigin.web("c1", "alice", 1L, null, null, 42L);
+        var p = new McpIdentityForwardProperties();
+        p.getToken().setEnabled(true);   // no private-key-pem
+        assertThat(svc(p).resolve(ctx(origin), "my-api")).isEmpty();
+    }
+
+    @Test
+    @DisplayName("token mode: mints RS256 JWT that verifies with trust/channel_type claims")
+    void tokenMintAndVerify() throws Exception {
+        KeyPair kp = rsaKeyPair();
+        var p = tokenProps(kp);
+        ChatOrigin origin = ChatOrigin.web("c1", "alice", 1L, null, null, 42L);
+
+        Optional<McpIdentityForwardService.Injection> inj = svc(p).resolve(ctx(origin), "my-api");
         assertThat(inj).isPresent();
         assertThat(inj.get().key()).isEqualTo(McpIdentityForwardProperties.TOKEN_ARG);
 
-        // The REST backend would do exactly this: verify with the public key.
+        // The REST backend verifies with the public key and reads the typed claims.
         Claims claims = Jwts.parser()
                 .verifyWith(kp.getPublic())
                 .requireIssuer("mateclaw")
@@ -83,9 +190,31 @@ class McpIdentityForwardServiceTest {
                 .parseSignedClaims(inj.get().value())
                 .getPayload();
 
-        assertThat(claims.getSubject()).isEqualTo("alice");
+        assertThat(claims.getSubject()).isEqualTo("42");
+        assertThat(claims.get("trust", String.class)).isEqualTo(McpIdentityForwardService.TRUST_AUTHENTICATED);
+        assertThat(claims.get("channel_type", String.class)).isEqualTo("web");
         assertThat(claims.getExpiration()).isAfter(new Date());
-        assertThat(claims.getId()).isNotBlank();   // jti present
+        assertThat(claims.getId()).isNotBlank();
+    }
+
+    @Test
+    @DisplayName("token mode: anonymous visitor token carries trust=anonymous")
+    void tokenAnonymousVisitor() throws Exception {
+        KeyPair kp = rsaKeyPair();
+        var p = tokenProps(kp);
+        ChatOrigin origin = ChatOrigin.web("c1", "visitor-xyz", 1L, null).withSender(null, "api", null);
+
+        Optional<McpIdentityForwardService.Injection> inj = svc(p).resolve(ctx(origin), "my-api");
+        assertThat(inj).isPresent();
+
+        Claims claims = Jwts.parser()
+                .verifyWith(kp.getPublic())
+                .build()
+                .parseSignedClaims(inj.get().value())
+                .getPayload();
+        assertThat(claims.getSubject()).isEqualTo("visitor-xyz");
+        assertThat(claims.get("trust", String.class)).isEqualTo(McpIdentityForwardService.TRUST_ANONYMOUS);
+        assertThat(claims.get("channel_type", String.class)).isEqualTo("api");
     }
 
     @Test

--- a/mateclaw-server/src/test/java/vip/mate/tool/mcp/runtime/McpIdentityForwardServiceTest.java
+++ b/mateclaw-server/src/test/java/vip/mate/tool/mcp/runtime/McpIdentityForwardServiceTest.java
@@ -1,0 +1,99 @@
+package vip.mate.tool.mcp.runtime;
+
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.Jwts;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import vip.mate.tool.builtin.ToolExecutionContext;
+
+import java.security.KeyPair;
+import java.security.KeyPairGenerator;
+import java.util.Base64;
+import java.util.Date;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Tests {@link McpIdentityForwardService}: plaintext vs signed-token resolution,
+ * fail-closed when token mode lacks a key, and that a minted token verifies
+ * against the public key with the right claims.
+ */
+class McpIdentityForwardServiceTest {
+
+    @AfterEach
+    void clear() {
+        ToolExecutionContext.clear();
+    }
+
+    private McpIdentityForwardService svc(McpIdentityForwardProperties p) {
+        return new McpIdentityForwardService(p);
+    }
+
+    @Test
+    @DisplayName("plaintext mode: injects username under USER_ARG")
+    void plaintext() {
+        ToolExecutionContext.set("c1", "alice");
+        var p = new McpIdentityForwardProperties();
+        Optional<McpIdentityForwardService.Injection> inj = svc(p).resolve(null, "my-api");
+        assertThat(inj).isPresent();
+        assertThat(inj.get().key()).isEqualTo(McpIdentityForwardProperties.USER_ARG);
+        assertThat(inj.get().value()).isEqualTo("alice");
+    }
+
+    @Test
+    @DisplayName("no authenticated user: nothing injected")
+    void noUser() {
+        var p = new McpIdentityForwardProperties();
+        assertThat(svc(p).resolve(null, "my-api")).isEmpty();
+    }
+
+    @Test
+    @DisplayName("token mode but no key: fail-closed (nothing injected)")
+    void tokenModeNoKey() {
+        ToolExecutionContext.set("c1", "alice");
+        var p = new McpIdentityForwardProperties();
+        p.getToken().setEnabled(true);   // no private-key-pem
+        assertThat(svc(p).resolve(null, "my-api")).isEmpty();
+    }
+
+    @Test
+    @DisplayName("token mode: mints an RS256 JWT that verifies with the public key")
+    void tokenMintAndVerify() throws Exception {
+        KeyPair kp = KeyPairGenerator.getInstance("RSA").genKeyPair();   // 2048 default
+        var p = new McpIdentityForwardProperties();
+        p.getToken().setEnabled(true);
+        p.getToken().setIssuer("mateclaw");
+        p.getToken().setTtlSeconds(60);
+        p.getToken().setPrivateKeyPem(Base64.getEncoder().encodeToString(kp.getPrivate().getEncoded()));
+
+        ToolExecutionContext.set("c1", "alice");
+        Optional<McpIdentityForwardService.Injection> inj = svc(p).resolve(null, "my-api");
+
+        assertThat(inj).isPresent();
+        assertThat(inj.get().key()).isEqualTo(McpIdentityForwardProperties.TOKEN_ARG);
+
+        // The REST backend would do exactly this: verify with the public key.
+        Claims claims = Jwts.parser()
+                .verifyWith(kp.getPublic())
+                .requireIssuer("mateclaw")
+                .requireAudience("my-api")
+                .build()
+                .parseSignedClaims(inj.get().value())
+                .getPayload();
+
+        assertThat(claims.getSubject()).isEqualTo("alice");
+        assertThat(claims.getExpiration()).isAfter(new Date());
+        assertThat(claims.getId()).isNotBlank();   // jti present
+    }
+
+    @Test
+    @DisplayName("audienceFor: explicit mapping wins, else server name")
+    void audienceResolution() {
+        var p = new McpIdentityForwardProperties();
+        assertThat(p.audienceFor(42L, "svc")).isEqualTo("svc");          // default = name
+        p.getToken().setAudiences(java.util.Map.of("svc", "https://api.internal"));
+        assertThat(p.audienceFor(42L, "svc")).isEqualTo("https://api.internal");
+    }
+}


### PR DESCRIPTION
承接 #460（on-behalf-of 身份透传），针对 [issuecomment-4846189299](https://github.com/mateaix/mateclaw/issues/459#issuecomment-4846189299) 提出的 **webchat/IM 渠道身份语义错配**，从第一性原理补上身份的「主体类型」维度。

> ⚠️ 本 PR 基于 #460（`feat/mcp-identity-forward`），**应先合 #460**。本 PR 相对 #460 的增量改动见 review；若 GitHub 显示的 diff 含 #460 内容，是因为 base 指向 dev。

## 问题本质（第一性原理）

#460 透传的身份是一维裸字符串 `ChatOrigin.requesterId`：WebAPI 登录时是用户名，webchat 时是 visitorId，IM 时是外部 senderId——后端无从区分。签名 token 模式（#460 的 d204b702）让问题更严重：对 visitorId 盖上 RS256 签名，后端验签通过后会误判"这是 MateClaw 认证过的用户"。根因是 **on-behalf-of 信任模型缺少「主体类型」维度**——身份（identity）和标识（identifier）被混为一谈。

## 方案：身份类型化（identity typing）

`McpIdentityForwardService` 新增 `classify()`，按渠道把身份分四类：

| 渠道 | sub | trust | 后端语义 |
|---|---|---|---|
| WebAPI 登录 | **不可变 userId** | `authenticated` | 可完整 on-behalf-of 授权 |
| WebChat 访客 | visitorId | `anonymous` | 显式降级，后端自行决定 |
| IM 发送者 | senderId | `external` | 外部平台 id，同 anonymous |
| cron/system | — | — | fail-closed，不注入（绝不替非用户断言身份） |

`mint()` 增加 `trust` + `channel_type` 两个 JWT claim；明文模式 value 改为 `trust:subject` 前缀格式。后端凭 `trust` claim 区分身份类型，不再裸信一个字符串。

## userId 如何到达 resolve()（不耦合用户存储）

`McpIdentityForwardService` 原本刻意不耦合用户存储。认证用户的不可变 userId 通过既有数据流到达，无需在 resolve() 反查：

1. `JwtAuthFilter`（JWT/PAT 两路径）把 `user.getId()` 写入 `auth.setDetails()`——userId 在认证层一次到位
2. `ChatController.memoryOrigin` 从 `auth` 取 userId，填进新增的 `ChatOrigin.requesterUserId` 字段
3. `resolve()` 直接读 `origin.requesterUserId()`，无需依赖 AuthService

`requesterUserId` 在非 web 渠道为 null（webchat/IM/cron 本就没有 userId），这天然与分类吻合：有 userId → authenticated；无 → anonymous/external。

## 改动清单（7 生产文件 + 9 测试文件）

- `ChatOrigin.java`：新增 `requesterUserId` 字段（only-add，符合 record 演进纪律）+ 工厂/wither 透传
- `JwtAuthFilter.java`：两路径 `auth.setDetails(user.getId())`
- `ChatController.java`：`memoryOrigin` 接收并填充 userId
- `McpIdentityForwardService.java`：`classify()` 分类 + `mint()` 加 claims + 明文前缀化
- `ChannelChatOriginFactory`/`SkillConsolidationService`/`SkillReflectionService`：补 ChatOrigin 第 13 参数
- 测试：12 个既有 ChatOrigin 构造补参；`McpIdentityForwardServiceTest` 重写覆盖四类身份分类（token 验签断言 trust/channel_type claims）

## 验证

82 个测试全绿，0 失败 0 错误：
- 身份分类四类（authenticated→userId、anonymous→visitorId、external→IM、cron→none）
- token 模式验签 + trust/channel_type claim 正确性
- 明文模式前缀格式
- 完整 ChatOrigin / MCP runtime 回归（含 DelegateAsync、CronJobRunner、ApprovalReplay 等）

## 解决

- 修复 issuecomment-4846189299 的 webchat 语义错配
- 解决 #460 待办「sub 解析成不可变 user id」
- 消除 confused-deputy 风险（访客获得不当认证信任级）

Depends on #460.