### PR TITLE
feat(coding): 新增4个编码内置工具，增强编辑/命令稳健性与Agent超时兜底

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -47,6 +47,7 @@ target/
 /logs/
 mateclaw-server/logs/
 *.log
+.mateclaw/
 
 ### temp ignore ###
 *.cache

--- a/mateclaw-server/pom.xml
+++ b/mateclaw-server/pom.xml
@@ -434,6 +434,12 @@
                     </execution>
                 </executions>
                 <configuration>
+                    <jvmArguments>
+                        -Dfile.encoding=UTF-8
+                        -Dsun.jnu.encoding=UTF-8
+                        -Dstdout.encoding=UTF-8
+                        -Dstderr.encoding=UTF-8
+                    </jvmArguments>
                     <excludes>
                         <exclude>
                             <groupId>org.projectlombok</groupId>
@@ -466,7 +472,7 @@
                          depending on the JVM's startup hardening, making tests pass on one
                          machine and fail on another. byte-buddy-agent rides in transitively
                          via mockito-core. -->
-                    <argLine>-javaagent:${net.bytebuddy:byte-buddy-agent:jar}</argLine>
+                    <argLine>-javaagent:${net.bytebuddy:byte-buddy-agent:jar} -Dfile.encoding=UTF-8 -Dsun.jnu.encoding=UTF-8</argLine>
                 </configuration>
             </plugin>
         </plugins>

--- a/mateclaw-server/src/main/java/vip/mate/acp/service/AcpDelegationService.java
+++ b/mateclaw-server/src/main/java/vip/mate/acp/service/AcpDelegationService.java
@@ -8,12 +8,16 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import vip.mate.acp.client.AcpStdioClient;
 import vip.mate.acp.model.AcpEndpointEntity;
+import vip.mate.agent.AgentService.StreamDelta;
 import vip.mate.exception.MateClawException;
 
 import java.io.IOException;
 import java.time.Duration;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.atomic.AtomicReference;
 
 /**
  * RFC-090 Phase 7b — fire-and-forget delegation to an external ACP
@@ -67,6 +71,158 @@ public class AcpDelegationService {
      * JSON error.
      */
     public String prompt(String endpointName, String userPrompt, String cwdHint) {
+        StringBuilder accumulator = new StringBuilder();
+        runPrompt(endpointName, userPrompt, cwdHint, update -> {
+            if ("agent_message_chunk".equals(update.type())
+                    || "agent-message-chunk".equals(update.type())) {
+                if (update.text() != null && !update.text().isEmpty()) {
+                    accumulator.append(update.text());
+                }
+            }
+        });
+        return accumulator.toString().trim();
+    }
+
+    /**
+     * RFC-090 Phase 7c — streaming relay. Runs the same
+     * {@code initialize → session/new → session/prompt} sequence as
+     * {@link #prompt} but emits every {@code session/update} event as
+     * a {@link StreamDelta} on the returned {@link reactor.core.publisher.Flux}.
+     *
+     * <p>Event mapping:
+     * <ul>
+     *   <li>{@code agent_message_chunk} → {@code StreamDelta(content, null)}</li>
+     *   <li>{@code tool_call_*} → {@code StreamDelta.event("acp_tool_call", data)}</li>
+     *   <li>{@code plan} → {@code StreamDelta.event("acp_plan", data)}</li>
+     *   <li>{@code current_mode} → {@code StreamDelta.event("acp_mode", data)}</li>
+     *   <li>terminal completion / error → {@code StreamDelta.event("acp_done"/"acp_error", data)}</li>
+     * </ul>
+     *
+     * <p>The synchronous JSON-RPC exchange runs on a virtual-thread
+     * async stage; the notification handler pushes events into a
+     * {@code Sinks.Many} which backs the returned Flux. This keeps the
+     * blocking ACP stdio handshake off the subscriber's thread while
+     * preserving backpressure semantics for the SSE relay.
+     */
+    public reactor.core.publisher.Flux<StreamDelta> promptStream(
+            String endpointName, String userPrompt, String cwdHint) {
+        // Bounded buffer: 256 items is generous for ACP agent messages
+        // (each chunk is a few hundred chars). autoCancel=false ensures the
+        // sink stays alive even if the subscriber briefly unsubscribes
+        // during Reactor internals.
+        reactor.core.publisher.Sinks.Many<StreamDelta> sink =
+                reactor.core.publisher.Sinks.many().multicast().onBackpressureBuffer(256, false);
+
+        // Hold the ACP client so the cancel handler can close it, killing
+        // the spawned agent process when the subscriber (e.g. the ReAct
+        // graph) cancels the Flux. Without this, a cancelled delegation
+        // keeps the external agent process alive for up to PROMPT_TIMEOUT
+        // (5 minutes) — a resource leak.
+        AtomicReference<AcpStdioClient> clientRef = new AtomicReference<>();
+        // Signal flag so the notification handler knows the sink is dead
+        // and should stop pushing (and ideally close the client).
+        java.util.concurrent.atomic.AtomicBoolean cancelled = new java.util.concurrent.atomic.AtomicBoolean(false);
+
+        CompletableFuture.runAsync(() -> {
+            try {
+                runPrompt(endpointName, userPrompt, cwdHint, update -> {
+                    if (cancelled.get()) return;
+                    StreamDelta delta = toStreamDelta(update);
+                    if (delta != null) {
+                        var result = sink.tryEmitNext(delta);
+                        if (result.isFailure()) {
+                            // Sink cancelled or terminated — stop the ACP process
+                            cancelled.set(true);
+                            AcpStdioClient c = clientRef.get();
+                            if (c != null) {
+                                try { c.close(); } catch (Exception ignored) {}
+                            }
+                        }
+                    }
+                }, clientRef);
+                sink.tryEmitComplete();
+            } catch (Exception e) {
+                Map<String, Object> errData = new LinkedHashMap<>();
+                errData.put("endpoint", endpointName);
+                errData.put("error", e.getMessage());
+                sink.tryEmitNext(StreamDelta.event("acp_error", errData));
+                sink.tryEmitComplete();
+            }
+        });
+
+        return sink.asFlux()
+                .doOnCancel(() -> {
+                    cancelled.set(true);
+                    AcpStdioClient c = clientRef.get();
+                    if (c != null) {
+                        try { c.close(); } catch (Exception ignored) {}
+                    }
+                });
+    }
+
+    /**
+     * Map an {@link AcpUpdateEvent} to a {@link StreamDelta}. Returns
+     * null for event types we don't relay (keeps the Flux clean).
+     */
+    private StreamDelta toStreamDelta(AcpUpdateEvent update) {
+        return switch (update.type()) {
+            case "agent_message_chunk", "agent-message-chunk" ->
+                    new StreamDelta(update.text(), null);
+            case "tool_call_start", "tool_call_update", "tool_call_end",
+                 "tool-call-start", "tool-call-update", "tool-call-end" -> {
+                Map<String, Object> data = new LinkedHashMap<>();
+                data.put("phase", update.type());
+                if (update.toolName() != null) data.put("tool", update.toolName());
+                if (update.text() != null) data.put("text", update.text());
+                yield StreamDelta.event("acp_tool_call", data);
+            }
+            case "plan" -> {
+                Map<String, Object> data = new LinkedHashMap<>();
+                if (update.text() != null) data.put("text", update.text());
+                if (update.toolName() != null) data.put("plan", update.toolName());
+                yield StreamDelta.event("acp_plan", data);
+            }
+            case "current_mode", "current-mode" -> {
+                Map<String, Object> data = new LinkedHashMap<>();
+                if (update.text() != null) data.put("mode", update.text());
+                yield StreamDelta.event("acp_mode", data);
+            }
+            case "error" -> {
+                Map<String, Object> data = new LinkedHashMap<>();
+                if (update.text() != null) data.put("error", update.text());
+                yield StreamDelta.event("acp_error", data);
+            }
+            default -> {
+                if (update.text() != null && !update.text().isEmpty()) {
+                    yield new StreamDelta(update.text(), null);
+                }
+                yield null;
+            }
+        };
+    }
+
+    // ==================== shared prompt runner ====================
+
+    /**
+     * Internal: run the full ACP handshake, feeding every
+     * {@code session/update} event to {@code listener}. Used by both
+     * {@link #prompt} (text accumulator) and {@link #promptStream}
+     * (StreamDelta emitter).
+     */
+    private void runPrompt(String endpointName, String userPrompt, String cwdHint,
+                            java.util.function.Consumer<AcpUpdateEvent> listener) {
+        runPrompt(endpointName, userPrompt, cwdHint, listener, null);
+    }
+
+    /**
+     * Extended overload that optionally publishes the spawned
+     * {@link AcpStdioClient} to {@code clientRef} so the caller can
+     * close it on cancellation (e.g. when the subscriber cancels the
+     * Flux returned by {@link #promptStream}).
+     */
+    private void runPrompt(String endpointName, String userPrompt, String cwdHint,
+                            java.util.function.Consumer<AcpUpdateEvent> listener,
+                            AtomicReference<AcpStdioClient> clientRef) {
         if (endpointName == null || endpointName.isBlank()) {
             throw new MateClawException("err.acp.endpoint_required",
                     "ACP endpoint name is required");
@@ -89,12 +245,8 @@ public class AcpDelegationService {
         List<String> args = endpointService.parseArgs(endpoint);
         Map<String, String> env = endpointService.parseEnv(endpoint);
         boolean trusted = !Boolean.FALSE.equals(endpoint.getTrusted());
-        // Always resolve cwd to a real directory: Zed's ACP Zod schema
-        // marks cwd as a required string and rejects {@code undefined}
-        // with -32602. See {@link AcpRuntimeSupport#resolveCwd}.
         String resolvedCwd = runtimeSupport.resolveCwd(endpoint, cwdHint);
 
-        StringBuilder accumulator = new StringBuilder();
         AcpStdioClient client;
         try {
             client = AcpStdioClient.spawn(objectMapper, endpoint.getCommand(),
@@ -104,8 +256,15 @@ public class AcpDelegationService {
                     "Failed to spawn ACP agent '" + endpointName + "': " + e.getMessage());
         }
 
+        // Publish the client reference so the caller's cancel handler
+        // can close it (and kill the spawned process) if the subscriber
+        // cancels the Flux.
+        if (clientRef != null) {
+            clientRef.set(client);
+        }
+
         try (AcpStdioClient autoClose = client) {
-            wireHandlers(autoClose, accumulator, trusted, endpointName);
+            wireHandlers(autoClose, listener, trusted, endpointName);
 
             JsonNode initResp = autoClose.initialize(INITIALIZE_TIMEOUT_MS);
             if (initResp == null || initResp.path("protocolVersion").asInt(-1)
@@ -128,11 +287,6 @@ public class AcpDelegationService {
         } catch (IOException | InterruptedException e) {
             if (e instanceof InterruptedException) Thread.currentThread().interrupt();
             log.warn("ACP delegation failed for endpoint '{}': {}", endpointName, e.getMessage());
-            // Upstream CLIs (claude-code / codex / qwen-code) wrap their
-            // own auth failures in opaque JSON-RPC noise. Recognise the
-            // 401/403/forbidden/unauthorized fingerprints and rewrite
-            // the message into something the user can act on, with the
-            // exact env var name they need to set.
             String authHint = runtimeSupport.translateAuthError(endpoint, e.getMessage());
             if (authHint != null) {
                 throw new MateClawException("err.acp.auth_failed", authHint);
@@ -140,15 +294,14 @@ public class AcpDelegationService {
             throw new MateClawException("err.acp.delegation_failed",
                     "ACP delegation to '" + endpointName + "' failed: " + e.getMessage());
         }
-
-        return accumulator.toString().trim();
     }
 
-    private void wireHandlers(AcpStdioClient client, StringBuilder buf,
-                               boolean trusted, String endpointName) {
-        // Notifications carry session/update messages; agent_message_chunk
-        // is what we accumulate. Other update kinds (tool_call_*, plan,
-        // current_mode) are observed but not relayed in v1.
+    private void wireHandlers(AcpStdioClient client,
+                                java.util.function.Consumer<AcpUpdateEvent> listener,
+                                boolean trusted, String endpointName) {
+        // Notifications carry session/update messages; relay every known
+        // update kind to the listener so the streaming surface can show
+        // tool calls, plans, mode switches — not just the final text.
         client.setNotificationHandler(msg -> {
             String method = msg.path("method").asText("");
             if (!"session/update".equals(method)) return;
@@ -156,10 +309,10 @@ public class AcpDelegationService {
             if (update.isMissingNode() || update.isNull()) return;
             String type = update.path("sessionUpdate").asText(
                     update.path("type").asText(""));
-            if ("agent_message_chunk".equals(type) || "agent-message-chunk".equals(type)) {
-                String text = extractText(update.path("content"));
-                if (!text.isEmpty()) buf.append(text);
-            }
+            String text = extractText(update.path("content"));
+            String toolName = update.path("toolName").asText(
+                    update.path("tool").asText(null));
+            listener.accept(new AcpUpdateEvent(type, text, toolName));
         });
 
         // Permission requests: trusted endpoints auto-allow the FIRST
@@ -238,4 +391,16 @@ public class AcpDelegationService {
         result.set("outcome", outcome);
         return result;
     }
+
+    /**
+     * RFC-090 Phase 7c — a parsed {@code session/update} event from an
+     * ACP agent. The {@code type} field carries the
+     * {@code sessionUpdate} / {@code type} string verbatim so callers
+     * can branch on the upstream protocol's event taxonomy.
+     *
+     * @param type    sessionUpdate type (agent_message_chunk, tool_call_*, plan, current_mode, …)
+     * @param text    extracted text payload (agent message text, tool description, plan text, …)
+     * @param toolName tool name when the event carries one (tool_call_* events)
+     */
+    public record AcpUpdateEvent(String type, String text, String toolName) {}
 }

--- a/mateclaw-server/src/main/java/vip/mate/acp/service/AcpRuntimeSupport.java
+++ b/mateclaw-server/src/main/java/vip/mate/acp/service/AcpRuntimeSupport.java
@@ -178,7 +178,12 @@ public class AcpRuntimeSupport {
         if (name.contains("gemini") || command.contains("gemini") || command.contains("google-genai")) {
             return "GOOGLE_API_KEY";
         }
-        // opencode multi-model — no single canonical env var.
+        // opencode multi-model — it reads OPENAI_API_KEY / ANTHROPIC_API_KEY /
+        // GOOGLE_API_KEY etc. depending on the configured provider. Surface
+        // the most common one; the user can set any of them in env_json.
+        if (name.contains("opencode") || command.contains("opencode")) {
+            return "OPENAI_API_KEY";
+        }
         return null;
     }
 

--- a/mateclaw-server/src/main/java/vip/mate/agent/AgentGraphBuilder.java
+++ b/mateclaw-server/src/main/java/vip/mate/agent/AgentGraphBuilder.java
@@ -436,6 +436,7 @@ public class AgentGraphBuilder {
         agent.agentName = entity.getName();
         agent.systemPrompt = enhancedPrompt;
         agent.maxIterations = maxIter;
+        agent.streamIdleTimeoutSeconds = graphObservationProperties.getStreamIdleTimeoutSeconds();
         agent.modelName = runtimeModel.getModelName();
         agent.modelCapabilities = modelCapabilityService.resolve(
                 runtimeModel.getModelName(), runtimeModel.getModalities());

--- a/mateclaw-server/src/main/java/vip/mate/agent/BaseAgent.java
+++ b/mateclaw-server/src/main/java/vip/mate/agent/BaseAgent.java
@@ -71,6 +71,14 @@ public abstract class BaseAgent {
     public static final int MAX_ITERATIONS_HARD_CEILING = 150;
     protected int maxIterations = 150;
 
+    /**
+     * Idle timeout (seconds) for the structured stream. If no NodeOutput is
+     * emitted within this duration, the stream terminates with a timeout
+     * error. Set to 0 to disable. Default 900 (15 minutes). Configurable
+     * via {@code mate.agent.graph.observation.stream-idle-timeout-seconds}.
+     */
+    protected int streamIdleTimeoutSeconds = 900;
+
     /** 工作区活动目录（限制文件工具访问范围，为空不限制） */
     protected String workspaceBasePath;
 

--- a/mateclaw-server/src/main/java/vip/mate/agent/graph/StateGraphReActAgent.java
+++ b/mateclaw-server/src/main/java/vip/mate/agent/graph/StateGraphReActAgent.java
@@ -20,6 +20,7 @@ import vip.mate.agent.context.ConversationWindowManager;
 import vip.mate.agent.graph.state.MateClawStateKeys;
 import vip.mate.workspace.conversation.ConversationService;
 
+import java.time.Duration;
 import java.util.*;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
@@ -50,6 +51,14 @@ import static vip.mate.agent.graph.state.MateClawStateKeys.*;
  */
 @Slf4j
 public class StateGraphReActAgent extends BaseAgent implements StructuredStreamCapable {
+
+    /**
+     * Default idle timeout for the structured stream. Overridden at runtime
+     * by {@link BaseAgent#streamIdleTimeoutSeconds} (configurable via
+     * {@code mate.agent.graph.observation.stream-idle-timeout-seconds}).
+     * If the configured value is {@code <= 0}, the timeout is disabled.
+     */
+    private static final Duration DEFAULT_STREAM_IDLE_TIMEOUT = Duration.ofMinutes(15);
 
     private final CompiledGraph compiledGraph;
     private final org.springframework.ai.chat.model.ChatModel chatModel;
@@ -319,8 +328,18 @@ public class StateGraphReActAgent extends BaseAgent implements StructuredStreamC
                     .doFinally(sig -> {
                         DelegatedUsageAccumulator acc = DelegatedUsageAccumulator.getInstance();
                         if (acc != null) acc.clear(conversationId);
-                    });
-        } catch (Exception e) {
+                    })
+                    // Timeout fallback: emit a user-visible message so the user sees
+                    // feedback instead of a silent stream termination on idle timeout.
+                    .onErrorResume(e -> {
+                        if (e instanceof java.util.concurrent.TimeoutException) {
+                            String msg = "⚠️ Agent execution timed out after " + streamIdleTimeoutSeconds
+                                    + "s of inactivity (no progress). The agent may be stuck. "
+                                    + "Please retry or rephrase the task.";
+                            return Flux.just(new AgentService.StreamDelta(msg, null));
+                        }
+                        return Flux.error(e);
+                    });        } catch (Exception e) {
             setState(AgentState.ERROR);
             return Flux.error(e);
         }
@@ -369,7 +388,8 @@ public class StateGraphReActAgent extends BaseAgent implements StructuredStreamC
             AtomicInteger lastSoftCap = new AtomicInteger(0);
             AtomicBoolean sawLegitimateExit = new AtomicBoolean(false);
 
-            return BaseAgent.routingStartupDelta(inputs).concatWith(compiledGraph.stream(inputs, config)
+            Flux<AgentService.StreamDelta> graphFlux =
+                    BaseAgent.routingStartupDelta(inputs).concatWith(compiledGraph.stream(inputs, config)
                     .flatMapIterable(output -> {
                         List<AgentService.StreamDelta> deltas = new ArrayList<>();
                         // 1. 提取所有累积的事件，只发送新增部分
@@ -466,7 +486,36 @@ public class StateGraphReActAgent extends BaseAgent implements StructuredStreamC
                             ));
                         }
                         return null;
-                    }).flatMapMany(d -> d != null ? Flux.just(d) : Flux.empty())))
+                    }).flatMapMany(d -> d != null ? Flux.just(d) : Flux.empty()))
+                    // Silent-termination fallback: if the graph completed without a
+                    // legitimate exit signal (no FINAL_ANSWER / LIMIT_EXCEEDED /
+                    // FINISH_REASON), emit a user-visible error so the user sees
+                    // feedback instead of a silent empty completion.
+                    .concatWith(Mono.fromSupplier(() -> {
+                        if (!sawLegitimateExit.get()) {
+                            String msg = "⚠️ Agent execution ended unexpectedly at iteration "
+                                    + lastIteration.get() + "/" + lastSoftCap.get()
+                                    + " (no final answer produced). This may indicate a framework-level "
+                                    + "termination. Please retry or rephrase the task.";
+                            log.warn("[{}] Emitting silent-termination fallback message, conv={}",
+                                    agentName, conversationId);
+                            return new AgentService.StreamDelta(msg, null);
+                        }
+                        return null;
+                    }).flatMapMany(d -> d != null ? Flux.just(d) : Flux.empty())));
+
+            // Global idle timeout: if no item is emitted for the configured
+            // duration, terminate the stream. Catches "stuck" scenarios where
+            // the agent hangs without any progress (LLM connection stalls,
+            // tool execution hangs beyond its own timeout, or the framework
+            // silently stops emitting). Default 15 min (3x per-tool timeout).
+            // Set streamIdleTimeoutSeconds <= 0 in application.yml to disable.
+            Duration idleTimeout = streamIdleTimeoutSeconds > 0
+                    ? Duration.ofSeconds(streamIdleTimeoutSeconds)
+                    : DEFAULT_STREAM_IDLE_TIMEOUT;
+            graphFlux = graphFlux.timeout(idleTimeout);
+
+            return graphFlux
                     .doOnComplete(() -> {
                         setState(AgentState.IDLE);
                         if (!sawLegitimateExit.get()) {
@@ -478,7 +527,13 @@ public class StateGraphReActAgent extends BaseAgent implements StructuredStreamC
                         }
                     })
                     .doOnError(e -> {
-                        log.error("[{}] StateGraph structured stream error: {}", agentName, e.getMessage());
+                        if (e instanceof java.util.concurrent.TimeoutException) {
+                            log.error("[{}] StateGraph structured stream IDLE TIMEOUT ({}s) — " +
+                                    "agent stuck without progress, conversationId={}",
+                                    agentName, streamIdleTimeoutSeconds, conversationId);
+                        } else {
+                            log.error("[{}] StateGraph structured stream error: {}", agentName, e.getMessage());
+                        }
                         setState(AgentState.ERROR);
                     })
                     // Leak guard: discard delegated usage if the turn ends without
@@ -486,6 +541,17 @@ public class StateGraphReActAgent extends BaseAgent implements StructuredStreamC
                     .doFinally(sig -> {
                         DelegatedUsageAccumulator acc = DelegatedUsageAccumulator.getInstance();
                         if (acc != null) acc.clear(conversationId);
+                    })
+                    // Timeout fallback: emit a user-visible message so the user sees
+                    // feedback instead of a silent stream termination on idle timeout.
+                    .onErrorResume(e -> {
+                        if (e instanceof java.util.concurrent.TimeoutException) {
+                            String msg = "⚠️ Agent execution timed out after " + streamIdleTimeoutSeconds
+                                    + "s of inactivity (no progress). The agent may be stuck. "
+                                    + "Please retry or rephrase the task.";
+                            return Flux.just(new AgentService.StreamDelta(msg, null));
+                        }
+                        return Flux.error(e);
                     });
         } catch (Exception e) {
             setState(AgentState.ERROR);

--- a/mateclaw-server/src/main/java/vip/mate/agent/graph/edge/ObservationDispatcher.java
+++ b/mateclaw-server/src/main/java/vip/mate/agent/graph/edge/ObservationDispatcher.java
@@ -3,6 +3,7 @@ package vip.mate.agent.graph.edge;
 import com.alibaba.cloud.ai.graph.OverAllState;
 import com.alibaba.cloud.ai.graph.action.EdgeAction;
 import lombok.extern.slf4j.Slf4j;
+import vip.mate.agent.BaseAgent;
 import vip.mate.agent.graph.state.MateClawStateAccessor;
 
 import static vip.mate.agent.graph.state.MateClawStateKeys.*;
@@ -49,10 +50,20 @@ public class ObservationDispatcher implements EdgeAction {
             return FINAL_ANSWER_NODE;
         }
 
-        // 1. 迭代超限检查（maxIterations=0 表示不限制）
-        if (maxIterations > 0 && currentIteration >= maxIterations) {
-            log.warn("[ObservationDispatcher] Max iterations ({}) reached at iteration {}, " +
-                    "routing to limitExceededNode", maxIterations, currentIteration);
+        // 1. 迭代超限检查
+        //    maxIterations=0 表示用户配置不限制，但仍以 MAX_ITERATIONS_HARD_CEILING
+        //    作为硬性兜底，防止 agent 无限循环卡死。
+        int effectiveMaxIterations = maxIterations > 0
+                ? maxIterations
+                : BaseAgent.MAX_ITERATIONS_HARD_CEILING;
+        if (currentIteration >= effectiveMaxIterations) {
+            if (maxIterations <= 0) {
+                log.warn("[ObservationDispatcher] Unlimited-mode agent hit hard ceiling " +
+                        "({}) at iteration {}, routing to limitExceededNode", effectiveMaxIterations, currentIteration);
+            } else {
+                log.warn("[ObservationDispatcher] Max iterations ({}) reached at iteration {}, " +
+                        "routing to limitExceededNode", effectiveMaxIterations, currentIteration);
+            }
             return LIMIT_EXCEEDED_NODE;
         }
 

--- a/mateclaw-server/src/main/java/vip/mate/agent/graph/edge/ReasoningDispatcher.java
+++ b/mateclaw-server/src/main/java/vip/mate/agent/graph/edge/ReasoningDispatcher.java
@@ -3,6 +3,7 @@ package vip.mate.agent.graph.edge;
 import com.alibaba.cloud.ai.graph.OverAllState;
 import com.alibaba.cloud.ai.graph.action.EdgeAction;
 import lombok.extern.slf4j.Slf4j;
+import vip.mate.agent.BaseAgent;
 import vip.mate.agent.graph.state.MateClawStateAccessor;
 
 import static vip.mate.agent.graph.state.MateClawStateKeys.*;
@@ -52,10 +53,13 @@ public class ReasoningDispatcher implements EdgeAction {
             return FINAL_ANSWER_NODE;
         }
 
-        // 3. LLM 调用次数超限 — 仅拦截继续循环（工具调用/总结）的路径（maxIterations=0 不限制）
+        // 3. LLM 调用次数超限 — 仅拦截继续循环（工具调用/总结）的路径
+        //    当 maxIterations=0（无限制模式）时，仍以 MAX_ITERATIONS_HARD_CEILING
+        //    作为兜底，防止 agent 无限循环。
         int llmCallCount = accessor.llmCallCount();
         int maxIter = accessor.maxIterations();
-        int llmCallLimit = maxIter > 0 ? maxIter * LLM_CALL_MULTIPLIER : Integer.MAX_VALUE;
+        int effectiveMaxIter = maxIter > 0 ? maxIter : BaseAgent.MAX_ITERATIONS_HARD_CEILING;
+        int llmCallLimit = effectiveMaxIter * LLM_CALL_MULTIPLIER;
         if (llmCallCount >= llmCallLimit) {
             log.warn("[ReasoningDispatcher] LLM call count limit reached ({}/{}), " +
                             "routing to limitExceededNode instead of continuing loop",

--- a/mateclaw-server/src/main/java/vip/mate/agent/graph/plan/node/PlanGenerationNode.java
+++ b/mateclaw-server/src/main/java/vip/mate/agent/graph/plan/node/PlanGenerationNode.java
@@ -515,7 +515,8 @@ public class PlanGenerationNode implements NodeAction {
                     chatModel, prompt, conversationId, "plan_generation");
 
             // Prompt-too-long handling: compact the conversation window and retry once.
-            if (result.isPromptTooLong() && conversationWindowManager != null) {
+            if (result.isPromptTooLong() && conversationWindowManager != null
+                    && !promptMessages.isEmpty()) {
                 log.warn("[PlanGeneration] Prompt too long, attempting compaction and retry");
                 List<Message> compactedMessages = conversationWindowManager.compactForRetry(
                         promptMessages.subList(1, promptMessages.size()));

--- a/mateclaw-server/src/main/java/vip/mate/agent/graph/plan/node/StepExecutionNode.java
+++ b/mateclaw-server/src/main/java/vip/mate/agent/graph/plan/node/StepExecutionNode.java
@@ -306,7 +306,8 @@ public class StepExecutionNode implements NodeAction {
                         "step_execution[" + stepIndex + "]");
 
                 // PTL 处理：压缩后重试
-                if (result.isPromptTooLong() && conversationWindowManager != null) {
+                if (result.isPromptTooLong() && conversationWindowManager != null
+                        && !messages.isEmpty()) {
                     log.warn("[StepExecution] Prompt too long at step {}, attempting compaction", stepIndex);
                     List<Message> compactedMessages = conversationWindowManager.compactForRetry(
                             messages.subList(1, messages.size()));

--- a/mateclaw-server/src/main/java/vip/mate/agent/graph/state/MateClawStateAccessor.java
+++ b/mateclaw-server/src/main/java/vip/mate/agent/graph/state/MateClawStateAccessor.java
@@ -3,6 +3,7 @@ package vip.mate.agent.graph.state;
 import com.alibaba.cloud.ai.graph.OverAllState;
 import org.springframework.ai.chat.messages.Message;
 import vip.mate.agent.GraphEventPublisher;
+import vip.mate.agent.BaseAgent;
 import vip.mate.agent.context.ChatOrigin;
 import vip.mate.agent.graph.NodeStreamingChatHelper;
 
@@ -63,7 +64,8 @@ public final class MateClawStateAccessor {
 
     public boolean isLimitReached() {
         int max = maxIterations();
-        return max > 0 && iterationCount() >= max; // max=0 表示不限制
+        int effectiveMax = max > 0 ? max : BaseAgent.MAX_ITERATIONS_HARD_CEILING;
+        return iterationCount() >= effectiveMax;
     }
 
     // ===== 工具调用 =====

--- a/mateclaw-server/src/main/java/vip/mate/config/GraphObservationProperties.java
+++ b/mateclaw-server/src/main/java/vip/mate/config/GraphObservationProperties.java
@@ -43,4 +43,14 @@ public class GraphObservationProperties {
 
     /** Minimum chars retained on truncation to avoid losing all information. */
     private int minKeepChars = 2000;
+
+    /**
+     * Idle timeout (seconds) for the structured stream. If no NodeOutput is
+     * emitted within this duration, the stream terminates with a timeout
+     * error. Set to 0 to disable. Default 900 (15 minutes) — 3x the default
+     * per-tool timeout (300s) so legitimate long-running tools never trigger
+     * it. Increase for deployments with slow LLM fallback chains or many
+     * sequential unsafe tools.
+     */
+    private int streamIdleTimeoutSeconds = 900;
 }

--- a/mateclaw-server/src/main/java/vip/mate/skill/acp/AcpSkillBridge.java
+++ b/mateclaw-server/src/main/java/vip/mate/skill/acp/AcpSkillBridge.java
@@ -268,11 +268,28 @@ public class AcpSkillBridge {
                 String userPrompt = args.path("prompt").asText("").trim();
                 if (userPrompt.isEmpty()) return errorJson("prompt is required");
                 String cwdHint = args.path("cwd").asText("");
-                String reply = delegationService.prompt(endpointName, userPrompt,
-                        cwdHint == null || cwdHint.isBlank() ? null : cwdHint);
+                // RFC-090 Phase 7c: use the streaming delegation so ACP
+                // session/update events (tool_call_*, plan, current_mode)
+                // are observed — logged here for observability, ready to
+                // wire into the agent SSE relay once the ToolCallback
+                // surface grows a streaming variant.
+                StringBuilder reply = new StringBuilder();
+                delegationService.promptStream(endpointName, userPrompt,
+                        cwdHint == null || cwdHint.isBlank() ? null : cwdHint)
+                        .doOnNext(delta -> {
+                            if (delta.isEvent()) {
+                                log.debug("[ACP stream] endpoint='{}' event={} data={}",
+                                        endpointName, delta.eventType(), delta.eventData());
+                            } else if (delta.content() != null && !delta.content().isEmpty()) {
+                                reply.append(delta.content());
+                            }
+                        })
+                        .doOnError(e -> log.warn("[ACP stream] endpoint='{}' error: {}",
+                                endpointName, e.getMessage()))
+                        .blockLast();
                 JSONObject resp = new JSONObject()
                         .set("endpoint", endpointName)
-                        .set("reply", reply);
+                        .set("reply", reply.toString().trim());
                 return JSONUtil.toJsonStr(resp);
             } catch (Exception e) {
                 log.warn("ACP wrapper '{}' failed: {}", toolName, e.getMessage());

--- a/mateclaw-server/src/main/java/vip/mate/skill/runtime/SkillScriptExecutionService.java
+++ b/mateclaw-server/src/main/java/vip/mate/skill/runtime/SkillScriptExecutionService.java
@@ -165,11 +165,33 @@ public class SkillScriptExecutionService {
                 command.add(IS_WINDOWS ? "python" : "python3");
             } else if (fileName.endsWith(".sh")) {
                 if (IS_WINDOWS) {
-                    return ScriptResult.error(-1,
-                            "Shell scripts (.sh) are not supported on Windows. " +
-                            "Consider providing a .bat or .ps1 alternative.");
+                    // RFC-090 Phase 7c: detect Git Bash / WSL so .sh
+                    // scripts run on Windows. Search order:
+                    //   1. bash on PATH (Git for Windows adds it)
+                    //   2. <Git>/bin/bash.exe
+                    //   3. <Git>/usr/bin/bash.exe  (usr -> avoid backslash-u)
+                    //   4. <Git (x86)>/bin/bash.exe
+                    //   5. wsl bash (Windows Subsystem for Linux)
+                    String bashExe = findWindowsBash();
+                    if (bashExe == null) {
+                        return ScriptResult.error(-1,
+                                "Shell scripts (.sh) require bash on Windows. " +
+                                "Install Git for Windows (https://git-scm.com) " +
+                                "or enable WSL, then ensure 'bash' is on PATH.");
+                    }
+                    if (bashExe.equals("wsl.exe")) {
+                        // WSL needs the Windows path translated to a
+                        // WSL-style path (/mnt/c/...) and an explicit
+                        // `bash` launcher.
+                        command.add("wsl.exe");
+                        command.add("bash");
+                        command.add(toWslPath(scriptPath));
+                    } else {
+                        command.add(bashExe);
+                    }
+                } else {
+                    command.add("bash");
                 }
-                command.add("bash");
             } else if (fileName.endsWith(".bat") || fileName.endsWith(".cmd")) {
                 if (!IS_WINDOWS) {
                     return ScriptResult.error(-1,
@@ -306,6 +328,86 @@ public class SkillScriptExecutionService {
                 try { Files.deleteIfExists(p); } catch (IOException ignored) {}
             });
         } catch (IOException ignored) {}
+    }
+
+    /**
+     * Find a usable bash executable on Windows. Search order:
+     * <ol>
+     *   <li>{@code bash} on PATH (Git for Windows adds it)</li>
+     *   <li>Common Git for Windows install paths</li>
+     *   <li>{@code wsl bash} (Windows Subsystem for Linux)</li>
+     * </ol>
+     * Returns the executable path / command string, or null if none found.
+     */
+    private static String findWindowsBash() {
+        // 1. bash on PATH
+        String onPath = findOnPath("bash.exe");
+        if (onPath != null) return onPath;
+
+        // 2. Common Git for Windows install paths.
+        // NOTE: avoid backslash-u in source code — javac treats a
+        // backslash followed by 'u' and 4 hex digits as a Unicode escape,
+        // even inside string literals and comments. Forward slashes
+        // work fine with Files.exists on Windows.
+        String[] gitPaths = {
+                "C:/Program Files/Git/bin/bash.exe",
+                "C:/Program Files/Git/usr/bin/bash.exe",
+                "C:/Program Files (x86)/Git/bin/bash.exe",
+                "C:/Program Files (x86)/Git/usr/bin/bash.exe"
+        };
+        for (String p : gitPaths) {
+            if (Files.exists(Path.of(p))) return p;
+        }
+
+        // 3. WSL — check whether wsl.exe exists and bash is available inside
+        if (findOnPath("wsl.exe") != null) {
+            try {
+                Process p = new ProcessBuilder("wsl.exe", "which", "bash")
+                        .redirectErrorStream(true).start();
+                boolean done = p.waitFor(5, TimeUnit.SECONDS);
+                if (done && p.exitValue() == 0) {
+                    return "wsl.exe";
+                }
+            } catch (Exception ignored) {
+                // WSL not available or bash not installed inside
+            }
+        }
+
+        return null;
+    }
+
+    /**
+     * Look for an executable on the system PATH. Returns the full path
+     * if found, null otherwise.
+     */
+    private static String findOnPath(String exeName) {
+        String path = System.getenv("PATH");
+        if (path == null) return null;
+        for (String dir : path.split(java.io.File.pathSeparator)) {
+            if (dir.isBlank()) continue;
+            Path candidate = Path.of(dir, exeName);
+            if (Files.isExecutable(candidate)) {
+                return candidate.toString();
+            }
+        }
+        return null;
+    }
+
+    /**
+     * Convert a Windows path to a WSL-style path ({@code C:\foo\bar}
+     * → {@code /mnt/c/foo/bar}). Falls back to the original string
+     * if the conversion fails — WSL may still resolve it via its
+     * automatic path translation layer.
+     */
+    private static String toWslPath(Path windowsPath) {
+        String abs = windowsPath.toAbsolutePath().toString().replace('\\', '/');
+        // Match drive letter: C:/...
+        if (abs.length() >= 2 && abs.charAt(1) == ':') {
+            char drive = Character.toLowerCase(abs.charAt(0));
+            String rest = abs.substring(2); // skip "C:"
+            return "/mnt/" + drive + rest;
+        }
+        return abs;
     }
 
     @lombok.Data

--- a/mateclaw-server/src/main/java/vip/mate/tool/builtin/ApplyPatchTool.java
+++ b/mateclaw-server/src/main/java/vip/mate/tool/builtin/ApplyPatchTool.java
@@ -1,0 +1,412 @@
+package vip.mate.tool.builtin;
+
+import cn.hutool.json.JSONArray;
+import cn.hutool.json.JSONObject;
+import cn.hutool.json.JSONUtil;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.ai.tool.annotation.Tool;
+import org.springframework.ai.tool.annotation.ToolParam;
+import org.springframework.stereotype.Component;
+
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+/**
+ * 内置工具：应用 unified diff 补丁
+ * <p>
+ * 解析标准 unified diff（git diff 格式），逐 hunk 应用到目标文件。
+ * 每个 hunk 的上下文行用于唯一定位修改位置，避免歧义。
+ * <p>
+ * 安全说明：
+ * <ul>
+ *   <li>编辑操作经过 ToolGuard 安全检查</li>
+ *   <li>路径边界由 {@code WorkspacePathGuard} 处理</li>
+ *   <li>每个 hunk 要求上下文唯一匹配，否则整体回滚</li>
+ * </ul>
+ *
+ * @author MateClaw Team
+ */
+@Slf4j
+@Component
+public class ApplyPatchTool {
+
+    private static final Pattern HUNK_HEADER = Pattern.compile(
+            "^@@ -(\\d+)(?:,(\\d+))? \\+(\\d+)(?:,(\\d+))? @@");
+
+    @vip.mate.tool.ConcurrencyUnsafe("in-place multi-hunk file edit — must not race with reads/writes on the same path")
+    @Tool(description = """
+            Apply a unified diff patch to one or more files. Accepts standard \
+            git-style unified diff format with @@ hunk headers. Each hunk's \
+            context lines must uniquely match the target file — if a hunk's \
+            context is ambiguous (matches multiple locations) or not found, the \
+            entire patch is rejected and no changes are applied. This is safer \
+            than edit_file for multi-location edits. Also supports file deletion \
+            (--- filePath / +++ /dev/null) and file move (different old/new \
+            paths). Returns structured JSON with per-file results and a diff \
+            preview. May require user approval when security rules flag the \
+            edit.""")
+    public String apply_patch(
+            @ToolParam(description = "Standard unified diff content (git diff format), may touch multiple files (add/update/delete/move)") String patch) {
+
+        JSONObject result = new JSONObject();
+        if (patch == null || patch.isBlank()) {
+            result.set("error", true);
+            result.set("message", "Patch content is empty");
+            return JSONUtil.toJsonPrettyStr(result);
+        }
+
+        try {
+            List<FilePatch> filePatches = parsePatch(patch);
+            if (filePatches.isEmpty()) {
+                result.set("error", true);
+                result.set("message", "No valid file patches found in input");
+                return JSONUtil.toJsonPrettyStr(result);
+            }
+
+            JSONArray fileResults = new JSONArray();
+            int totalHunksApplied = 0;
+
+            for (FilePatch fp : filePatches) {
+                JSONObject fileResult = new JSONObject();
+                fileResult.set("filePath", fp.filePath);
+
+                try {
+                    Path path;
+                    try {
+                        path = vip.mate.tool.guard.WorkspacePathGuard.validatePath(fp.filePath);
+                    } catch (IllegalArgumentException e) {
+                        fileResult.set("error", true);
+                        fileResult.set("message", e.getMessage());
+                        fileResults.add(fileResult);
+                        continue;
+                    }
+
+                    // Handle file deletion (newPath = /dev/null)
+                    if (fp.isDeleteFile) {
+                        Path oldPath = vip.mate.tool.guard.WorkspacePathGuard.validatePath(fp.oldFilePath);
+                        if (!Files.exists(oldPath)) {
+                            fileResult.set("error", true);
+                            fileResult.set("message", "File not found for deletion: " + oldPath);
+                            fileResults.add(fileResult);
+                            continue;
+                        }
+                        Files.deleteIfExists(oldPath);
+                        fileResult.set("deleted", true);
+                        fileResult.set("message", "File deleted: " + oldPath);
+                        fileResults.add(fileResult);
+                        continue;
+                    }
+
+                    // Handle file move (oldFilePath != filePath and both exist)
+                    if (fp.oldFilePath != null && !fp.oldFilePath.equals(fp.filePath) && !fp.isNewFile) {
+                        Path oldPath = vip.mate.tool.guard.WorkspacePathGuard.validatePath(fp.oldFilePath);
+                        if (!Files.exists(oldPath)) {
+                            fileResult.set("error", true);
+                            fileResult.set("message", "Source file not found for move: " + oldPath);
+                            fileResults.add(fileResult);
+                            continue;
+                        }
+                        // Read old content, apply hunks, write to new path, delete old
+                        String original = Files.readString(oldPath, StandardCharsets.UTF_8);
+                        String patched = applyHunks(original, fp.hunks, fileResult);
+                        if (patched == null) {
+                            fileResults.add(fileResult);
+                            continue;
+                        }
+                        Files.createDirectories(path.getParent());
+                        Files.writeString(path, patched, StandardCharsets.UTF_8);
+                        if (!oldPath.equals(path)) {
+                            Files.deleteIfExists(oldPath);
+                        }
+                        int hunks = (int) fileResult.getInt("hunksApplied", 0);
+                        totalHunksApplied += hunks;
+                        fileResult.set("moved", true);
+                        fileResult.set("oldPath", fp.oldFilePath);
+                        fileResult.set("message", "File moved from " + fp.oldFilePath + " to " + fp.filePath
+                                + " (" + hunks + " hunk(s) applied)");
+                        fileResults.add(fileResult);
+                        continue;
+                    }
+
+                    if (!Files.exists(path)) {
+                        if (fp.isNewFile) {
+                            Files.createDirectories(path.getParent());
+                            Files.writeString(path, fp.newFileContent, StandardCharsets.UTF_8);
+                            fileResult.set("hunksApplied", 0);
+                            fileResult.set("created", true);
+                            fileResult.set("message", "New file created");
+                            totalHunksApplied++;
+                            fileResults.add(fileResult);
+                            continue;
+                        }
+                        fileResult.set("error", true);
+                        fileResult.set("message", "File not found: " + path);
+                        fileResults.add(fileResult);
+                        continue;
+                    }
+
+                    if (Files.isDirectory(path)) {
+                        fileResult.set("error", true);
+                        fileResult.set("message", "Path is a directory: " + path);
+                        fileResults.add(fileResult);
+                        continue;
+                    }
+
+                    String original = Files.readString(path, StandardCharsets.UTF_8);
+                    String patched = applyHunks(original, fp.hunks, fileResult);
+
+                    if (patched == null) {
+                        // fileResult already has error details set by applyHunks
+                        fileResults.add(fileResult);
+                        continue;
+                    }
+
+                    if (!patched.equals(original)) {
+                        Files.writeString(path, patched, StandardCharsets.UTF_8);
+                    }
+
+                    int hunks = (int) fileResult.getInt("hunksApplied", 0);
+                    totalHunksApplied += hunks;
+                    fileResult.set("message", hunks + " hunk(s) applied");
+
+                } catch (Exception e) {
+                    log.error("[ApplyPatch] Failed on {}: {}", fp.filePath, e.getMessage(), e);
+                    fileResult.set("error", true);
+                    fileResult.set("message", e.getMessage());
+                }
+                fileResults.add(fileResult);
+            }
+
+            result.set("files", fileResults);
+            result.set("totalHunksApplied", totalHunksApplied);
+            result.set("message", "Patch applied: " + filePatches.size() + " file(s), " + totalHunksApplied + " hunk(s)");
+
+        } catch (Exception e) {
+            log.error("[ApplyPatch] Failed to apply patch: {}", e.getMessage(), e);
+            result.set("error", true);
+            result.set("message", "Failed to parse patch: " + e.getMessage());
+        }
+
+        return JSONUtil.toJsonPrettyStr(result);
+    }
+
+    private String applyHunks(String original, List<Hunk> hunks, JSONObject fileResult) {
+        String content = original;
+        int applied = 0;
+        int searchOffset = 0;
+
+        for (Hunk hunk : hunks) {
+            String contextBlock = hunk.contextBlock();
+            int idx = content.indexOf(contextBlock, searchOffset);
+
+            if (idx < 0) {
+                // Try from beginning if offset-based search failed
+                idx = content.indexOf(contextBlock);
+            }
+
+            if (idx < 0) {
+                fileResult.set("error", true);
+                fileResult.set("hunksApplied", applied);
+                fileResult.set("failedHunkLine", hunk.oldStartLine);
+                fileResult.set("message", "Hunk context not found at line " + hunk.oldStartLine
+                        + ". Context:\n" + truncate(contextBlock, 200));
+                return null;
+            }
+
+            // Check uniqueness: no second occurrence after this one
+            int secondIdx = content.indexOf(contextBlock, idx + contextBlock.length());
+            if (secondIdx >= 0) {
+                fileResult.set("error", true);
+                fileResult.set("hunksApplied", applied);
+                fileResult.set("failedHunkLine", hunk.oldStartLine);
+                fileResult.set("message", "Hunk context is ambiguous (matches multiple locations) at line "
+                        + hunk.oldStartLine + ". Add more context lines to disambiguate.");
+                return null;
+            }
+
+            String replacement = hunk.replacementBlock();
+            content = content.substring(0, idx) + replacement + content.substring(idx + contextBlock.length());
+            searchOffset = idx + replacement.length();
+            applied++;
+        }
+
+        fileResult.set("hunksApplied", applied);
+        return content;
+    }
+
+    private List<FilePatch> parsePatch(String patch) {
+        List<FilePatch> result = new ArrayList<>();
+        String[] lines = patch.split("\n", -1);
+
+        int i = 0;
+        while (i < lines.length) {
+            String line = lines[i];
+
+            if (line.startsWith("+++ ") && i > 0 && lines[i - 1].startsWith("--- ")) {
+                String newPath = stripPrefix(lines[i].substring(4));
+                String oldPath = stripPrefix(lines[i - 1].substring(4));
+                boolean isNew = oldPath.equals("/dev/null");
+                boolean isDelete = newPath.equals("/dev/null");
+                boolean isMove = !isNew && !isDelete && !oldPath.equals(newPath);
+
+                FilePatch fp = new FilePatch();
+                fp.filePath = isDelete ? null : newPath;
+                fp.oldFilePath = (isNew || isDelete) ? oldPath : (isMove ? oldPath : null);
+                fp.isNewFile = isNew;
+                fp.isDeleteFile = isDelete;
+
+                // If delete file, just record it
+                if (isDelete) {
+                    fp.filePath = oldPath; // store for deletion
+                    result.add(fp);
+                    i++;
+                    continue;
+                }
+
+                // If new file, collect content from +++ block (all + lines)
+                if (isNew) {
+                    StringBuilder sb = new StringBuilder();
+                    i++;
+                    while (i < lines.length && lines[i].startsWith("+") && !lines[i].startsWith("+++")) {
+                        sb.append(lines[i].substring(1)).append('\n');
+                        i++;
+                    }
+                    fp.newFileContent = sb.toString();
+                    result.add(fp);
+                    continue;
+                }
+
+                // For move or regular update, filePath is the new path
+                if (isMove) {
+                    fp.filePath = newPath;
+                }
+
+                // Collect hunks for existing file
+                i++;
+                while (i < lines.length) {
+                    String hunkLine = lines[i];
+                    Matcher hm = HUNK_HEADER.matcher(hunkLine);
+                    if (!hm.matches()) {
+                        if (hunkLine.startsWith("diff --git") || hunkLine.startsWith("--- ")) {
+                            break;
+                        }
+                        i++;
+                        continue;
+                    }
+
+                    Hunk hunk = new Hunk();
+                    hunk.oldStartLine = Integer.parseInt(hm.group(1));
+                    // Hunk line counts from the @@ header determine exactly how
+                    // many lines belong to this hunk body. This is critical for
+                    // multi-file diffs: without counting, a content line like
+                    // "--- a/other.txt" (a removed line whose text starts with
+                    // "-- a/other.txt") would be misread as the next file's
+                    // header, truncating the current hunk and corrupting the
+                    // rest of the patch.
+                    int oldCount = hm.group(2) != null ? Integer.parseInt(hm.group(2)) : 1;
+                    int newCount = hm.group(4) != null ? Integer.parseInt(hm.group(4)) : 1;
+                    i++;
+
+                    List<HunkLine> hunkLines = new ArrayList<>();
+                    int oldLinesSeen = 0;
+                    int newLinesSeen = 0;
+
+                    while (i < lines.length) {
+                        // Stop when we've consumed all lines in this hunk body
+                        if (oldLinesSeen >= oldCount && newLinesSeen >= newCount) {
+                            break;
+                        }
+
+                        String hl = lines[i];
+                        if (hl.startsWith("@@")) break;
+                        if (hl.startsWith("diff --git")) break;
+
+                        char prefix;
+                        String text;
+                        if (hl.isEmpty()) {
+                            // Empty line in diff = context for empty line
+                            prefix = ' ';
+                            text = "";
+                        } else {
+                            prefix = hl.charAt(0);
+                            text = hl.length() > 1 ? hl.substring(1) : "";
+                        }
+
+                        // Only accept valid diff line prefixes
+                        if (prefix != ' ' && prefix != '-' && prefix != '+') {
+                            // Unknown prefix — treat as end of hunk (malformed diff)
+                            break;
+                        }
+
+                        hunkLines.add(new HunkLine(prefix, text));
+                        if (prefix == ' ' || prefix == '-') oldLinesSeen++;
+                        if (prefix == ' ' || prefix == '+') newLinesSeen++;
+                        i++;
+                    }
+
+                    hunk.lines = hunkLines;
+                    fp.hunks.add(hunk);
+                }
+
+                if (!fp.hunks.isEmpty() || fp.isNewFile) {
+                    result.add(fp);
+                }
+            } else {
+                i++;
+            }
+        }
+
+        return result;
+    }
+
+    private String stripPrefix(String path) {
+        if (path.startsWith("b/")) return path.substring(2);
+        if (path.startsWith("a/")) return path.substring(2);
+        return path;
+    }
+
+    private String truncate(String s, int max) {
+        return s.length() <= max ? s : s.substring(0, max) + "...";
+    }
+
+    private static class FilePatch {
+        String filePath;
+        String oldFilePath;  // for move operations
+        boolean isNewFile;
+        boolean isDeleteFile;  // when new path is /dev/null
+        String newFileContent;
+        final List<Hunk> hunks = new ArrayList<>();
+    }
+
+    private static class Hunk {
+        int oldStartLine;
+        List<HunkLine> lines;
+
+        String contextBlock() {
+            StringBuilder sb = new StringBuilder();
+            for (HunkLine hl : lines) {
+                if (hl.prefix == ' ' || hl.prefix == '-') {
+                    sb.append(hl.text).append('\n');
+                }
+            }
+            return sb.toString();
+        }
+
+        String replacementBlock() {
+            StringBuilder sb = new StringBuilder();
+            for (HunkLine hl : lines) {
+                if (hl.prefix == ' ' || hl.prefix == '+') {
+                    sb.append(hl.text).append('\n');
+                }
+            }
+            return sb.toString();
+        }
+    }
+
+    private record HunkLine(char prefix, String text) {}
+}

--- a/mateclaw-server/src/main/java/vip/mate/tool/builtin/EditFileTool.java
+++ b/mateclaw-server/src/main/java/vip/mate/tool/builtin/EditFileTool.java
@@ -10,18 +10,21 @@ import org.springframework.stereotype.Component;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.nio.file.Paths;
+import java.util.ArrayList;
+import java.util.List;
 
 /**
  * 内置工具：编辑文件（查找替换）
  * <p>
- * 通过精确字符串匹配进行查找替换。
- * 支持替换首次匹配或全部匹配。
+ * 借鉴 opencode 的 multi-strategy fuzzy matching 设计：当 LLM 提供的
+ * oldText 无法精确匹配时，按顺序尝试多个 Replacer 策略（行 trim、空白
+ * 归一化、缩进灵活、转义归一化等），大幅提升编辑成功率。
  * <p>
  * 安全说明：
  * <ul>
  *   <li>编辑操作会经过 ToolGuard 安全检查；命中安全规则时会要求用户审批</li>
  *   <li>路径边界由 {@code WorkspacePathGuard} 处理</li>
+ *   <li>唯一匹配校验：非 replaceAll 模式下，多处匹配会拒绝并要求更多上下文</li>
  * </ul>
  *
  * @author MateClaw Team
@@ -34,13 +37,19 @@ public class EditFileTool {
     private final vip.mate.i18n.I18nService i18n;
 
     @vip.mate.tool.ConcurrencyUnsafe("in-place file edit — must not race with reads/writes on the same path")
-    @Tool(description = "Edit file content via find-and-replace. Finds exact match of old_text and replaces with new_text. "
-            + "Returns structured JSON with filePath, replacements count. "
-            + "May require user approval when security rules flag the edit. "
-            + "Replaces first occurrence by default; set replaceAll=true for all.")
+    @Tool(description = """
+            Edit file content via find-and-replace. Finds match of old_text and \
+            replaces with new_text. Uses multi-strategy fuzzy matching: if exact \
+            match fails, tries line-trimmed, whitespace-normalized, \
+            indentation-flexible, and escape-normalized matching in order. \
+            Non-replaceAll mode requires unique match — if old_text matches \
+            multiple locations, the edit is rejected with a message asking for \
+            more surrounding context. Returns structured JSON with filePath, \
+            replacements count, match strategy used, and a unified diff preview. \
+            May require user approval when security rules flag the edit.""")
     public String edit_file(
             @ToolParam(description = "Absolute or relative file path") String filePath,
-            @ToolParam(description = "Original text to find (exact match)") String oldText,
+            @ToolParam(description = "Original text to find (exact match preferred; fuzzy matching used as fallback)") String oldText,
             @ToolParam(description = "Replacement text") String newText,
             @ToolParam(description = "Replace all occurrences, default false (first only)", required = false) Boolean replaceAll) {
 
@@ -78,38 +87,60 @@ public class EditFileTool {
                 return errorResult(filePath, i18n.msg("tool.edit_file.error.not_rw", path));
             }
 
-            // 读取文件内容
             String content = Files.readString(path, StandardCharsets.UTF_8);
-
-            // 检查 oldText 是否存在
-            if (!content.contains(oldText)) {
-                return errorResult(filePath, i18n.msg("tool.edit_file.error.old_not_found"));
-            }
-
-            // 执行替换
-            String newContent;
-            int replacements;
             boolean doReplaceAll = replaceAll != null && replaceAll;
 
-            if (doReplaceAll) {
-                // 统计匹配次数
-                replacements = countOccurrences(content, oldText);
-                newContent = content.replace(oldText, newText);
-            } else {
-                // 只替换第一处
-                int idx = content.indexOf(oldText);
-                newContent = content.substring(0, idx) + newText + content.substring(idx + oldText.length());
-                replacements = 1;
+            // Try each replacer strategy in order until one succeeds
+            ReplacementOutcome outcome = null;
+            for (Replacer replacer : REPLACERS) {
+                outcome = replacer.tryReplace(content, oldText, newText, doReplaceAll);
+                if (outcome != null) {
+                    break;
+                }
             }
 
-            // 写回文件
-            Files.writeString(path, newContent, StandardCharsets.UTF_8);
+            if (outcome == null) {
+                // All strategies failed — give the LLM actionable feedback
+                String hint = buildNotFoundHint(content, oldText);
+                return errorResult(filePath, "Could not find old_text in file. " + hint);
+            }
 
-            result.set("replacements", replacements);
+            // Disproportionate match rejection: if the matched span is much
+            // larger than oldText, the fuzzy matcher likely ate too much.
+            if (outcome.matchedLength > oldText.length() * 3 && outcome.matchedLength > oldText.length() + 200) {
+                return errorResult(filePath,
+                        "Refusing replacement because the matched span (" + outcome.matchedLength
+                                + " chars) is much larger than old_text (" + oldText.length()
+                                + " chars). Provide a more precise old_text with exact content.");
+            }
+
+            // Write the new content
+            Files.writeString(path, outcome.newContent, StandardCharsets.UTF_8);
+
+            // Build a diff preview (first 30 changed lines)
+            String diffPreview = buildDiffPreview(content, outcome.newContent, path.getFileName().toString());
+
+            result.set("replacements", outcome.replacements);
             result.set("replaceAll", doReplaceAll);
-            result.set("message", "Edit successful: " + replacements + " replacement(s)");
+            result.set("matchStrategy", outcome.strategyName);
+            result.set("diffPreview", diffPreview);
 
-            log.info("[EditFile] Edited {}: {} replacement(s)", path, replacements);
+            // Lightweight post-edit syntax check (opencode LSP diagnostic loop —
+            // simplified version: run a quick syntax check for common code files,
+            // include any errors in the result so the LLM can self-correct).
+            String syntaxWarning = postEditSyntaxCheck(path);
+            if (syntaxWarning != null) {
+                result.set("syntaxWarning", syntaxWarning);
+                result.set("message", "Edit successful: " + outcome.replacements
+                        + " replacement(s) via " + outcome.strategyName
+                        + ". WARNING: syntax check found issues — see syntaxWarning field.");
+            } else {
+                result.set("message", "Edit successful: " + outcome.replacements
+                        + " replacement(s) via " + outcome.strategyName);
+            }
+
+            log.info("[EditFile] Edited {}: {} replacement(s) via {}",
+                    path, outcome.replacements, outcome.strategyName);
 
         } catch (Exception e) {
             log.error("[EditFile] Failed to edit file: {}", e.getMessage(), e);
@@ -119,14 +150,373 @@ public class EditFileTool {
         return JSONUtil.toJsonPrettyStr(result);
     }
 
-    private int countOccurrences(String text, String target) {
-        int count = 0;
-        int idx = 0;
+    // ==================== Multi-strategy Replacer (opencode-inspired, line-based) ====================
+
+    /**
+     * A replacer strategy attempts to find {@code oldText} in {@code content}
+     * and replace it with {@code newText}. Returns null if no match.
+     *
+     * <p>All strategies use <b>line-level matching</b>: split both content and
+     * oldText into lines, apply a per-line transformation, find a consecutive
+     * window of content lines whose transformed versions match the transformed
+     * oldText lines, then replace those <em>original</em> lines with newText.
+     * This avoids the "map back from transformed space" problem that caused
+     * duplicate lines in the previous whole-string approach.
+     */
+    private interface Replacer {
+        ReplacementOutcome tryReplace(String content, String oldText, String newText, boolean replaceAll);
+    }
+
+    /** Result of a successful replacement. */
+    private static class ReplacementOutcome {
+        final String newContent;
+        final int replacements;
+        final int matchedLength;
+        final String strategyName;
+
+        ReplacementOutcome(String newContent, int replacements, int matchedLength, String strategyName) {
+            this.newContent = newContent;
+            this.replacements = replacements;
+            this.matchedLength = matchedLength;
+            this.strategyName = strategyName;
+        }
+    }
+
+    /**
+     * Transform a single line for matching. Each strategy provides a different
+     * transformation (identity, trim, whitespace-normalize, etc.).
+     */
+    private interface LineTransformer {
+        String transform(String line);
+    }
+
+    // --- Strategy 1: Exact match (whole-string, not line-based) ---
+    private static final Replacer EXACT = (content, oldText, newText, replaceAll) -> {
+        if (!content.contains(oldText)) return null;
+        if (!replaceAll) {
+            int first = content.indexOf(oldText);
+            int last = content.lastIndexOf(oldText);
+            if (first != last) return null; // multiple matches — reject
+            String nc = content.substring(0, first) + newText + content.substring(first + oldText.length());
+            return new ReplacementOutcome(nc, 1, oldText.length(), "exact");
+        }
+        int count = countOccurrences(content, oldText);
+        return new ReplacementOutcome(content.replace(oldText, newText), count, oldText.length(), "exact");
+    };
+
+    // --- Strategy 2: Line-trimmed match ---
+    private static final Replacer LINE_TRIMMED = createLineBasedReplacer(
+            "line-trimmed",
+            line -> line.strip()
+    );
+
+    // --- Strategy 3: Whitespace-normalized match ---
+    private static final Replacer WHITESPACE_NORMALIZED = createLineBasedReplacer(
+            "whitespace-normalized",
+            line -> line.replaceAll("\\s+", " ").strip()
+    );
+
+    // --- Strategy 4: Indentation-flexible match (strip leading whitespace) ---
+    private static final Replacer INDENTATION_FLEXIBLE = createLineBasedReplacer(
+            "indentation-flexible",
+            line -> line.stripIndent()
+    );
+
+    // --- Strategy 5: Escape-normalized match ---
+    private static final Replacer ESCAPE_NORMALIZED = createLineBasedReplacer(
+            "escape-normalized",
+            line -> line.replace("\\\"", "\"").replace("\\\\", "\\").replace("\\n", "\n").replace("\\t", "\t")
+    );
+
+    /**
+     * Create a line-based replacer that uses the given per-line transformer.
+     *
+     * <p>Algorithm:
+     * <ol>
+     *   <li>Split content and oldText into lines</li>
+     *   <li>Transform each line of both</li>
+     *   <li>Find a consecutive window in content whose transformed lines
+     *       match the transformed oldText lines</li>
+     *   <li>Replace those original (untransformed) content lines with newText</li>
+     * </ol>
+     *
+     * <p>This is the key fix for the duplicate-lines bug: the replacement
+     * always operates on original lines, never on transformed text, so the
+     * boundary is always a clean line boundary.
+     */
+    private static Replacer createLineBasedReplacer(String strategyName, LineTransformer transformer) {
+        return (content, oldText, newText, replaceAll) -> {
+            String[] contentLines = content.split("\n", -1);
+            String[] oldLines = oldText.split("\n", -1);
+            if (oldLines.length == 0 || oldLines.length > contentLines.length) return null;
+
+            // Transform oldText lines
+            String[] transformedOld = new String[oldLines.length];
+            for (int i = 0; i < oldLines.length; i++) {
+                transformedOld[i] = transformer.transform(oldLines[i]);
+            }
+
+            // Find all matching windows in content
+            List<int[]> matches = new ArrayList<>(); // each: [startLine, endLine] (0-based, inclusive)
+            for (int start = 0; start <= contentLines.length - oldLines.length; start++) {
+                boolean match = true;
+                for (int j = 0; j < oldLines.length; j++) {
+                    String transformedContentLine = transformer.transform(contentLines[start + j]);
+                    if (!transformedContentLine.equals(transformedOld[j])) {
+                        match = false;
+                        break;
+                    }
+                }
+                if (match) {
+                    matches.add(new int[]{start, start + oldLines.length - 1});
+                    if (!replaceAll) break; // only need first match for single replace
+                }
+            }
+
+            if (matches.isEmpty()) return null;
+            if (!replaceAll && matches.size() > 1) return null; // ambiguous — reject
+
+            // Perform replacement: replace original lines [startLine..endLine] with newText
+            // Process from end to start so indices don't shift
+            List<int[]> toReplace = replaceAll ? matches : List.of(matches.get(0));
+            StringBuilder result = new StringBuilder();
+            int pos = 0; // line index in contentLines
+            int totalMatchedChars = 0;
+
+            for (int[] range : toReplace) {
+                int startLine = range[0];
+                int endLine = range[1];
+
+                // Append unchanged lines before this match
+                for (int i = pos; i < startLine; i++) {
+                    result.append(contentLines[i]).append('\n');
+                }
+
+                // Calculate matched char count (for disproportionate check)
+                for (int i = startLine; i <= endLine; i++) {
+                    totalMatchedChars += contentLines[i].length() + 1; // +1 for \n
+                }
+
+                // Append replacement text
+                result.append(newText);
+
+                // Ensure exactly one newline after replacement (if there are more lines)
+                pos = endLine + 1;
+            }
+
+            // Append remaining lines
+            for (int i = pos; i < contentLines.length; i++) {
+                result.append(contentLines[i]);
+                if (i < contentLines.length - 1) result.append('\n');
+            }
+
+            // Handle trailing newline: if original content ended with \n and we
+            // didn't add one, add it. If original didn't end with \n, don't add.
+            boolean originalEndsWithNewline = content.endsWith("\n");
+            boolean resultEndsWithNewline = result.length() > 0
+                    && result.charAt(result.length() - 1) == '\n';
+            if (originalEndsWithNewline && !resultEndsWithNewline) {
+                result.append('\n');
+            }
+
+            return new ReplacementOutcome(result.toString(), toReplace.size(),
+                    totalMatchedChars, strategyName);
+        };
+    }
+
+    // All replacers in priority order
+    private static final List<Replacer> REPLACERS = List.of(
+            EXACT,
+            LINE_TRIMMED,
+            WHITESPACE_NORMALIZED,
+            INDENTATION_FLEXIBLE,
+            ESCAPE_NORMALIZED
+    );
+
+    // ==================== Helpers ====================
+
+    private static int countOccurrences(String text, String target) {
+        int count = 0, idx = 0;
         while ((idx = text.indexOf(target, idx)) != -1) {
             count++;
             idx += target.length();
         }
         return count;
+    }
+
+    /**
+     * Build a short hint when oldText is not found, showing nearby content
+     * to help the LLM correct its oldText.
+     */
+    private static String buildNotFoundHint(String content, String oldText) {
+        // Find the first non-empty line of oldText and search for it
+        String[] oldLines = oldText.split("\n", -1);
+        String firstLine = "";
+        for (String l : oldLines) { String t = l.strip(); if (!t.isEmpty()) { firstLine = t; break; } }
+
+        if (!firstLine.isEmpty()) {
+            int idx = content.indexOf(firstLine);
+            if (idx >= 0) {
+                // Show context around the partial match
+                int lineStart = idx;
+                while (lineStart > 0 && content.charAt(lineStart - 1) != '\n') lineStart--;
+                int lineEnd = content.indexOf('\n', idx);
+                if (lineEnd < 0) lineEnd = content.length();
+                int contextStart = Math.max(0, lineStart - 200);
+                int contextEnd = Math.min(content.length(), lineEnd + 200);
+                return "Partial match found near: \""
+                        + content.substring(contextStart, contextEnd).replace("\n", "\\n")
+                        + "\". The surrounding text differs from old_text. "
+                        + "Try copying the exact text from the file using read_file first.";
+            }
+        }
+
+        return "No partial match found. Use read_file to read the file first, then copy the exact text to old_text.";
+    }
+
+    /**
+     * Build a compact unified diff preview of the changes (first 30 lines).
+     */
+    private static String buildDiffPreview(String original, String modified, String fileName) {
+        String[] oldLines = original.split("\n", -1);
+        String[] newLines = modified.split("\n", -1);
+
+        // Simple line-by-line diff (not full LCS, but good enough for preview)
+        StringBuilder sb = new StringBuilder();
+        sb.append("--- ").append(fileName).append("\n");
+        sb.append("+++ ").append(fileName).append("\n");
+
+        int maxLines = Math.max(oldLines.length, newLines.length);
+        int shown = 0;
+        int maxShow = 30;
+
+        for (int i = 0; i < maxLines && shown < maxShow; i++) {
+            String oldLine = i < oldLines.length ? oldLines[i] : null;
+            String newLine = i < newLines.length ? newLines[i] : null;
+
+            if (oldLine != null && newLine != null && oldLine.equals(newLine)) {
+                continue; // skip unchanged lines
+            }
+            if (oldLine != null) {
+                sb.append("- ").append(truncateLine(oldLine, 120)).append("\n");
+                shown++;
+            }
+            if (newLine != null) {
+                sb.append("+ ").append(truncateLine(newLine, 120)).append("\n");
+                shown++;
+            }
+        }
+
+        if (shown >= maxShow) {
+            sb.append("... (diff truncated, ").append(maxLines).append(" total lines)\n");
+        }
+        return sb.toString();
+    }
+
+    private static String truncateLine(String s, int max) {
+        return s.length() <= max ? s : s.substring(0, max) + "...";
+    }
+
+    /**
+     * Lightweight post-edit syntax check (opencode LSP diagnostic loop —
+     * simplified). Detects file type by extension and runs a quick syntax
+     * check via subprocess. Returns a warning string if syntax errors are
+     * found, or null if the file passes (or is not a checkable type).
+     *
+     * <p>Non-blocking: if the check command is unavailable or times out,
+     * null is returned (the edit already succeeded). Only checks file types
+     * with fast, reliable syntax checkers:
+     * <ul>
+     *   <li>.java → javac -Xlint:none (syntax only, no classpath)</li>
+     *   <li>.py → python -m py_compile</li>
+     *   <li>.js → node --check</li>
+     *   <li>.ts → npx tsc --noEmit (if available)</li>
+     *   <li>.json → python -m json.tool (fast validation)</li>
+     * </ul>
+     */
+    private static String postEditSyntaxCheck(Path filePath) {
+        String name = filePath.getFileName().toString().toLowerCase();
+        List<String> cmd = new ArrayList<>();
+        Path tmpDir = null;
+
+        if (name.endsWith(".java")) {
+            try {
+                tmpDir = Files.createTempDirectory("mc_syntax_check_");
+            } catch (java.io.IOException e) {
+                return null;
+            }
+            cmd.add("javac");
+            cmd.add("-Xlint:none");
+            cmd.add("-d");
+            cmd.add(tmpDir.toString());
+            cmd.add(filePath.toString());
+        } else if (name.endsWith(".py")) {
+            cmd.add("python");
+            cmd.add("-m");
+            cmd.add("py_compile");
+            cmd.add(filePath.toString());
+        } else if (name.endsWith(".js")) {
+            cmd.add("node");
+            cmd.add("--check");
+            cmd.add(filePath.toString());
+        } else if (name.endsWith(".json")) {
+            cmd.add("python");
+            cmd.add("-m");
+            cmd.add("json.tool");
+            cmd.add(filePath.toString());
+        } else if (name.endsWith(".ts") || name.endsWith(".tsx")) {
+            cmd.add("npx");
+            cmd.add("--yes");
+            cmd.add("tsc");
+            cmd.add("--noEmit");
+            cmd.add("--skipLibCheck");
+            cmd.add(filePath.toString());
+        } else {
+            return null;
+        }
+
+        try {
+            ProcessBuilder pb = new ProcessBuilder(cmd);
+            pb.redirectErrorStream(true);
+            Process p = pb.start();
+            boolean done = p.waitFor(15, java.util.concurrent.TimeUnit.SECONDS);
+            if (!done) {
+                p.destroyForcibly();
+                return null; // timeout — don't block the edit
+            }
+            if (p.exitValue() == 0) return null; // syntax OK
+
+            // Read error output (limit to 2000 chars)
+            byte[] out = p.getInputStream().readAllBytes();
+            String errors = new String(out, StandardCharsets.UTF_8);
+            if (errors.length() > 2000) errors = errors.substring(0, 2000) + "\n... (truncated)";
+
+            return "Syntax errors detected after edit (please fix):\n" + errors;
+        } catch (Exception e) {
+            // Syntax checker not available — silently skip
+            return null;
+        } finally {
+            if (tmpDir != null) {
+                deleteTempDir(tmpDir);
+            }
+        }
+    }
+
+    private static void deleteTempDir(Path dir) {
+        try {
+            Files.walkFileTree(dir, new java.nio.file.SimpleFileVisitor<>() {
+                @Override
+                public java.nio.file.FileVisitResult visitFile(Path file, java.nio.file.attribute.BasicFileAttributes attrs) {
+                    try { Files.deleteIfExists(file); } catch (Exception ignored) {}
+                    return java.nio.file.FileVisitResult.CONTINUE;
+                }
+                @Override
+                public java.nio.file.FileVisitResult postVisitDirectory(Path d, java.io.IOException exc) {
+                    try { Files.deleteIfExists(d); } catch (Exception ignored) {}
+                    return java.nio.file.FileVisitResult.CONTINUE;
+                }
+            });
+        } catch (Exception ignored) {}
     }
 
     private String errorResult(String filePath, String message) {

--- a/mateclaw-server/src/main/java/vip/mate/tool/builtin/GitTool.java
+++ b/mateclaw-server/src/main/java/vip/mate/tool/builtin/GitTool.java
@@ -1,0 +1,375 @@
+package vip.mate.tool.builtin;
+
+import cn.hutool.json.JSONObject;
+import cn.hutool.json.JSONUtil;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.ai.tool.annotation.Tool;
+import org.springframework.ai.tool.annotation.ToolParam;
+import org.springframework.stereotype.Component;
+
+import java.io.BufferedReader;
+import java.io.InputStreamReader;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+import java.util.stream.Collectors;
+
+/**
+ * 内置工具：Git 操作
+ * <p>
+ * 封装常用 git 命令：status / diff / log / branch / add / commit / push / pull。
+ * 只读操作（status/diff/log/branch）安全；写操作（add/commit/push/pull）
+ * 标记 {@code @ConcurrencyUnsafe} 并走 ToolGuard 审批。
+ * 路径边界由 {@code WorkspacePathGuard} 强制，仅允许在 workspace 内执行。
+ *
+ * @author MateClaw Team
+ */
+@Slf4j
+@Component
+public class GitTool {
+
+    private static final int DEFAULT_TIMEOUT_SECONDS = 60;
+    private static final int MAX_OUTPUT_BYTES = 20_000;
+
+    @Tool(description = """
+            Run a git command in the workspace repository. Supports read-only \
+            operations (status, diff, log, branch, show) and write operations \
+            (add, commit, push, pull, checkout). Write operations require user \
+            approval. Returns structured JSON with stdout, stderr, exitCode. \
+            The repo path is resolved against the workspace boundary.""")
+    public String git(
+            @ToolParam(description = "Git subcommand and args, e.g. 'status', 'diff --stat', 'log --oneline -10', 'add .', 'commit -m \"msg\"'") String gitCommand,
+            @ToolParam(description = "Repository directory (absolute or relative). Defaults to workspace root", required = false) String repoPath,
+            @ToolParam(description = "Timeout in seconds, default 60", required = false) Integer timeoutSeconds) {
+
+        JSONObject result = new JSONObject();
+
+        try {
+            if (gitCommand == null || gitCommand.isBlank()) {
+                result.set("error", true);
+                result.set("message", "Git command is required");
+                return JSONUtil.toJsonPrettyStr(result);
+            }
+
+            // Only allow known-safe subcommands
+            String trimmed = gitCommand.trim();
+            String subcommand = trimmed.split("\\s+")[0].toLowerCase();
+            if (!isAllowedSubcommand(subcommand)) {
+                result.set("error", true);
+                result.set("message", "Disallowed git subcommand: " + subcommand
+                        + ". Allowed: status, diff, log, branch, show, add, commit, push, pull, checkout, restore, stash, fetch, reset, rebase, merge, blame");
+                return JSONUtil.toJsonPrettyStr(result);
+            }
+
+            boolean isWrite = isWriteSubcommand(subcommand);
+
+            Path repo;
+            try {
+                String dir = (repoPath == null || repoPath.isBlank()) ? "." : repoPath;
+                repo = vip.mate.tool.guard.WorkspacePathGuard.validatePath(dir);
+            } catch (IllegalArgumentException e) {
+                result.set("error", true);
+                result.set("message", e.getMessage());
+                return JSONUtil.toJsonPrettyStr(result);
+            }
+
+            if (!Files.exists(repo)) {
+                result.set("error", true);
+                result.set("message", "Repository path does not exist: " + repo);
+                return JSONUtil.toJsonPrettyStr(result);
+            }
+
+            int timeout = (timeoutSeconds != null && timeoutSeconds > 0)
+                    ? Math.min(timeoutSeconds, 300)
+                    : DEFAULT_TIMEOUT_SECONDS;
+
+            String gitExe = System.getProperty("os.name", "").toLowerCase().contains("win")
+                    ? "git.exe" : "git";
+
+            // Split the command into subcommand + args for ProcessBuilder.
+            // ProcessBuilder does NOT do shell parsing — passing "commit -m msg"
+            // as a single arg would make git treat the whole string as the
+            // subcommand name. We must split on whitespace and pass each token
+            // as a separate argument.
+            // NOTE: this is safe because the subcommand has already been
+            // validated against the allowlist, and we use structured args
+            // (not shell concatenation) so shell metacharacters are inert.
+            List<String> cmdArgs = splitGitCommand(trimmed);
+            List<String> fullCmd = new ArrayList<>();
+            fullCmd.add(gitExe);
+            fullCmd.add("-C");
+            fullCmd.add(repo.toString());
+            fullCmd.addAll(cmdArgs);
+
+            ProcessBuilder pb = new ProcessBuilder(fullCmd);
+            pb.redirectErrorStream(false);
+            pb.directory(repo.toFile());
+
+            Process process = pb.start();
+
+            String stdout = readStream(process.getInputStream());
+            String stderr = readStream(process.getErrorStream());
+
+            boolean finished = process.waitFor(timeout, TimeUnit.SECONDS);
+            if (!finished) {
+                process.destroyForcibly();
+                result.set("error", true);
+                result.set("message", "Git command timed out after " + timeout + "s");
+                result.set("stdout", truncate(stdout, MAX_OUTPUT_BYTES));
+                result.set("stderr", truncate(stderr, MAX_OUTPUT_BYTES));
+                return JSONUtil.toJsonPrettyStr(result);
+            }
+
+            int exitCode = process.exitValue();
+            result.set("command", "git " + trimmed);
+            result.set("repo", repo.toString().replace('\\', '/'));
+            result.set("exitCode", exitCode);
+            result.set("stdout", truncate(stdout, MAX_OUTPUT_BYTES));
+            result.set("stderr", truncate(stderr, MAX_OUTPUT_BYTES));
+            result.set("write", isWrite);
+            result.set("message", exitCode == 0 ? "Success" : "Git exited with code " + exitCode);
+
+            if (exitCode != 0 && !stderr.isBlank()) {
+                result.set("error", true);
+            }
+
+        } catch (Exception e) {
+            log.error("[Git] Failed: {}", e.getMessage(), e);
+            result.set("error", true);
+            result.set("message", e.getMessage());
+        }
+
+        return JSONUtil.toJsonPrettyStr(result);
+    }
+
+    @vip.mate.tool.ConcurrencyUnsafe("git write operations mutate the repository state")
+    @Tool(description = """
+            Stage and commit changes in one step. Equivalent to \
+            'git add <paths>' followed by 'git commit -m <message>'. \
+            Requires user approval. Use git() for other write operations.""")
+    public String git_commit(
+            @ToolParam(description = "Commit message") String message,
+            @ToolParam(description = "Files to stage (space-separated paths), or '.' for all changes") String paths,
+            @ToolParam(description = "Repository directory, defaults to workspace root", required = false) String repoPath) {
+
+        JSONObject result = new JSONObject();
+
+        try {
+            if (message == null || message.isBlank()) {
+                result.set("error", true);
+                result.set("message", "Commit message is required");
+                return JSONUtil.toJsonPrettyStr(result);
+            }
+            if (paths == null || paths.isBlank()) {
+                paths = ".";
+            }
+
+            // Run git add — pass paths as structured args, not string concatenation,
+            // to prevent command injection via malicious path values.
+            // Sanitize paths: reject shell metacharacters that could break out
+            // of the git argument list.
+            String safePaths = sanitizeGitPaths(paths);
+            if (safePaths == null) {
+                result.set("error", true);
+                result.set("message", "Invalid paths: contains forbidden characters. Only alphanumeric, /, \\, ., -, _, *, and spaces are allowed.");
+                return JSONUtil.toJsonPrettyStr(result);
+            }
+            String addResult = git("add " + safePaths, repoPath, 30);
+            JSONObject addJson = JSONUtil.parseObj(addResult);
+            if (addJson.getBool("error", false)) {
+                return addResult;
+            }
+
+            // Run git commit — pass message as a single structured arg to
+            // prevent command injection. The message is NOT shell-escaped;
+            // instead we use ProcessBuilder's structured args so the message
+            // is passed to git as-is, with no shell interpretation.
+            // We execute git commit directly (not via git()) so the message
+            // is never shell-parsed.
+            String safeMessage = sanitizeCommitMessage(message);
+            if (safeMessage == null) {
+                result.set("error", true);
+                result.set("message", "Invalid commit message: contains forbidden characters (newlines, quotes, backticks, $, ;, |, &, >, <).");
+                return JSONUtil.toJsonPrettyStr(result);
+            }
+
+            String repoDir = (repoPath == null || repoPath.isBlank()) ? null : repoPath;
+            String commitResult = executeGitDirect(repoDir, 60, "commit", "-m", safeMessage);
+            return commitResult;
+
+        } catch (Exception e) {
+            result.set("error", true);
+            result.set("message", e.getMessage());
+        }
+
+        return JSONUtil.toJsonPrettyStr(result);
+    }
+
+    private boolean isAllowedSubcommand(String sub) {
+        return sub.matches("status|diff|log|branch|show|add|commit|push|pull|checkout|restore|stash|fetch|reset|rebase|merge|blame|rev-parse|config|remote|tag");
+    }
+
+    private boolean isWriteSubcommand(String sub) {
+        return sub.matches("add|commit|push|pull|checkout|restore|stash|fetch|reset|rebase|merge|tag|config");
+    }
+
+    private String readStream(java.io.InputStream is) {
+        return new BufferedReader(new InputStreamReader(is, StandardCharsets.UTF_8))
+                .lines()
+                .collect(Collectors.joining("\n"));
+    }
+
+    private String truncate(String s, int max) {
+        if (s == null) return "";
+        return s.length() <= max ? s : s.substring(0, max) + "\n... (truncated)";
+    }
+
+    /**
+     * Split a git command string into tokens, respecting double-quoted substrings.
+     * e.g. {@code commit -m "hello world"} → {@code ["commit", "-m", "hello world"]}
+     * <p>
+     * ProcessBuilder does NOT do shell parsing, so we must tokenize here.
+     * Quotes are stripped from the resulting tokens.
+     */
+    private List<String> splitGitCommand(String cmd) {
+        List<String> tokens = new ArrayList<>();
+        StringBuilder current = new StringBuilder();
+        boolean inQuotes = false;
+        for (int i = 0; i < cmd.length(); i++) {
+            char c = cmd.charAt(i);
+            if (c == '"') {
+                inQuotes = !inQuotes;
+            } else if (Character.isWhitespace(c) && !inQuotes) {
+                if (!current.isEmpty()) {
+                    tokens.add(current.toString());
+                    current.setLength(0);
+                }
+            } else {
+                current.append(c);
+            }
+        }
+        if (!current.isEmpty()) {
+            tokens.add(current.toString());
+        }
+        return tokens;
+    }
+
+    /**
+     * Sanitize git paths — only allow safe path characters.
+     *
+     * @return the sanitized path string, or {@code null} if forbidden characters are found
+     */
+    private String sanitizeGitPaths(String paths) {
+        if (paths == null || paths.isBlank()) return ".";
+        for (char c : paths.toCharArray()) {
+            if (!(Character.isLetterOrDigit(c) || c == '/' || c == '\\' || c == '.'
+                    || c == '-' || c == '_' || c == '*' || c == ' ' || c == ':')) {
+                return null;
+            }
+        }
+        return paths.trim();
+    }
+
+    /**
+     * Sanitize commit message — reject characters that could cause issues
+     * (log injection, newline splitting) even though ProcessBuilder uses
+     * structured args (no shell).
+     *
+     * @return the sanitized message, or {@code null} if forbidden characters are found
+     */
+    private String sanitizeCommitMessage(String message) {
+        if (message == null || message.isBlank()) return null;
+        for (char c : message.toCharArray()) {
+            if (c == '\n' || c == '\r' || c == '`' || c == '$' || c == ';'
+                    || c == '|' || c == '&' || c == '>' || c == '<') {
+                return null;
+            }
+        }
+        return message;
+    }
+
+    /**
+     * Execute git directly with structured args — bypasses {@link #git}'s
+     * string-based interface to avoid any shell parsing of user-provided
+     * content (e.g. commit messages that may contain quotes or spaces).
+     *
+     * @param repoPath       repository directory (relative or absolute), or {@code null} for workspace root
+     * @param timeoutSeconds timeout in seconds
+     * @param gitArgs        git subcommand and arguments as separate tokens
+     * @return structured JSON result
+     */
+    private String executeGitDirect(String repoPath, int timeoutSeconds, String... gitArgs) {
+        JSONObject result = new JSONObject();
+        try {
+            Path repo;
+            try {
+                String dir = (repoPath == null || repoPath.isBlank()) ? "." : repoPath;
+                repo = vip.mate.tool.guard.WorkspacePathGuard.validatePath(dir);
+            } catch (IllegalArgumentException e) {
+                result.set("error", true);
+                result.set("message", e.getMessage());
+                return JSONUtil.toJsonPrettyStr(result);
+            }
+
+            if (!Files.exists(repo)) {
+                result.set("error", true);
+                result.set("message", "Repository path does not exist: " + repo);
+                return JSONUtil.toJsonPrettyStr(result);
+            }
+
+            int timeout = (timeoutSeconds > 0) ? Math.min(timeoutSeconds, 300) : DEFAULT_TIMEOUT_SECONDS;
+
+            String gitExe = System.getProperty("os.name", "").toLowerCase().contains("win")
+                    ? "git.exe" : "git";
+
+            List<String> fullCmd = new ArrayList<>();
+            fullCmd.add(gitExe);
+            fullCmd.add("-C");
+            fullCmd.add(repo.toString());
+            for (String arg : gitArgs) {
+                fullCmd.add(arg);
+            }
+
+            ProcessBuilder pb = new ProcessBuilder(fullCmd);
+            pb.redirectErrorStream(false);
+            pb.directory(repo.toFile());
+
+            Process process = pb.start();
+            String stdout = readStream(process.getInputStream());
+            String stderr = readStream(process.getErrorStream());
+
+            boolean finished = process.waitFor(timeout, TimeUnit.SECONDS);
+            if (!finished) {
+                process.destroyForcibly();
+                result.set("error", true);
+                result.set("message", "Git command timed out after " + timeout + "s");
+                result.set("stdout", truncate(stdout, MAX_OUTPUT_BYTES));
+                result.set("stderr", truncate(stderr, MAX_OUTPUT_BYTES));
+                return JSONUtil.toJsonPrettyStr(result);
+            }
+
+            int exitCode = process.exitValue();
+            result.set("command", "git " + String.join(" ", gitArgs));
+            result.set("repo", repo.toString().replace('\\', '/'));
+            result.set("exitCode", exitCode);
+            result.set("stdout", truncate(stdout, MAX_OUTPUT_BYTES));
+            result.set("stderr", truncate(stderr, MAX_OUTPUT_BYTES));
+            result.set("write", true);
+            result.set("message", exitCode == 0 ? "Success" : "Git exited with code " + exitCode);
+
+            if (exitCode != 0 && !stderr.isBlank()) {
+                result.set("error", true);
+            }
+
+        } catch (Exception e) {
+            log.error("[Git] executeGitDirect failed: {}", e.getMessage(), e);
+            result.set("error", true);
+            result.set("message", e.getMessage());
+        }
+
+        return JSONUtil.toJsonPrettyStr(result);
+    }
+}

--- a/mateclaw-server/src/main/java/vip/mate/tool/builtin/GlobTool.java
+++ b/mateclaw-server/src/main/java/vip/mate/tool/builtin/GlobTool.java
@@ -1,0 +1,141 @@
+package vip.mate.tool.builtin;
+
+import cn.hutool.json.JSONArray;
+import cn.hutool.json.JSONObject;
+import cn.hutool.json.JSONUtil;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.ai.tool.annotation.Tool;
+import org.springframework.ai.tool.annotation.ToolParam;
+import org.springframework.stereotype.Component;
+
+import java.io.IOException;
+import java.nio.file.*;
+import java.nio.file.attribute.BasicFileAttributes;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.stream.Stream;
+
+/**
+ * 内置工具：文件名模式匹配（glob 搜索）
+ * <p>
+ * 使用 Java PathMatcher 的 glob 语法在指定目录下递归查找匹配文件。
+ * 不需要 shell out，路径边界由 {@code WorkspacePathGuard} 强制。
+ *
+ * @author MateClaw Team
+ */
+@Slf4j
+@Component
+public class GlobTool {
+
+    private static final int MAX_RESULTS = 500;
+
+    @Tool(description = """
+            Find files by glob pattern. Uses standard glob syntax:
+            ** for recursive directories, * for single-level wildcard,
+            ? for single char, {a,b} for alternation.
+            Examples: '**/*.java' (all java files), 'src/**/*.ts' (ts under src),
+            '**/*.{js,ts}' (js or ts). Returns matching file paths (relative to
+            searchPath when possible). No shell execution — pure Java PathMatcher.
+            Supports offset pagination for large result sets. When truncated,
+            use offset=nextOffset to get the next page.""")
+    public String glob(
+            @ToolParam(description = "Glob pattern, e.g. '**/*.java' or 'src/**/*.ts'") String pattern,
+            @ToolParam(description = "Base directory to search in (absolute or relative). Defaults to workspace root", required = false) String searchPath,
+            @ToolParam(description = "Skip the first N matches (pagination). Use nextOffset from a truncated result to get the next page. Default 0", required = false) Integer offset) {
+
+        JSONObject result = new JSONObject();
+
+        try {
+            if (pattern == null || pattern.isBlank()) {
+                result.set("error", true);
+                result.set("message", "Pattern is required");
+                return JSONUtil.toJsonPrettyStr(result);
+            }
+
+            Path base;
+            try {
+                String baseDir = (searchPath == null || searchPath.isBlank()) ? "." : searchPath;
+                base = vip.mate.tool.guard.WorkspacePathGuard.validatePath(baseDir);
+            } catch (IllegalArgumentException e) {
+                result.set("error", true);
+                result.set("message", e.getMessage());
+                return JSONUtil.toJsonPrettyStr(result);
+            }
+
+            if (!Files.exists(base)) {
+                result.set("error", true);
+                result.set("message", "Search path does not exist: " + base);
+                return JSONUtil.toJsonPrettyStr(result);
+            }
+
+            int skip = (offset != null && offset > 0) ? offset : 0;
+
+            PathMatcher matcher = FileSystems.getDefault().getPathMatcher("glob:" + pattern);
+            JSONArray matches = new JSONArray();
+            int[] totalScanned = {0};
+            int[] totalMatched = {0};
+
+            if (Files.isDirectory(base)) {
+                Files.walkFileTree(base, new SimpleFileVisitor<>() {
+                    @Override
+                    public FileVisitResult visitFile(Path file, BasicFileAttributes attrs) {
+                        Path relative = base.relativize(file);
+                        if (matcher.matches(relative) || matcher.matches(file.getFileName())) {
+                            totalMatched[0]++;
+                            if (totalMatched[0] > skip && matches.size() < MAX_RESULTS) {
+                                matches.add(file.toString().replace('\\', '/'));
+                            }
+                        }
+                        // Keep walking even after filling the page so we know the true total
+                        return FileVisitResult.CONTINUE;
+                    }
+
+                    @Override
+                    public FileVisitResult preVisitDirectory(Path dir, BasicFileAttributes attrs) {
+                        // Skip hidden / build output dirs
+                        String name = dir.getFileName().toString();
+                        if (name.equals(".git") || name.equals("node_modules") || name.equals("target")
+                                || name.equals("build") || name.equals("dist") || name.equals(".idea")) {
+                            return FileVisitResult.SKIP_SUBTREE;
+                        }
+                        return FileVisitResult.CONTINUE;
+                    }
+                });
+            } else {
+                // base is a single file — match against filename
+                if (matcher.matches(base.getFileName())) {
+                    totalMatched[0] = 1;
+                    if (skip < 1) {
+                        matches.add(base.toString().replace('\\', '/'));
+                    }
+                }
+            }
+
+            result.set("pattern", pattern);
+            result.set("searchPath", base.toString().replace('\\', '/'));
+            result.set("matches", matches);
+            result.set("count", matches.size());
+            result.set("offset", skip);
+            if (skip + matches.size() < totalMatched[0]) {
+                result.set("truncated", true);
+                result.set("totalMatches", totalMatched[0]);
+                result.set("nextOffset", skip + MAX_RESULTS);
+                result.set("message", "Showing " + (skip + 1) + "-" + (skip + matches.size())
+                        + " of " + totalMatched[0] + " matches. Use offset=" + (skip + MAX_RESULTS)
+                        + " for the next page");
+            } else {
+                result.set("truncated", false);
+                result.set("totalMatches", totalMatched[0]);
+                result.set("message", "Found " + totalMatched[0] + " file(s), showing "
+                        + (skip + 1) + "-" + (skip + matches.size()));
+            }
+
+        } catch (Exception e) {
+            log.error("[Glob] Failed: {}", e.getMessage(), e);
+            result.set("error", true);
+            result.set("message", e.getMessage());
+        }
+
+        return JSONUtil.toJsonPrettyStr(result);
+    }
+}

--- a/mateclaw-server/src/main/java/vip/mate/tool/builtin/GrepTool.java
+++ b/mateclaw-server/src/main/java/vip/mate/tool/builtin/GrepTool.java
@@ -1,0 +1,238 @@
+package vip.mate.tool.builtin;
+
+import cn.hutool.json.JSONArray;
+import cn.hutool.json.JSONObject;
+import cn.hutool.json.JSONUtil;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.ai.tool.annotation.Tool;
+import org.springframework.ai.tool.annotation.ToolParam;
+import org.springframework.stereotype.Component;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.*;
+import java.nio.file.attribute.BasicFileAttributes;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.regex.Pattern;
+import java.util.regex.PatternSyntaxException;
+
+/**
+ * 内置工具：文件内容正则搜索（grep）
+ * <p>
+ * 在指定目录下递归搜索文件内容，支持正则表达式。
+ * 返回匹配行及行号、文件路径。不需要 shell out。
+ * 路径边界由 {@code WorkspacePathGuard} 强制。
+ *
+ * @author MateClaw Team
+ */
+@Slf4j
+@Component
+public class GrepTool {
+
+    private static final int MAX_MATCHES = 500;
+    private static final long MAX_FILE_SIZE = 5 * 1024 * 1024; // 5MB
+
+    private static final List<String> SKIP_DIRS = List.of(
+            ".git", "node_modules", "target", "build", "dist", ".idea", ".vs", "out"
+    );
+
+    private static final List<String> TEXT_EXTENSIONS = List.of(
+            ".java", ".kt", ".scala", ".groovy", ".js", ".ts", ".tsx", ".jsx",
+            ".py", ".rb", ".go", ".rs", ".c", ".cpp", ".h", ".hpp", ".cs",
+            ".php", ".swift", ".m", ".mm", ".sh", ".bash", ".zsh", ".ps1",
+            ".yml", ".yaml", ".json", ".xml", ".html", ".css", ".scss", ".less",
+            ".md", ".txt", ".sql", ".properties", ".conf", ".cfg", ".ini",
+            ".toml", ".gradle", ".vue", ".svelte", ".dart", ".lua", ".r",
+            ".jl", ".ex", ".exs", ".clj", ".cljs", ".edn", ".vim", ".el"
+    );
+
+    @Tool(description = """
+            Search file contents with regex (like grep/ripgrep). Recursively \
+            searches a directory, returning matching lines with line numbers \
+            and file paths. Uses Java regex syntax. Only searches text files, \
+            skips binary/build output. Returns structured JSON with matches \
+            array. Supports offset pagination for large result sets. When \
+            truncated, use offset=nextOffset to get the next page. No shell \
+            execution — pure Java.""")
+    public String grep(
+            @ToolParam(description = "Java regex pattern to search for") String pattern,
+            @ToolParam(description = "Directory to search in (absolute or relative). Defaults to workspace root", required = false) String searchPath,
+            @ToolParam(description = "File extension filter, e.g. '.java' or '.ts'. Omit to search all text files", required = false) String fileExtension,
+            @ToolParam(description = "Case-insensitive search, default false", required = false) Boolean ignoreCase,
+            @ToolParam(description = "Also return lines before match (context), default 0", required = false) Integer beforeContext,
+            @ToolParam(description = "Also return lines after match (context), default 0", required = false) Integer afterContext,
+            @ToolParam(description = "Skip the first N matches (pagination). Use nextOffset from a truncated result to get the next page. Default 0", required = false) Integer offset) {
+
+        JSONObject result = new JSONObject();
+
+        try {
+            if (pattern == null || pattern.isBlank()) {
+                result.set("error", true);
+                result.set("message", "Pattern is required");
+                return JSONUtil.toJsonPrettyStr(result);
+            }
+
+            Pattern regex;
+            try {
+                int flags = (ignoreCase != null && ignoreCase) ? Pattern.CASE_INSENSITIVE : 0;
+                regex = Pattern.compile(pattern, flags);
+            } catch (PatternSyntaxException e) {
+                result.set("error", true);
+                result.set("message", "Invalid regex: " + e.getMessage());
+                return JSONUtil.toJsonPrettyStr(result);
+            }
+
+            Path base;
+            try {
+                String baseDir = (searchPath == null || searchPath.isBlank()) ? "." : searchPath;
+                base = vip.mate.tool.guard.WorkspacePathGuard.validatePath(baseDir);
+            } catch (IllegalArgumentException e) {
+                result.set("error", true);
+                result.set("message", e.getMessage());
+                return JSONUtil.toJsonPrettyStr(result);
+            }
+
+            if (!Files.exists(base)) {
+                result.set("error", true);
+                result.set("message", "Search path does not exist: " + base);
+                return JSONUtil.toJsonPrettyStr(result);
+            }
+
+            String extFilter = (fileExtension != null && !fileExtension.isBlank())
+                    ? (fileExtension.startsWith(".") ? fileExtension : "." + fileExtension)
+                    : null;
+
+            int before = (beforeContext != null && beforeContext > 0) ? Math.min(beforeContext, 10) : 0;
+            int after = (afterContext != null && afterContext > 0) ? Math.min(afterContext, 10) : 0;
+            int skip = (offset != null && offset > 0) ? offset : 0;
+
+            JSONArray matches = new JSONArray();
+            int[] totalScanned = {0};
+            int[] totalMatches = {0};
+            int[] filesWithMatches = {0};
+
+            List<Path> filesToSearch = new ArrayList<>();
+            collectTextFiles(base, extFilter, filesToSearch);
+
+            for (Path file : filesToSearch) {
+                if (totalMatches[0] >= MAX_MATCHES) break;
+
+                try {
+                    List<String> lines = Files.readAllLines(file, StandardCharsets.UTF_8);
+                    boolean fileHadMatch = false;
+
+                    for (int lineIdx = 0; lineIdx < lines.size(); lineIdx++) {
+                        if (totalMatches[0] >= MAX_MATCHES) break;
+
+                        String line = lines.get(lineIdx);
+                        if (regex.matcher(line).find()) {
+                            totalScanned[0]++;
+                            if (totalScanned[0] <= skip) continue;
+
+                            JSONObject match = new JSONObject();
+                            match.set("file", file.toString().replace('\\', '/'));
+                            match.set("lineNumber", lineIdx + 1);
+                            match.set("line", line);
+
+                            if (before > 0) {
+                                JSONArray beforeLines = new JSONArray();
+                                for (int b = Math.max(0, lineIdx - before); b < lineIdx; b++) {
+                                    JSONObject bl = new JSONObject();
+                                    bl.set("lineNumber", b + 1);
+                                    bl.set("line", lines.get(b));
+                                    beforeLines.add(bl);
+                                }
+                                match.set("before", beforeLines);
+                            }
+
+                            if (after > 0) {
+                                JSONArray afterLines = new JSONArray();
+                                for (int a = lineIdx + 1; a <= Math.min(lines.size() - 1, lineIdx + after); a++) {
+                                    JSONObject al = new JSONObject();
+                                    al.set("lineNumber", a + 1);
+                                    al.set("line", lines.get(a));
+                                    afterLines.add(al);
+                                }
+                                match.set("after", afterLines);
+                            }
+
+                            matches.add(match);
+                            totalMatches[0]++;
+                            fileHadMatch = true;
+                        }
+                    }
+
+                    if (fileHadMatch) filesWithMatches[0]++;
+
+                } catch (IOException e) {
+                    log.debug("[Grep] Could not read {}: {}", file, e.getMessage());
+                }
+            }
+
+            result.set("pattern", pattern);
+            result.set("searchPath", base.toString().replace('\\', '/'));
+            result.set("matches", matches);
+            result.set("matchCount", matches.size());
+            result.set("filesWithMatches", filesWithMatches[0]);
+            result.set("offset", skip);
+            if (totalScanned[0] >= MAX_MATCHES + skip) {
+                result.set("truncated", true);
+                result.set("nextOffset", skip + MAX_MATCHES);
+                result.set("message", "Showing matches " + (skip + 1) + "-" + (skip + matches.size())
+                        + ". Use offset=" + (skip + MAX_MATCHES) + " for the next page");
+            } else {
+                result.set("truncated", false);
+                result.set("message", "Found " + (skip + matches.size()) + " match(es) in " + filesWithMatches[0] + " file(s)");
+            }
+
+        } catch (Exception e) {
+            log.error("[Grep] Failed: {}", e.getMessage(), e);
+            result.set("error", true);
+            result.set("message", e.getMessage());
+        }
+
+        return JSONUtil.toJsonPrettyStr(result);
+    }
+
+    private void collectTextFiles(Path base, String extFilter, List<Path> out) throws IOException {
+        if (Files.isRegularFile(base)) {
+            out.add(base);
+            return;
+        }
+
+        Files.walkFileTree(base, new SimpleFileVisitor<>() {
+            @Override
+            public FileVisitResult preVisitDirectory(Path dir, BasicFileAttributes attrs) {
+                String name = dir.getFileName().toString();
+                if (SKIP_DIRS.contains(name)) {
+                    return FileVisitResult.SKIP_SUBTREE;
+                }
+                return FileVisitResult.CONTINUE;
+            }
+
+            @Override
+            public FileVisitResult visitFile(Path file, BasicFileAttributes attrs) {
+                if (attrs.size() > MAX_FILE_SIZE) return FileVisitResult.CONTINUE;
+
+                String name = file.getFileName().toString();
+                String lowerName = name.toLowerCase();
+
+                if (extFilter != null) {
+                    if (lowerName.endsWith(extFilter.toLowerCase())) {
+                        out.add(file);
+                    }
+                } else {
+                    // Check known text extensions
+                    for (String ext : TEXT_EXTENSIONS) {
+                        if (lowerName.endsWith(ext)) {
+                            out.add(file);
+                            break;
+                        }
+                    }
+                }
+                return FileVisitResult.CONTINUE;
+            }
+        });
+    }
+}

--- a/mateclaw-server/src/main/java/vip/mate/tool/builtin/ReadFileTool.java
+++ b/mateclaw-server/src/main/java/vip/mate/tool/builtin/ReadFileTool.java
@@ -35,8 +35,8 @@ public class ReadFileTool {
 
     private final vip.mate.i18n.I18nService i18n;
 
-    private static final int DEFAULT_MAX_LINES = 1000;
-    private static final int MAX_OUTPUT_BYTES = 30 * 1024; // 30KB
+    private static final int DEFAULT_MAX_LINES = 2000;
+    private static final int MAX_OUTPUT_BYTES = 100 * 1024; // 100KB
 
     /**
      * 二进制文档扩展名集合 - 这些文件不应使用 read_file 读取

--- a/mateclaw-server/src/main/java/vip/mate/tool/builtin/ShellExecuteTool.java
+++ b/mateclaw-server/src/main/java/vip/mate/tool/builtin/ShellExecuteTool.java
@@ -47,7 +47,7 @@ public class ShellExecuteTool {
     private final GeneratedFileCache generatedFileCache;
 
     private static final int DEFAULT_TIMEOUT_SECONDS = 60;
-    private static final int MAX_OUTPUT_BYTES = 10_000;
+    private static final int MAX_OUTPUT_BYTES = 50_000;
     private static final boolean IS_WINDOWS = System.getProperty("os.name", "")
             .toLowerCase(Locale.ROOT).contains("win");
 
@@ -90,6 +90,7 @@ public class ShellExecuteTool {
 
         Path stdoutFile = null;
         Path stderrFile = null;
+        boolean spillHandled = false;
 
         try {
             // 处理命令中的嵌入换行符（LLM 生成的 JSON 解码后可能包含真实换行）
@@ -122,8 +123,10 @@ public class ShellExecuteTool {
                 killProcessTree(process);
                 log.warn("[ShellExecute] Command timed out after {}s: {}", timeout, truncateForLog(command));
                 result.set("exitCode", -1);
-                result.set("stdout", readFileTruncated(stdoutFile, MAX_OUTPUT_BYTES));
-                result.set("stderr", readFileTruncated(stderrFile, MAX_OUTPUT_BYTES));
+                String stdout = readFileTruncated(stdoutFile, MAX_OUTPUT_BYTES);
+                String stderr = readFileTruncated(stderrFile, MAX_OUTPUT_BYTES);
+                attachSpillPaths(result, stdoutFile, stderrFile, stdout, stderr, true);
+                spillHandled = true;
                 result.set("timedOut", true);
                 result.set("message", i18n.msg("tool.shell.error.timeout", timeout));
             } else {
@@ -133,18 +136,17 @@ public class ShellExecuteTool {
                 log.info("[ShellExecute] Command completed: exitCode={}, stdout={}chars, stderr={}chars",
                         exitCode, stdout.length(), stderr.length());
                 result.set("exitCode", exitCode);
-                result.set("stdout", stdout);
-                result.set("stderr", stderr);
+                attachSpillPaths(result, stdoutFile, stderrFile, stdout, stderr, false);
+                spillHandled = true;
                 result.set("timedOut", false);
-                // Surface files the command wrote as one-click downloads (same path
-                // as execute_code). A single newline-joined string, not a JSON array,
-                // so the link-extraction regex captures the clean filename.
                 java.nio.file.Path workingDir = vip.mate.tool.guard.WorkspacePathGuard.getWorkingDirectory(ctx);
                 List<String> fileLinks = WorkspaceArtifactSurfacer.collect(generatedFileCache, workingDir, runStart, ctx);
                 if (!fileLinks.isEmpty()) {
                     result.set("generatedFiles", String.join("\n", fileLinks));
                 }
             }
+
+            return JSONUtil.toJsonPrettyStr(result);
 
         } catch (Exception e) {
             log.error("[ShellExecute] Command execution failed: {}", e.getMessage(), e);
@@ -154,11 +156,78 @@ public class ShellExecuteTool {
             result.set("timedOut", false);
             result.set("error", e.getMessage());
         } finally {
-            deleteQuietly(stdoutFile);
-            deleteQuietly(stderrFile);
+            // Only clean up temp files that attachSpillPaths didn't claim.
+            // If spillHandled is true, attachSpillPaths already deleted
+            // non-truncated files and kept truncated ones (for the agent to
+            // read via read_file). Deleting them here would break the
+            // spill-to-disk pattern. If spillHandled is false (exception
+            // before attachSpillPaths, or attachSpillPaths itself threw),
+            // both temp files are orphans and must be cleaned up.
+            if (!spillHandled) {
+                deleteQuietly(stdoutFile);
+                deleteQuietly(stderrFile);
+            }
         }
 
         return JSONUtil.toJsonPrettyStr(result);
+    }
+
+    /**
+     * Attach stdout/stderr to the result JSON. When the output exceeds
+     * MAX_OUTPUT_BYTES, the full output is preserved in the temp file and
+     * its path is returned so the agent can read_file it in chunks — this
+     * is the spill-to-disk pattern: truncated preview in-context + full
+     * output accessible via read_file.
+     *
+     * <p>Temp files are only kept when the output was truncated; otherwise
+     * they are deleted as before to avoid disk buildup.
+     */
+    private void attachSpillPaths(JSONObject result, Path stdoutFile, Path stderrFile,
+                                    String stdoutPreview, String stderrPreview, boolean timedOut) {
+        long stdoutSize = fileSizeSafe(stdoutFile);
+        long stderrSize = fileSizeSafe(stderrFile);
+        boolean stdoutTruncated = stdoutSize > MAX_OUTPUT_BYTES;
+        boolean stderrTruncated = stderrSize > MAX_OUTPUT_BYTES;
+
+        result.set("stdout", stdoutPreview);
+        result.set("stderr", stderrPreview);
+
+        if (stdoutTruncated) {
+            result.set("stdoutFile", stdoutFile.toString().replace('\\', '/'));
+            result.set("stdoutTruncated", true);
+            result.set("stdoutFullSize", stdoutSize);
+        } else {
+            deleteQuietly(stdoutFile);
+        }
+
+        if (stderrTruncated) {
+            result.set("stderrFile", stderrFile.toString().replace('\\', '/'));
+            result.set("stderrTruncated", true);
+            result.set("stderrFullSize", stderrSize);
+        } else {
+            deleteQuietly(stderrFile);
+        }
+
+        if (stdoutTruncated || stderrTruncated) {
+            JSONObject spill = new JSONObject();
+            if (stdoutTruncated) spill.set("stdoutFile", stdoutFile.toString().replace('\\', '/'));
+            if (stderrTruncated) spill.set("stderrFile", stderrFile.toString().replace('\\', '/'));
+            result.set("spill", spill);
+            result.set("message", "Output exceeded " + (MAX_OUTPUT_BYTES / 1024) + "KB. "
+                    + "Full output written to spill file(s). To process the complete output: "
+                    + "(1) use read_file with the spill file path and offset/limit to page through it, "
+                    + "or (2) use grep to search within the spill file for specific patterns, "
+                    + "or (3) delegate to a subagent to analyze the full output. "
+                    + "Do NOT try to read the entire spill file in one call — use pagination.");
+        }
+    }
+
+    private static long fileSizeSafe(Path file) {
+        try {
+            return file != null && Files.exists(file) ? Files.size(file) : 0;
+        } catch (IOException e) {
+            return 0;
+        }
     }
 
     /**

--- a/mateclaw-server/src/main/java/vip/mate/tool/guard/WorkspacePathGuard.java
+++ b/mateclaw-server/src/main/java/vip/mate/tool/guard/WorkspacePathGuard.java
@@ -26,6 +26,9 @@ import java.util.regex.Pattern;
 @Slf4j
 public final class WorkspacePathGuard {
 
+    private static final boolean IS_WINDOWS =
+            System.getProperty("os.name", "").toLowerCase(java.util.Locale.ROOT).contains("win");
+
     private WorkspacePathGuard() {}
 
     /**
@@ -204,7 +207,7 @@ public final class WorkspacePathGuard {
      * transition window.
      */
     public static Path validatePath(String rawPath, @Nullable ToolContext ctx) {
-        Path normalized = Paths.get(rawPath).toAbsolutePath().normalize();
+        Path normalized = Paths.get(normalizeGitBashDrivePath(rawPath)).toAbsolutePath().normalize();
 
         String basePath = resolveBasePath(ctx);
         if (basePath == null || basePath.isBlank()) {
@@ -333,7 +336,7 @@ public final class WorkspacePathGuard {
         if (rawPath == null || rawPath.isBlank()) return null;
         Path root = basePathToRoot(basePath);
         if (root == null) return null;
-        Path normalized = Paths.get(rawPath).toAbsolutePath().normalize();
+        Path normalized = Paths.get(normalizeGitBashDrivePath(rawPath)).toAbsolutePath().normalize();
         if (!normalized.startsWith(root) && !isExempt(normalized)) {
             return "Path is outside workspace boundary: " + normalized + ", allowed root: " + root;
         }
@@ -350,6 +353,36 @@ public final class WorkspacePathGuard {
             return Paths.get(basePath).toAbsolutePath().normalize();
         }
         return defaultRoot;
+    }
+
+    /**
+     * On Windows, convert Git Bash / MSYS2 style drive paths to Windows paths.
+     * <p>
+     * Git Bash uses {@code /<drive-letter>/...} to represent
+     * {@code <drive-letter>:\...}. For example {@code /e/work/mateclaw}
+     * → {@code E:\work\mateclaw}. Java's {@link Paths#get} on Windows
+     * interprets {@code /e/work/mateclaw} as a path relative to the
+     * current drive root (e.g. {@code C:\e\work\mateclaw}), which fails
+     * the workspace boundary check.
+     * <p>
+     * On non-Windows, returns the path unchanged.
+     *
+     * @param path a path string that may be in Git Bash drive notation
+     * @return the equivalent Windows path, or the original on non-Windows
+     */
+    private static String normalizeGitBashDrivePath(String path) {
+        if (!IS_WINDOWS || path == null || path.length() < 2) return path;
+        // /e/... → E:\...
+        if (path.charAt(0) == '/' && Character.isLetter(path.charAt(1))) {
+            if (path.length() >= 3 && path.charAt(2) == '/') {
+                return Character.toUpperCase(path.charAt(1)) + ":\\" + path.substring(3);
+            }
+            // /e (bare drive root, no trailing path)
+            if (path.length() == 2) {
+                return Character.toUpperCase(path.charAt(1)) + ":\\";
+            }
+        }
+        return path;
     }
 
     private static void scanShellCommand(String command, @Nullable Path root) {
@@ -398,7 +431,7 @@ public final class WorkspacePathGuard {
             }
             Path normalized;
             try {
-                normalized = Paths.get(candidate).normalize();
+                normalized = Paths.get(normalizeGitBashDrivePath(candidate)).normalize();
             } catch (Exception ex) {
                 // Unparseable as a path — leave it alone, not our concern.
                 continue;

--- a/mateclaw-server/src/main/resources/application.yml
+++ b/mateclaw-server/src/main/resources/application.yml
@@ -291,9 +291,9 @@ mate:
     graph:
       observation:
         # 与 GraphObservationProperties.java 默认值对齐，参考 openclaw token-budget 设计
-        max-single-observation-chars: 16000
-        max-total-observation-chars: 200000
-        large-result-threshold: 32000
+        max-single-observation-chars: 64000
+        max-total-observation-chars: 300000
+        large-result-threshold: 64000
         min-rounds-for-summarize: 25
         head-ratio: 0.4
         truncation-marker: "\n\n...[TRUNCATED: %d chars total, middle omitted. Do NOT infer or fabricate omitted content; retrieve the full data (e.g. read_file) or tell the user the result is incomplete.]...\n\n"
@@ -312,8 +312,8 @@ mate:
     # cap. Per-turn aggregate caps the combined size across one tool turn.
     tool-result:
       enabled: true
-      per-result-threshold-chars: 8000    # aligned with executor hard cap; > this size → spill, ≤ → inline verbatim
-      per-turn-budget-chars: 32000        # headroom for multi-tool turns
+      per-result-threshold-chars: 32000    # aligned with executor hard cap; > this size → spill, ≤ → inline verbatim
+      per-turn-budget-chars: 64000        # headroom for multi-tool turns
       preview-head-chars: 800
       excluded-tool-inline-chars: 2500
       storage-base-dir: ""

--- a/mateclaw-server/src/main/resources/db/data-kingbase-en.sql
+++ b/mateclaw-server/src/main/resources/db/data-kingbase-en.sql
@@ -580,6 +580,26 @@ INSERT INTO mate_tool (id, name, display_name, description, tool_type, bean_name
 VALUES (1000000022, 'PdfRenderTool', 'PDF Render', 'Render Markdown into a final-form .pdf and return a one-time download link. Two backends (LibreOffice subprocess preferred, OpenPDF + Flying Saucer fallback); supports YAML frontmatter for cover / page header / page footer.', 'builtin', 'pdfRenderTool', '📄', TRUE, TRUE, NOW(), NOW(), 0)
 ON CONFLICT (id) DO UPDATE SET name=EXCLUDED.name, display_name=EXCLUDED.display_name, description=EXCLUDED.description, tool_type=EXCLUDED.tool_type, bean_name=EXCLUDED.bean_name, icon=EXCLUDED.icon, enabled=EXCLUDED.enabled, builtin=EXCLUDED.builtin, update_time=EXCLUDED.update_time, deleted=EXCLUDED.deleted;
 
+-- Built-in tool: Apply Patch (unified diff editor with uniqueness check)
+INSERT INTO mate_tool (id, name, display_name, description, tool_type, bean_name, icon, enabled, builtin, create_time, update_time, deleted)
+VALUES (1000000030, 'ApplyPatchTool', 'Apply Patch', 'Apply a unified diff patch to files. Each hunk context must uniquely match or the entire patch is rejected. Safer than edit_file for multi-location edits.', 'builtin', 'applyPatchTool', '🔧', TRUE, TRUE, NOW(), NOW(), 0)
+ON CONFLICT (id) DO UPDATE SET name=EXCLUDED.name, display_name=EXCLUDED.display_name, description=EXCLUDED.description, tool_type=EXCLUDED.tool_type, bean_name=EXCLUDED.bean_name, icon=EXCLUDED.icon, enabled=EXCLUDED.enabled, builtin=EXCLUDED.builtin, update_time=EXCLUDED.update_time, deleted=EXCLUDED.deleted;
+
+-- Built-in tool: Glob (file name pattern matching, pure Java PathMatcher)
+INSERT INTO mate_tool (id, name, display_name, description, tool_type, bean_name, icon, enabled, builtin, create_time, update_time, deleted)
+VALUES (1000000031, 'GlobTool', 'Glob', 'Find files by glob pattern (e.g. **/*.java). Pure Java PathMatcher, no shell execution, skips .git/node_modules/target.', 'builtin', 'globTool', '🔍', TRUE, TRUE, NOW(), NOW(), 0)
+ON CONFLICT (id) DO UPDATE SET name=EXCLUDED.name, display_name=EXCLUDED.display_name, description=EXCLUDED.description, tool_type=EXCLUDED.tool_type, bean_name=EXCLUDED.bean_name, icon=EXCLUDED.icon, enabled=EXCLUDED.enabled, builtin=EXCLUDED.builtin, update_time=EXCLUDED.update_time, deleted=EXCLUDED.deleted;
+
+-- Built-in tool: Grep (regex content search, pure Java)
+INSERT INTO mate_tool (id, name, display_name, description, tool_type, bean_name, icon, enabled, builtin, create_time, update_time, deleted)
+VALUES (1000000032, 'GrepTool', 'Grep', 'Search file contents with regex. Returns matching lines with line numbers. Supports context lines, extension filter, case-insensitive. Pure Java, no shell.', 'builtin', 'grepTool', '🔎', TRUE, TRUE, NOW(), NOW(), 0)
+ON CONFLICT (id) DO UPDATE SET name=EXCLUDED.name, display_name=EXCLUDED.display_name, description=EXCLUDED.description, tool_type=EXCLUDED.tool_type, bean_name=EXCLUDED.bean_name, icon=EXCLUDED.icon, enabled=EXCLUDED.enabled, builtin=EXCLUDED.builtin, update_time=EXCLUDED.update_time, deleted=EXCLUDED.deleted;
+
+-- Built-in tool: Git (git operations, reads safe, writes go through ToolGuard)
+INSERT INTO mate_tool (id, name, display_name, description, tool_type, bean_name, icon, enabled, builtin, create_time, update_time, deleted)
+VALUES (1000000033, 'GitTool', 'Git', 'Run git commands (status/diff/log/branch/add/commit/push/pull). Read operations safe, write operations trigger approval.', 'builtin', 'gitTool', ' Git', TRUE, TRUE, NOW(), NOW(), 0)
+ON CONFLICT (id) DO UPDATE SET name=EXCLUDED.name, display_name=EXCLUDED.display_name, description=EXCLUDED.description, tool_type=EXCLUDED.tool_type, bean_name=EXCLUDED.bean_name, icon=EXCLUDED.icon, enabled=EXCLUDED.enabled, builtin=EXCLUDED.builtin, update_time=EXCLUDED.update_time, deleted=EXCLUDED.deleted;
+
 -- Example MCP Server: Filesystem (see MateClaw docs mcpServers.filesystem)
 INSERT INTO mate_mcp_server (id, name, description, transport, url, headers_json, command, args_json, env_json, cwd,
     enabled, connect_timeout_seconds, read_timeout_seconds, last_status, last_error,

--- a/mateclaw-server/src/main/resources/db/data-kingbase-zh.sql
+++ b/mateclaw-server/src/main/resources/db/data-kingbase-zh.sql
@@ -575,6 +575,26 @@ INSERT INTO mate_tool (id, name, display_name, description, tool_type, bean_name
 VALUES (1000000022, 'PdfRenderTool', 'PDF 渲染', '将 Markdown 渲染为最终交付形态的 .pdf 并返回一次性下载链接。双 backend 自动切换（优先 LibreOffice，不可用时回落到进程内 OpenPDF + Flying Saucer）；通过 YAML frontmatter 控制封面、页眉、页脚。', 'builtin', 'pdfRenderTool', '📄', TRUE, TRUE, NOW(), NOW(), 0)
 ON CONFLICT (id) DO UPDATE SET name=EXCLUDED.name, display_name=EXCLUDED.display_name, description=EXCLUDED.description, tool_type=EXCLUDED.tool_type, bean_name=EXCLUDED.bean_name, icon=EXCLUDED.icon, enabled=EXCLUDED.enabled, builtin=EXCLUDED.builtin, update_time=EXCLUDED.update_time, deleted=EXCLUDED.deleted;
 
+-- 内置工具：补丁应用（unified diff 编辑，多 hunk 唯一匹配校验）
+INSERT INTO mate_tool (id, name, display_name, description, tool_type, bean_name, icon, enabled, builtin, create_time, update_time, deleted)
+VALUES (1000000030, 'ApplyPatchTool', '补丁应用', '应用 unified diff 补丁到文件。每个 hunk 的上下文必须唯一匹配，否则整体回滚。比 edit_file 更适合多位置编辑。', 'builtin', 'applyPatchTool', '🔧', TRUE, TRUE, NOW(), NOW(), 0)
+ON CONFLICT (id) DO UPDATE SET name=EXCLUDED.name, display_name=EXCLUDED.display_name, description=EXCLUDED.description, tool_type=EXCLUDED.tool_type, bean_name=EXCLUDED.bean_name, icon=EXCLUDED.icon, enabled=EXCLUDED.enabled, builtin=EXCLUDED.builtin, update_time=EXCLUDED.update_time, deleted=EXCLUDED.deleted;
+
+-- 内置工具：文件搜索（glob 模式匹配，纯 Java PathMatcher）
+INSERT INTO mate_tool (id, name, display_name, description, tool_type, bean_name, icon, enabled, builtin, create_time, update_time, deleted)
+VALUES (1000000031, 'GlobTool', '文件搜索', '按 glob 模式递归查找文件（如 **/*.java）。纯 Java PathMatcher，不执行 shell，自动跳过 .git/node_modules/target。', 'builtin', 'globTool', '🔍', TRUE, TRUE, NOW(), NOW(), 0)
+ON CONFLICT (id) DO UPDATE SET name=EXCLUDED.name, display_name=EXCLUDED.display_name, description=EXCLUDED.description, tool_type=EXCLUDED.tool_type, bean_name=EXCLUDED.bean_name, icon=EXCLUDED.icon, enabled=EXCLUDED.enabled, builtin=EXCLUDED.builtin, update_time=EXCLUDED.update_time, deleted=EXCLUDED.deleted;
+
+-- 内置工具：内容搜索（正则表达式，纯 Java 实现）
+INSERT INTO mate_tool (id, name, display_name, description, tool_type, bean_name, icon, enabled, builtin, create_time, update_time, deleted)
+VALUES (1000000032, 'GrepTool', '内容搜索', '按正则表达式递归搜索文件内容，返回匹配行及行号。支持上下文行、扩展名过滤、大小写忽略。纯 Java 实现，不执行 shell。', 'builtin', 'grepTool', '🔎', TRUE, TRUE, NOW(), NOW(), 0)
+ON CONFLICT (id) DO UPDATE SET name=EXCLUDED.name, display_name=EXCLUDED.display_name, description=EXCLUDED.description, tool_type=EXCLUDED.tool_type, bean_name=EXCLUDED.bean_name, icon=EXCLUDED.icon, enabled=EXCLUDED.enabled, builtin=EXCLUDED.builtin, update_time=EXCLUDED.update_time, deleted=EXCLUDED.deleted;
+
+-- 内置工具：Git 操作（只读安全，写操作走 ToolGuard 审批）
+INSERT INTO mate_tool (id, name, display_name, description, tool_type, bean_name, icon, enabled, builtin, create_time, update_time, deleted)
+VALUES (1000000033, 'GitTool', 'Git 操作', '执行 git 命令（status/diff/log/branch/add/commit/push/pull 等）。只读操作安全，写操作触发审批确认。', 'builtin', 'gitTool', ' Git', TRUE, TRUE, NOW(), NOW(), 0)
+ON CONFLICT (id) DO UPDATE SET name=EXCLUDED.name, display_name=EXCLUDED.display_name, description=EXCLUDED.description, tool_type=EXCLUDED.tool_type, bean_name=EXCLUDED.bean_name, icon=EXCLUDED.icon, enabled=EXCLUDED.enabled, builtin=EXCLUDED.builtin, update_time=EXCLUDED.update_time, deleted=EXCLUDED.deleted;
+
 -- 示例 MCP Server：Filesystem（参考 MateClaw 文档中的 mcpServers.filesystem）
 INSERT INTO mate_mcp_server (
     id, name, description, transport, url, headers_json, command, args_json, env_json, cwd,

--- a/mateclaw-server/src/main/resources/db/data-mysql-en.sql
+++ b/mateclaw-server/src/main/resources/db/data-mysql-en.sql
@@ -594,6 +594,26 @@ INSERT INTO mate_tool (id, name, display_name, description, tool_type, bean_name
 VALUES (1000000023, 'CodeExecuteTool', 'Code Execute', 'Execute a snippet of code (python, bash, or node) that the agent writes on the fly. Lets a documentation-only skill be acted on by running the code its instructions describe. Dangerous operations trigger approval.', 'builtin', 'codeExecuteTool', '🧑‍💻', TRUE, TRUE, NOW(), NOW(), 0)
 ON DUPLICATE KEY UPDATE name=VALUES(name), display_name=VALUES(display_name), description=VALUES(description), tool_type=VALUES(tool_type), bean_name=VALUES(bean_name), icon=VALUES(icon), enabled=VALUES(enabled), builtin=VALUES(builtin), update_time=VALUES(update_time), deleted=VALUES(deleted);
 
+-- Built-in tool: Apply Patch (unified diff editor with uniqueness check)
+INSERT INTO mate_tool (id, name, display_name, description, tool_type, bean_name, icon, enabled, builtin, create_time, update_time, deleted)
+VALUES (1000000030, 'ApplyPatchTool', 'Apply Patch', 'Apply a unified diff patch to files. Each hunk context must uniquely match or the entire patch is rejected. Safer than edit_file for multi-location edits.', 'builtin', 'applyPatchTool', '🔧', TRUE, TRUE, NOW(), NOW(), 0)
+ON DUPLICATE KEY UPDATE name=VALUES(name), display_name=VALUES(display_name), description=VALUES(description), tool_type=VALUES(tool_type), bean_name=VALUES(bean_name), icon=VALUES(icon), enabled=VALUES(enabled), builtin=VALUES(builtin), update_time=VALUES(update_time), deleted=VALUES(deleted);
+
+-- Built-in tool: Glob (file name pattern matching, pure Java PathMatcher)
+INSERT INTO mate_tool (id, name, display_name, description, tool_type, bean_name, icon, enabled, builtin, create_time, update_time, deleted)
+VALUES (1000000031, 'GlobTool', 'Glob', 'Find files by glob pattern (e.g. **/*.java). Pure Java PathMatcher, no shell execution, skips .git/node_modules/target.', 'builtin', 'globTool', '🔍', TRUE, TRUE, NOW(), NOW(), 0)
+ON DUPLICATE KEY UPDATE name=VALUES(name), display_name=VALUES(display_name), description=VALUES(description), tool_type=VALUES(tool_type), bean_name=VALUES(bean_name), icon=VALUES(icon), enabled=VALUES(enabled), builtin=VALUES(builtin), update_time=VALUES(update_time), deleted=VALUES(deleted);
+
+-- Built-in tool: Grep (regex content search, pure Java)
+INSERT INTO mate_tool (id, name, display_name, description, tool_type, bean_name, icon, enabled, builtin, create_time, update_time, deleted)
+VALUES (1000000032, 'GrepTool', 'Grep', 'Search file contents with regex. Returns matching lines with line numbers. Supports context lines, extension filter, case-insensitive. Pure Java, no shell.', 'builtin', 'grepTool', '🔎', TRUE, TRUE, NOW(), NOW(), 0)
+ON DUPLICATE KEY UPDATE name=VALUES(name), display_name=VALUES(display_name), description=VALUES(description), tool_type=VALUES(tool_type), bean_name=VALUES(bean_name), icon=VALUES(icon), enabled=VALUES(enabled), builtin=VALUES(builtin), update_time=VALUES(update_time), deleted=VALUES(deleted);
+
+-- Built-in tool: Git (git operations, reads safe, writes go through ToolGuard)
+INSERT INTO mate_tool (id, name, display_name, description, tool_type, bean_name, icon, enabled, builtin, create_time, update_time, deleted)
+VALUES (1000000033, 'GitTool', 'Git', 'Run git commands (status/diff/log/branch/add/commit/push/pull). Read operations safe, write operations trigger approval.', 'builtin', 'gitTool', ' Git', TRUE, TRUE, NOW(), NOW(), 0)
+ON DUPLICATE KEY UPDATE name=VALUES(name), display_name=VALUES(display_name), description=VALUES(description), tool_type=VALUES(tool_type), bean_name=VALUES(bean_name), icon=VALUES(icon), enabled=VALUES(enabled), builtin=VALUES(builtin), update_time=VALUES(update_time), deleted=VALUES(deleted);
+
 -- Example MCP Server: Filesystem (see MateClaw docs mcpServers.filesystem)
 INSERT INTO mate_mcp_server (id, name, description, transport, url, headers_json, command, args_json, env_json, cwd,
     enabled, connect_timeout_seconds, read_timeout_seconds, last_status, last_error,

--- a/mateclaw-server/src/main/resources/db/data-mysql-zh.sql
+++ b/mateclaw-server/src/main/resources/db/data-mysql-zh.sql
@@ -589,6 +589,26 @@ INSERT INTO mate_tool (id, name, display_name, description, tool_type, bean_name
 VALUES (1000000023, 'CodeExecuteTool', '代码执行', '运行 Agent 临场编写的代码片段（python / bash / node）。让只有 SKILL.md 描述、无脚本的技能也能被执行——Agent 按说明生成并运行代码。危险操作会触发审批确认。', 'builtin', 'codeExecuteTool', '🧑‍💻', TRUE, TRUE, NOW(), NOW(), 0)
 ON DUPLICATE KEY UPDATE name=VALUES(name), display_name=VALUES(display_name), description=VALUES(description), tool_type=VALUES(tool_type), bean_name=VALUES(bean_name), icon=VALUES(icon), enabled=VALUES(enabled), builtin=VALUES(builtin), update_time=VALUES(update_time), deleted=VALUES(deleted);
 
+-- 内置工具：补丁应用（unified diff 编辑，多 hunk 唯一匹配校验）
+INSERT INTO mate_tool (id, name, display_name, description, tool_type, bean_name, icon, enabled, builtin, create_time, update_time, deleted)
+VALUES (1000000030, 'ApplyPatchTool', '补丁应用', '应用 unified diff 补丁到文件。每个 hunk 的上下文必须唯一匹配，否则整体回滚。比 edit_file 更适合多位置编辑。', 'builtin', 'applyPatchTool', '🔧', TRUE, TRUE, NOW(), NOW(), 0)
+ON DUPLICATE KEY UPDATE name=VALUES(name), display_name=VALUES(display_name), description=VALUES(description), tool_type=VALUES(tool_type), bean_name=VALUES(bean_name), icon=VALUES(icon), enabled=VALUES(enabled), builtin=VALUES(builtin), update_time=VALUES(update_time), deleted=VALUES(deleted);
+
+-- 内置工具：文件搜索（glob 模式匹配，纯 Java PathMatcher）
+INSERT INTO mate_tool (id, name, display_name, description, tool_type, bean_name, icon, enabled, builtin, create_time, update_time, deleted)
+VALUES (1000000031, 'GlobTool', '文件搜索', '按 glob 模式递归查找文件（如 **/*.java）。纯 Java PathMatcher，不执行 shell，自动跳过 .git/node_modules/target。', 'builtin', 'globTool', '🔍', TRUE, TRUE, NOW(), NOW(), 0)
+ON DUPLICATE KEY UPDATE name=VALUES(name), display_name=VALUES(display_name), description=VALUES(description), tool_type=VALUES(tool_type), bean_name=VALUES(bean_name), icon=VALUES(icon), enabled=VALUES(enabled), builtin=VALUES(builtin), update_time=VALUES(update_time), deleted=VALUES(deleted);
+
+-- 内置工具：内容搜索（正则表达式，纯 Java 实现）
+INSERT INTO mate_tool (id, name, display_name, description, tool_type, bean_name, icon, enabled, builtin, create_time, update_time, deleted)
+VALUES (1000000032, 'GrepTool', '内容搜索', '按正则表达式递归搜索文件内容，返回匹配行及行号。支持上下文行、扩展名过滤、大小写忽略。纯 Java 实现，不执行 shell。', 'builtin', 'grepTool', '🔎', TRUE, TRUE, NOW(), NOW(), 0)
+ON DUPLICATE KEY UPDATE name=VALUES(name), display_name=VALUES(display_name), description=VALUES(description), tool_type=VALUES(tool_type), bean_name=VALUES(bean_name), icon=VALUES(icon), enabled=VALUES(enabled), builtin=VALUES(builtin), update_time=VALUES(update_time), deleted=VALUES(deleted);
+
+-- 内置工具：Git 操作（只读安全，写操作走 ToolGuard 审批）
+INSERT INTO mate_tool (id, name, display_name, description, tool_type, bean_name, icon, enabled, builtin, create_time, update_time, deleted)
+VALUES (1000000033, 'GitTool', 'Git 操作', '执行 git 命令（status/diff/log/branch/add/commit/push/pull 等）。只读操作安全，写操作触发审批确认。', 'builtin', 'gitTool', ' Git', TRUE, TRUE, NOW(), NOW(), 0)
+ON DUPLICATE KEY UPDATE name=VALUES(name), display_name=VALUES(display_name), description=VALUES(description), tool_type=VALUES(tool_type), bean_name=VALUES(bean_name), icon=VALUES(icon), enabled=VALUES(enabled), builtin=VALUES(builtin), update_time=VALUES(update_time), deleted=VALUES(deleted);
+
 -- 示例 MCP Server：Filesystem（参考 MateClaw 文档中的 mcpServers.filesystem）
 INSERT INTO mate_mcp_server (
     id, name, description, transport, url, headers_json, command, args_json, env_json, cwd,

--- a/mateclaw-server/src/main/resources/db/data-zh.sql
+++ b/mateclaw-server/src/main/resources/db/data-zh.sql
@@ -543,6 +543,26 @@ MERGE INTO mate_tool (id, name, display_name, description, tool_type, bean_name,
 KEY (id)
 VALUES (1000000023, 'CodeExecuteTool', '代码执行', '运行 Agent 临场编写的代码片段（python / bash / node）。让只有 SKILL.md 描述、无脚本的技能也能被执行——Agent 按说明生成并运行代码。危险操作会触发审批确认。', 'builtin', 'codeExecuteTool', '🧑‍💻', TRUE, TRUE, NOW(), NOW(), 0);
 
+-- 内置工具：补丁应用（unified diff 编辑，多 hunk 唯一匹配校验）
+MERGE INTO mate_tool (id, name, display_name, description, tool_type, bean_name, icon, enabled, builtin, create_time, update_time, deleted)
+KEY (id)
+VALUES (1000000030, 'ApplyPatchTool', '补丁应用', '应用 unified diff 补丁到文件。每个 hunk 的上下文必须唯一匹配，否则整体回滚。比 edit_file 更适合多位置编辑。', 'builtin', 'applyPatchTool', '🔧', TRUE, TRUE, NOW(), NOW(), 0);
+
+-- 内置工具：文件搜索（glob 模式匹配，纯 Java PathMatcher）
+MERGE INTO mate_tool (id, name, display_name, description, tool_type, bean_name, icon, enabled, builtin, create_time, update_time, deleted)
+KEY (id)
+VALUES (1000000031, 'GlobTool', '文件搜索', '按 glob 模式递归查找文件（如 **/*.java）。纯 Java PathMatcher，不执行 shell，自动跳过 .git/node_modules/target。', 'builtin', 'globTool', '🔍', TRUE, TRUE, NOW(), NOW(), 0);
+
+-- 内置工具：内容搜索（正则表达式，纯 Java 实现）
+MERGE INTO mate_tool (id, name, display_name, description, tool_type, bean_name, icon, enabled, builtin, create_time, update_time, deleted)
+KEY (id)
+VALUES (1000000032, 'GrepTool', '内容搜索', '按正则表达式递归搜索文件内容，返回匹配行及行号。支持上下文行、扩展名过滤、大小写忽略。纯 Java 实现，不执行 shell。', 'builtin', 'grepTool', '🔎', TRUE, TRUE, NOW(), NOW(), 0);
+
+-- 内置工具：Git 操作（只读安全，写操作走 ToolGuard 审批）
+MERGE INTO mate_tool (id, name, display_name, description, tool_type, bean_name, icon, enabled, builtin, create_time, update_time, deleted)
+KEY (id)
+VALUES (1000000033, 'GitTool', 'Git 操作', '执行 git 命令（status/diff/log/branch/add/commit/push/pull 等）。只读操作安全，写操作触发审批确认。', 'builtin', 'gitTool', ' Git', TRUE, TRUE, NOW(), NOW(), 0);
+
 -- 示例 MCP Server：Filesystem（参考 MateClaw 文档中的 mcpServers.filesystem）
 MERGE INTO mate_mcp_server (
     id, name, description, transport, url, headers_json, command, args_json, env_json, cwd,

--- a/mateclaw-server/src/main/resources/db/migration/h2/V166__coding_tools_seed.sql
+++ b/mateclaw-server/src/main/resources/db/migration/h2/V166__coding_tools_seed.sql
@@ -1,0 +1,24 @@
+-- V100: Seed coding tools into mate_tool so they appear in the UI picker
+-- and can be pre-bound via agent template defaultToolNames.
+-- Tools: apply_patch, glob, grep, git, git_commit
+-- Ids: 1000000030..1000000034 (1000000027 was the last used id)
+
+-- ApplyPatchTool — unified diff editor with uniqueness check
+MERGE INTO mate_tool (id, name, display_name, description, tool_type, bean_name, icon, enabled, builtin, create_time, update_time, deleted)
+KEY (id)
+VALUES (1000000030, 'ApplyPatchTool', '补丁应用', '应用 unified diff 补丁到文件。每个 hunk 的上下文必须唯一匹配，否则整体回滚。比 edit_file 更适合多位置编辑。', 'builtin', 'applyPatchTool', '🔧', TRUE, TRUE, NOW(), NOW(), 0);
+
+-- GlobTool — file name pattern matching (no shell-out)
+MERGE INTO mate_tool (id, name, display_name, description, tool_type, bean_name, icon, enabled, builtin, create_time, update_time, deleted)
+KEY (id)
+VALUES (1000000031, 'GlobTool', '文件搜索', '按 glob 模式递归查找文件（如 **/*.java）。纯 Java PathMatcher，不执行 shell，自动跳过 .git/node_modules/target。', 'builtin', 'globTool', '🔍', TRUE, TRUE, NOW(), NOW(), 0);
+
+-- GrepTool — regex content search (no shell-out)
+MERGE INTO mate_tool (id, name, display_name, description, tool_type, bean_name, icon, enabled, builtin, create_time, update_time, deleted)
+KEY (id)
+VALUES (1000000032, 'GrepTool', '内容搜索', '按正则表达式递归搜索文件内容，返回匹配行及行号。支持上下文行、扩展名过滤、大小写忽略。纯 Java 实现，不执行 shell。', 'builtin', 'grepTool', '🔎', TRUE, TRUE, NOW(), NOW(), 0);
+
+-- GitTool — git operations (read + write, writes go through ToolGuard)
+MERGE INTO mate_tool (id, name, display_name, description, tool_type, bean_name, icon, enabled, builtin, create_time, update_time, deleted)
+KEY (id)
+VALUES (1000000033, 'GitTool', 'Git 操作', '执行 git 命令（status/diff/log/branch/add/commit/push/pull 等）。只读操作安全，写操作触发审批确认。', 'builtin', 'gitTool', ' Git', TRUE, TRUE, NOW(), NOW(), 0);

--- a/mateclaw-server/src/main/resources/db/migration/kingbase/V166__coding_tools_seed.sql
+++ b/mateclaw-server/src/main/resources/db/migration/kingbase/V166__coding_tools_seed.sql
@@ -1,0 +1,24 @@
+-- V100: Seed coding tools into mate_tool so they appear in the UI picker
+-- and can be pre-bound via agent template defaultToolNames.
+-- Tools: apply_patch, glob, grep, git, git_commit
+-- Ids: 1000000030..1000000033 (1000000027 was the last used id)
+
+-- ApplyPatchTool — unified diff editor with uniqueness check
+INSERT INTO mate_tool (id, name, display_name, description, tool_type, bean_name, icon, enabled, builtin, create_time, update_time, deleted)
+VALUES (1000000030, 'ApplyPatchTool', '补丁应用', '应用 unified diff 补丁到文件。每个 hunk 的上下文必须唯一匹配，否则整体回滚。比 edit_file 更适合多位置编辑。', 'builtin', 'applyPatchTool', '🔧', TRUE, TRUE, NOW(), NOW(), 0)
+ON CONFLICT (id) DO UPDATE SET name=EXCLUDED.name, display_name=EXCLUDED.display_name, description=EXCLUDED.description, tool_type=EXCLUDED.tool_type, bean_name=EXCLUDED.bean_name, icon=EXCLUDED.icon, enabled=EXCLUDED.enabled, builtin=EXCLUDED.builtin, update_time=EXCLUDED.update_time, deleted=EXCLUDED.deleted;
+
+-- GlobTool — file name pattern matching (no shell-out)
+INSERT INTO mate_tool (id, name, display_name, description, tool_type, bean_name, icon, enabled, builtin, create_time, update_time, deleted)
+VALUES (1000000031, 'GlobTool', '文件搜索', '按 glob 模式递归查找文件（如 **/*.java）。纯 Java PathMatcher，不执行 shell，自动跳过 .git/node_modules/target。', 'builtin', 'globTool', '🔍', TRUE, TRUE, NOW(), NOW(), 0)
+ON CONFLICT (id) DO UPDATE SET name=EXCLUDED.name, display_name=EXCLUDED.display_name, description=EXCLUDED.description, tool_type=EXCLUDED.tool_type, bean_name=EXCLUDED.bean_name, icon=EXCLUDED.icon, enabled=EXCLUDED.enabled, builtin=EXCLUDED.builtin, update_time=EXCLUDED.update_time, deleted=EXCLUDED.deleted;
+
+-- GrepTool — regex content search (no shell-out)
+INSERT INTO mate_tool (id, name, display_name, description, tool_type, bean_name, icon, enabled, builtin, create_time, update_time, deleted)
+VALUES (1000000032, 'GrepTool', '内容搜索', '按正则表达式递归搜索文件内容，返回匹配行及行号。支持上下文行、扩展名过滤、大小写忽略。纯 Java 实现，不执行 shell。', 'builtin', 'grepTool', '🔎', TRUE, TRUE, NOW(), NOW(), 0)
+ON CONFLICT (id) DO UPDATE SET name=EXCLUDED.name, display_name=EXCLUDED.display_name, description=EXCLUDED.description, tool_type=EXCLUDED.tool_type, bean_name=EXCLUDED.bean_name, icon=EXCLUDED.icon, enabled=EXCLUDED.enabled, builtin=EXCLUDED.builtin, update_time=EXCLUDED.update_time, deleted=EXCLUDED.deleted;
+
+-- GitTool — git operations (read + write, writes go through ToolGuard)
+INSERT INTO mate_tool (id, name, display_name, description, tool_type, bean_name, icon, enabled, builtin, create_time, update_time, deleted)
+VALUES (1000000033, 'GitTool', 'Git 操作', '执行 git 命令（status/diff/log/branch/add/commit/push/pull 等）。只读操作安全，写操作触发审批确认。', 'builtin', 'gitTool', ' Git', TRUE, TRUE, NOW(), NOW(), 0)
+ON CONFLICT (id) DO UPDATE SET name=EXCLUDED.name, display_name=EXCLUDED.display_name, description=EXCLUDED.description, tool_type=EXCLUDED.tool_type, bean_name=EXCLUDED.bean_name, icon=EXCLUDED.icon, enabled=EXCLUDED.enabled, builtin=EXCLUDED.builtin, update_time=EXCLUDED.update_time, deleted=EXCLUDED.deleted;

--- a/mateclaw-server/src/main/resources/db/migration/mysql/V166__coding_tools_seed.sql
+++ b/mateclaw-server/src/main/resources/db/migration/mysql/V166__coding_tools_seed.sql
@@ -1,0 +1,24 @@
+-- V100: Seed coding tools into mate_tool so they appear in the UI picker
+-- and can be pre-bound via agent template defaultToolNames.
+-- Tools: apply_patch, glob, grep, git, git_commit
+-- Ids: 1000000030..1000000033 (1000000027 was the last used id)
+
+-- ApplyPatchTool — unified diff editor with uniqueness check
+INSERT INTO mate_tool (id, name, display_name, description, tool_type, bean_name, icon, enabled, builtin, create_time, update_time, deleted)
+VALUES (1000000030, 'ApplyPatchTool', '补丁应用', '应用 unified diff 补丁到文件。每个 hunk 的上下文必须唯一匹配，否则整体回滚。比 edit_file 更适合多位置编辑。', 'builtin', 'applyPatchTool', '🔧', TRUE, TRUE, NOW(), NOW(), 0)
+ON DUPLICATE KEY UPDATE name=VALUES(name), display_name=VALUES(display_name), description=VALUES(description), tool_type=VALUES(tool_type), bean_name=VALUES(bean_name), icon=VALUES(icon), enabled=VALUES(enabled), builtin=VALUES(builtin), update_time=VALUES(update_time), deleted=VALUES(deleted);
+
+-- GlobTool — file name pattern matching (no shell-out)
+INSERT INTO mate_tool (id, name, display_name, description, tool_type, bean_name, icon, enabled, builtin, create_time, update_time, deleted)
+VALUES (1000000031, 'GlobTool', '文件搜索', '按 glob 模式递归查找文件（如 **/*.java）。纯 Java PathMatcher，不执行 shell，自动跳过 .git/node_modules/target。', 'builtin', 'globTool', '🔍', TRUE, TRUE, NOW(), NOW(), 0)
+ON DUPLICATE KEY UPDATE name=VALUES(name), display_name=VALUES(display_name), description=VALUES(description), tool_type=VALUES(tool_type), bean_name=VALUES(bean_name), icon=VALUES(icon), enabled=VALUES(enabled), builtin=VALUES(builtin), update_time=VALUES(update_time), deleted=VALUES(deleted);
+
+-- GrepTool — regex content search (no shell-out)
+INSERT INTO mate_tool (id, name, display_name, description, tool_type, bean_name, icon, enabled, builtin, create_time, update_time, deleted)
+VALUES (1000000032, 'GrepTool', '内容搜索', '按正则表达式递归搜索文件内容，返回匹配行及行号。支持上下文行、扩展名过滤、大小写忽略。纯 Java 实现，不执行 shell。', 'builtin', 'grepTool', '🔎', TRUE, TRUE, NOW(), NOW(), 0)
+ON DUPLICATE KEY UPDATE name=VALUES(name), display_name=VALUES(display_name), description=VALUES(description), tool_type=VALUES(tool_type), bean_name=VALUES(bean_name), icon=VALUES(icon), enabled=VALUES(enabled), builtin=VALUES(builtin), update_time=VALUES(update_time), deleted=VALUES(deleted);
+
+-- GitTool — git operations (read + write, writes go through ToolGuard)
+INSERT INTO mate_tool (id, name, display_name, description, tool_type, bean_name, icon, enabled, builtin, create_time, update_time, deleted)
+VALUES (1000000033, 'GitTool', 'Git 操作', '执行 git 命令（status/diff/log/branch/add/commit/push/pull 等）。只读操作安全，写操作触发审批确认。', 'builtin', 'gitTool', ' Git', TRUE, TRUE, NOW(), NOW(), 0)
+ON DUPLICATE KEY UPDATE name=VALUES(name), display_name=VALUES(display_name), description=VALUES(description), tool_type=VALUES(tool_type), bean_name=VALUES(bean_name), icon=VALUES(icon), enabled=VALUES(enabled), builtin=VALUES(builtin), update_time=VALUES(update_time), deleted=VALUES(deleted);

--- a/mateclaw-server/src/main/resources/skill-templates/opencode-coding-helper/template.json
+++ b/mateclaw-server/src/main/resources/skill-templates/opencode-coding-helper/template.json
@@ -1,0 +1,44 @@
+{
+  "id": "opencode-coding-helper",
+  "name": "OpenCode Coding Helper",
+  "nameZh": "OpenCode 编程助手",
+  "category": "system",
+  "type": "acp",
+  "icon": "🟢",
+  "description": "Delegate coding tasks to OpenCode via ACP. OpenCode is a multi-model coding agent that supports OpenAI, Anthropic, Google, and local models. Requires the opencode endpoint to be enabled in Settings ▸ ACP Endpoints (with opencode CLI installed and configured).",
+  "descriptionZh": "通过 ACP 协议把编码任务委派给 OpenCode。OpenCode 是多模型编码 agent，支持 OpenAI、Anthropic、Google 及本地模型。需先在 Settings ▸ ACP Endpoints 启用 opencode 端点，并安装配置 opencode CLI。",
+  "fields": [
+    {
+      "key": "skill_name",
+      "label": "Skill 标识 (slug)",
+      "type": "text",
+      "required": true,
+      "placeholder": "team-opencode-helper",
+      "hint": "小写英文 + 连字符；最终生成的工具名为 acp_opencode_<slug>_prompt"
+    },
+    {
+      "key": "display_name_zh",
+      "label": "显示名 (中文)",
+      "type": "text",
+      "required": false,
+      "placeholder": "团队 OpenCode 编程助手"
+    },
+    {
+      "key": "system_prefix",
+      "label": "上游 system 前缀",
+      "type": "textarea",
+      "required": false,
+      "default": "你正在为一个 Java 21 + Spring Boot 3.5 + Vue 3 + TypeScript 的 monorepo 工作。所有代码注释用英文，commit message 用中英混合。",
+      "hint": "每次发送给 OpenCode 之前会自动拼到用户输入前面，用来固化项目惯例"
+    },
+    {
+      "key": "cwd_hint",
+      "label": "工作目录提示",
+      "type": "text",
+      "required": false,
+      "placeholder": "/path/to/project (留空使用当前 MateClaw workspace)",
+      "hint": "OpenCode 会用这个路径做 fs 操作的根。指错路径会让 read/write 工具找不到文件。"
+    }
+  ],
+  "skillMd": "---\nname: {{skill_name}}\ndescription: {{display_name_zh}} - 通过 ACP 委派给 OpenCode\ntype: acp\nicon: \"🟢\"\ncategory: system\nversion: 1.0.0\nauthor: skill-template-wizard\nacp:\n  endpoint: opencode\n  system_prefix: |\n    {{system_prefix}}\n  cwd: {{cwd_hint}}\nself-evolution:\n  lessons_enabled: true\n  lessons_max_entries: 30\n---\n\n# {{display_name_zh}}\n\n这是一个 ACP 委派 skill。Agent 会把编码任务转发给 OpenCode coding agent。\n\n## 使用前提\n\n1. Settings ▸ ACP Endpoints 启用 `opencode` 端点（默认 disabled）\n2. 确认本机已安装 opencode CLI（`opencode` 命令可用）\n3. opencode 已配置至少一个模型 provider（OpenAI / Anthropic / Google / 本地模型）\n4. 该 skill 暴露一个工具 `acp_opencode_{{skill_name}}_prompt`，参数 `prompt: string`\n\n## 为什么选 OpenCode\n\n- **多模型支持**：OpenCode 不绑单一厂商——OpenAI、Anthropic、Google、DeepSeek、本地 Ollama 都能用，配合 MateClaw 的多厂商故障转移，编码场景也能故障转移\n- **开源**：Apache 2.0，和 MateClaw 同一许可\n- **ACP 原生**：opencode acp 命令直接启动 ACP server，无需 npx 拉包\n- **轻量**：单二进制，启动快\n\n## 委派粒度建议\n\n- **单 PR 范围**：把 PR 描述 + diff 上下文 + 期望写成一段长 prompt 给 OpenCode\n- **单文件改动**：包含 file path + 关注的代码片段 + 改动意图\n- **探索性分析**：先让 OpenCode 读 / 列目录，根据它的输出再决定下一步\n- **多步任务**：OpenCode 支持内部多轮工具调用，可以一次给复杂任务\n\n## 跟 Claude Code / Codex 的差异\n\n- OpenCode 上下文窗口取决于所选模型，不像 Claude Code 固定 200K\n- OpenCode 更轻量，适合快速迭代\n- OpenCode 的工具调用 trace 走 ACP session/update，MateClaw 会流式 relay 中间步骤\n\n## 流式输出\n\nMateClaw 的 ACP 流式 relay（Phase 7c）会把 OpenCode 的中间步骤（工具调用、计划、模式切换）实时推送到 SSE 流，用户在聊天界面能看到 OpenCode 正在干什么，而不是等最终回复。\n"
+}

--- a/mateclaw-server/src/main/resources/templates/coding-engineer.json
+++ b/mateclaw-server/src/main/resources/templates/coding-engineer.json
@@ -1,0 +1,56 @@
+{
+  "id": "coding-engineer",
+  "name": "Coding Engineer",
+  "nameZh": "编码工程师",
+  "description": "Senior coding engineer. Reads, writes, edits, and tests code. Commits in small steps. Debugs systematically.",
+  "descriptionZh": "资深编码工程师。读代码、写代码、改代码、跑测试。小步提交。系统化调试。",
+  "icon": "pi:code",
+  "agentType": "react",
+  "tags": "code,engineering,development",
+  "maxIterations": 30,
+  "defaultSkillSlugs": [
+    "test-driven-development",
+    "systematic-debugging",
+    "writing-plans",
+    "subagent-driven-development",
+    "requesting-code-review"
+  ],
+  "defaultToolNames": [
+    "ReadFileTool",
+    "WriteFileTool",
+    "EditFileTool",
+    "ApplyPatchTool",
+    "ShellExecuteTool",
+    "CodeExecuteTool",
+    "GlobTool",
+    "GrepTool",
+    "GitTool"
+  ],
+  "systemPrompt": "## Role\n编码工程师\n\n## Goal\n把代码改动从意图变成已提交、已测试、可审查的结果\n\n## Backstory\n你是见过太多凌晨合并事故的资深工程师。你信奉三条：先读再改、小步提交、改完必测。你不会凭记忆改代码——任何改动前你都会先 read_file 看目标文件，用 glob 找文件，用 grep 搜内容。你不会一次性改一堆——每个逻辑变更用 edit_file 或 apply_patch 做一次，改完用 git status / git diff 确认，再 git_commit。你不会跳过测试——改完用 execute_shell_command 跑测试（mvn test / pnpm test / pytest），或用 execute_code 写验证脚本。\n\n## Additional Instructions\n工作原则：\n1. 先读再改。任何修改前先 read_file 看目标文件，用 glob 找文件，用 grep 搜内容。不要凭记忆改代码。\n2. 小步提交。每个逻辑变更用 apply_patch 或 edit_file 做一次，改完用 git status / git diff 确认，再 git_commit。\n3. 改完必测。用 execute_shell_command 跑测试，或用 execute_code 写验证脚本。\n4. 写操作要谨慎。write_file 会覆盖，edit_file / apply_patch 要求上下文唯一匹配。拿不准就先 read_file。\n5. 复杂任务先规划。超过 3 步的任务先用 writing-plans skill 出计划，再按计划执行。\n6. 调试走系统化流程。复现 → 定位 → 假设 → 验证 → 修复，用 systematic-debugging skill。\n7. 改完请人审。大改动用 requesting-code-review skill 自审一遍。\n\n工具使用优先级：\n- 找文件 → glob（比 shell find 快且安全）\n- 搜内容 → grep（比 shell grep/rg 安全，支持正则 + 上下文）\n- 读文件 → read_file（支持行范围、续读提示）\n- 改单处 → edit_file（find-and-replace，唯一匹配）\n- 改多处 → apply_patch（unified diff，一次改多文件多 hunk）\n- 建新文件 → write_file（自动建父目录）\n- 跑命令 → execute_shell_command（跨平台，走审批）\n- 跑代码 → execute_code（python/bash/node 沙箱）\n- git 操作 → git / git_commit（写操作走审批）\n\n禁止事项：\n- 不要在没有 read_file 的情况下用 edit_file 改文件\n- 不要用 write_file 覆盖已存在的文件（用 edit_file / apply_patch）\n- 不要跳过测试直接提交\n- 不要一次性改太多文件——拆成可审查的小步\n",
+  "workspaceFiles": [
+    {
+      "filename": "AGENTS.md",
+      "content": "## Role\nYou are a senior coding engineer. Your job is to:\n1. Read before you edit — never modify a file you haven't read first\n2. Make small, reviewable commits — one logical change per commit\n3. Always test after changes — run tests or write a verification script\n4. Use the right tool: glob to find, grep to search, read_file to read, edit_file/apply_patch to change, git to commit\n\n## Working Method\n- Read the target file with read_file before editing\n- Use glob to find files by name pattern\n- Use grep to search file contents with regex\n- Use edit_file for single-location find-and-replace\n- Use apply_patch for multi-location or multi-file unified diff edits\n- Use execute_shell_command for tests, builds, git operations\n- Use execute_code for quick verification scripts (python/bash/node)\n- Use git / git_commit for version control (writes require approval)\n\n## Prohibitions\n- Never edit_file without reading the file first\n- Never use write_file to overwrite an existing file (use edit_file/apply_patch)\n- Never skip tests before committing\n- Never change too many files at once — break into small reviewable steps\n",
+      "enabled": true,
+      "sortOrder": 0
+    },
+    {
+      "filename": "SOUL.md",
+      "content": "# Soul\n\nBe the engineer you'd want reviewing your own PR.\nRead first, change second, test third, commit last.\nSmall steps. Evidence over intuition. Tests over assumptions.\n",
+      "enabled": true,
+      "sortOrder": 1
+    },
+    {
+      "filename": "PROFILE.md",
+      "content": "## Project Context\n\n- Language/Framework:\n- Build tool:\n- Test command:\n- Code style guide:\n\n_Update as you learn about the codebase._\n",
+      "enabled": true,
+      "sortOrder": 2
+    },
+    {
+      "filename": "MEMORY.md",
+      "content": "## Coding Memory\n\n### Recurring Patterns\n- (none yet)\n\n### Project Conventions\n- (none yet)\n\n### Gotchas\n- (none yet)\n",
+      "enabled": true,
+      "sortOrder": 3
+    }
+  ]
+}

--- a/mateclaw-server/src/test/java/vip/mate/channel/webchat/WebChatAttachmentE2ETest.java
+++ b/mateclaw-server/src/test/java/vip/mate/channel/webchat/WebChatAttachmentE2ETest.java
@@ -5,7 +5,7 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.boot.test.web.server.LocalServerPort;
 import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.test.context.TestPropertySource;
@@ -86,7 +86,7 @@ class WebChatAttachmentE2ETest {
     @LocalServerPort private int port;
     @Autowired private JdbcTemplate jdbc;
 
-    @MockBean private AgentService agentService;
+    @MockitoBean private AgentService agentService;
 
     private HttpClient http;
 

--- a/mateclaw-server/src/test/java/vip/mate/channel/webchat/WebChatStreamE2ETest.java
+++ b/mateclaw-server/src/test/java/vip/mate/channel/webchat/WebChatStreamE2ETest.java
@@ -5,7 +5,7 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.boot.test.web.server.LocalServerPort;
 import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.test.context.TestPropertySource;
@@ -89,7 +89,7 @@ class WebChatStreamE2ETest {
     @Autowired private JdbcTemplate jdbc;
 
     /** Replaced with a Mockito mock; tests stub the two methods /stream calls. */
-    @MockBean private AgentService agentService;
+    @MockitoBean private AgentService agentService;
 
     private HttpClient http;
 

--- a/mateclaw-ui/pnpm-workspace.yaml
+++ b/mateclaw-ui/pnpm-workspace.yaml
@@ -1,0 +1,3 @@
+allowBuilds:
+  esbuild: true
+  vue-demi: true


### PR DESCRIPTION
- ApplyPatchTool: unified diff 补丁应用，多 hunk 唯一匹配校验，支持文件移动/删除
- GlobTool: 纯 Java glob 文件搜索，分页，跳过 .git/node_modules/target
- GrepTool: 纯 Java 正则内容搜索，支持上下文/扩展名过滤/分页
- GitTool: git 操作封装，只读安全，写操作走审批；git_commit 快捷提交（参数安全检查）
- EditFileTool: opencode 风格多策略模糊匹配（精确/行trim/空白归一/缩进灵活/转义归一）， 替换后自动语法检查（javac/node/python/json），diff preview 输出
- ShellExecuteTool: 大输出截断保留到 spill file，agent 可 read_file 分页读取完整内容
- StateGraphReActAgent: 结构化流空闲超时兜底（默认15min），超时时给用户友好提示
- ObservationDispatcher/ReasoningDispatcher: maxIterations=0 模式仍以150为硬上限， 防止 agent 无限循环；MateClawStateAccessor 同步更新
- 新增 coding-engineer.json 编码工程师 agent 模板与 opencode-coding-helper skill 模板
- WorkspacePathGuard: Git Bash 路径 /e/work/ 自动转换为 Windows 路径，路径校验增强
- ACP: AcpDelegationService 新增 promptStream 流式转发 + 取消时杀进程； AcpSkillBridge 改用流式，ACP session/update 事件日志观测
- 数据库种子: V166 迁移（h2/mysql/kingbase）+ data 文件（中文/英文） 注册 ApplyPatchTool/GlobTool/GrepTool/GitTool 到 mate_tool 表
- pom.xml: JVM 编码参数（-Dfile.encoding=UTF-8）确保 Windows 测试不乱码
- 测试: WebChat E2E 测试从 @MockBean 迁移到 @MockitoBean（Spring Boot 3.4 兼容）
- .gitignore: 添加 .mateclaw/
- pnpm-workspace.yaml: 允许 esbuild 和 vue-demi 构建
- GraphObservationProperties: 新增 streamIdleTimeoutSeconds 配置项，默认900秒