### PR TITLE
chore: ignore local .codebase-memory/ agent index

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -105,6 +105,9 @@ CLAUDE.md
 # Codex CLI local artifacts
 .codex/
 
+# Codebase memory (local agent index / graph artifact; do not commit)
+.codebase-memory/
+
 # Sync tooling local state (generated each run; report is intentionally tracked)
 scripts/.*-sync-state.json
 


### PR DESCRIPTION
Exclude the `.codebase-memory/` directory (local code-graph index / agent artifact) so it is not committed by mistake.

This is a tool-generated local directory (e.g. from codebase-memory indexing). It has no place in the shared repo.

**Diff:** single-line addition to `.gitignore`, no functional change.