### PR TITLE
fix(ui): 修复工具目录页面层级切换按钮文字溢出与比例失调

### DIFF
--- a/mateclaw-ui/src/views/Tools.vue
+++ b/mateclaw-ui/src/views/Tools.vue
@@ -274,8 +274,8 @@ async function toggleTool(tool: Tool) {
 .tools-section-title { font-size: 15px; font-weight: 700; color: var(--mc-text-primary); }
 .tools-section-count { font-size: 12px; font-weight: 600; color: var(--mc-text-secondary); background: var(--mc-bg-muted); padding: 2px 8px; border-radius: 10px; }
 .tools-section-hint { font-size: 12px; color: var(--mc-text-tertiary); }
-.tier-btn { width: auto; padding: 0 10px; font-size: 12px; font-weight: 600; white-space: nowrap; color: var(--mc-text-secondary); }
-.tier-btn:hover { color: var(--mc-primary); border-color: var(--mc-primary); }
+.tier-btn { width: auto; height: 30px; padding: 0 10px; font-size: 12px; font-weight: 600; line-height: 30px; white-space: nowrap; color: var(--mc-text-secondary); }
+.tier-btn:hover { background: var(--mc-bg-sunken); color: var(--mc-primary); border-color: var(--mc-primary); }
 .tier-locked { display: inline-flex; align-items: center; padding: 0 8px; font-size: 11px; color: var(--mc-text-tertiary); cursor: help; }
 .btn-primary { display: flex; align-items: center; gap: 6px; padding: 10px 16px; background: linear-gradient(135deg, var(--mc-primary), var(--mc-primary-hover)); color: white; border: none; border-radius: 14px; font-size: 14px; font-weight: 600; cursor: pointer; box-shadow: var(--mc-shadow-soft); }
 .btn-primary:hover { background: var(--mc-primary-hover); }


### PR DESCRIPTION
### 问题
「设置 → 工具目录」页面中，核心工具 / 扩展工具表格操作列的「→ 扩展」「← 核心」文字按钮渲染异常：文字溢出按钮边界，与同行的编辑、删除图标按钮高度不一致，整体比例失调。

### 原因
该按钮同时挂载 .row-btn （30×30px 图标按钮）和 .tier-btn （文字按钮）两个 CSS 类。 .tier-btn 仅重置了 width: auto ，但未重置 height: 30px ，且缺少 line-height 和 hover 背景色，导致 12px 文字被压在 30px 矮盒内无法正常居中渲染。

### 修复
mateclaw-ui/src/views/Tools.vue — .tier-btn 样式：

属性 修复前 修复后 height 继承 30px （隐式，无声明） 30px （显式，与编辑/删除按钮统一） line-height 无 30px （文字垂直居中） hover background 无 var(--mc-bg-sunken) （hover 有视觉反馈）

### 影响范围
- 仅影响 Tools.vue 中 .tier-btn 的渲染样式
- 不涉及逻辑、API、后端代码
- 无需跑测试