### PR TITLE
test(skill): add missing scripts/run.sh fixture for SkillBundleMaterializerTest

### DIFF
--- a/mateclaw-server/src/test/resources/test-bundles/sample/scripts/run.sh
+++ b/mateclaw-server/src/test/resources/test-bundles/sample/scripts/run.sh
@@ -1,0 +1,3 @@
+#!/bin/sh
+# Test fixture supporting file for SkillBundleMaterializerTest.
+echo "hello from sample bundle"


### PR DESCRIPTION
## 问题

`SkillBundleMaterializerTest` 的 3 个用例（`verbatimCopiesEverything`、`templateOverlaySkipsSkillMd`、`createsTargetDirectory`）在任何 fresh clone 上都会失败，断言"应有 3 个文件"实际只找到 2 个。

## 根因

测试 fixture `src/test/resources/test-bundles/sample/scripts/run.sh` 从未被提交到仓库——`git log --all` 对该路径零历史，`.gitignore` 也没有匹配规则，纯粹是遗漏。测试代码本身没问题（`pathTraversalGuard` 不依赖这个 fixture，一直是绿的）。

## 修复

补上这一个 fixture 文件，内容满足测试断言（`contains("hello from sample bundle")`）。

## 验证

`mvn test -Dtest=SkillBundleMaterializerTest` → 4/4 通过。