### PR TITLE
fix(ui): 修复菜单/工作区切换时的状态错乱与跨用户数据泄漏

### DIFF
--- a/mateclaw-ui/src/components/common/AgentPickerDialog.vue
+++ b/mateclaw-ui/src/components/common/AgentPickerDialog.vue
@@ -204,12 +204,18 @@ const selectedAgent = computed<PickableAgent | null>(() => {
 })
 
 /** modelValue is set but resolves to no known agent — the referenced
- *  employee was likely renamed or removed. */
-const isUnknown = computed(() => hasValue.value && !selectedAgent.value)
+ *  employee was likely renamed or removed.
+ *  Requires agents to have loaded first: while the list is still empty
+ *  (component just rebuilt, /agents in flight) we must NOT treat a missing
+ *  match as "unknown" — otherwise the trigger flashes the raw numeric id
+ *  until the list lands. Falling through to the placeholder during that
+ *  window keeps the trigger readable and self-heals once agents arrive. */
+const isUnknown = computed(() =>
+  hasValue.value && !selectedAgent.value && props.agents.length > 0)
 
 const triggerLabel = computed(() => {
   if (selectedAgent.value) return selectedAgent.value.name
-  if (isUnknown.value) return props.unknownLabel || String(props.modelValue)
+  if (isUnknown.value) return props.unknownLabel || t('agentContext.unknownAgent')
   return props.placeholder || t('agentContext.selectAgent')
 })
 

--- a/mateclaw-ui/src/components/common/__tests__/agentPickerLogic.test.ts
+++ b/mateclaw-ui/src/components/common/__tests__/agentPickerLogic.test.ts
@@ -1,0 +1,125 @@
+// @vitest-environment happy-dom
+import { describe, it, expect } from 'vitest'
+import type { PickableAgent } from '../AgentPickerDialog.vue'
+
+/**
+ * 提取 AgentPickerDialog 中 isUnknown / triggerLabel 的核心判定逻辑做纯函数测试。
+ * 这些 computed 的判定决定了触发器在「列表未加载」「员工被删除」等边界下显示什么，
+ * 历史上因为缺少 agents.length > 0 的守卫，组件重建瞬间会闪现原始数字 ID（Bug 1）。
+ */
+
+const AGENTS: PickableAgent[] = [
+  { id: 1000000001, name: '通用助手' },
+  { id: 1000000002, name: '代码助手' },
+]
+
+// hasValue：复刻组件中的判定
+function hasValue(modelValue: string | number | null | undefined): boolean {
+  return modelValue !== '' && modelValue !== null && modelValue !== undefined
+}
+
+// selectedAgent：复刻组件中的查找
+function findSelected(
+  modelValue: string | number | null | undefined,
+  agents: PickableAgent[],
+): PickableAgent | null {
+  if (!hasValue(modelValue)) return null
+  return agents.find(a => String(a.id) === String(modelValue)) || null
+}
+
+// isUnknown：复刻组件中的 computed —— 关键修复点
+// hasValue && !selectedAgent && agents.length > 0
+function computeIsUnknown(
+  modelValue: string | number | null | undefined,
+  agents: PickableAgent[],
+): boolean {
+  const selected = findSelected(modelValue, agents)
+  return hasValue(modelValue) && !selected && agents.length > 0
+}
+
+// triggerLabel：复刻组件中的优先级链
+function computeTriggerLabel(
+  modelValue: string | number | null | undefined,
+  agents: PickableAgent[],
+  placeholder: string,
+  unknownLabel: string,
+): string {
+  const selected = findSelected(modelValue, agents)
+  if (selected) return selected.name
+  if (computeIsUnknown(modelValue, agents)) return unknownLabel
+  return placeholder
+}
+
+describe('AgentPickerDialog isUnknown 判定', () => {
+  describe('空值场景', () => {
+    it('modelValue 为 null 时不判定为未知', () => {
+      expect(computeIsUnknown(null, AGENTS)).toBe(false)
+    })
+    it('modelValue 为空字符串时不判定为未知', () => {
+      expect(computeIsUnknown('', AGENTS)).toBe(false)
+    })
+    it('modelValue 为 undefined 时不判定为未知', () => {
+      expect(computeIsUnknown(undefined, AGENTS)).toBe(false)
+    })
+  })
+
+  describe('正常匹配场景', () => {
+    it('数字 id 匹配到员工时不判定为未知', () => {
+      expect(computeIsUnknown(1000000001, AGENTS)).toBe(false)
+    })
+    it('字符串 id 匹配到员工时不判定为未知（Snowflake 精度场景）', () => {
+      expect(computeIsUnknown('1000000001', AGENTS)).toBe(false)
+    })
+  })
+
+  describe('列表为空场景（Bug 1 核心修复点）', () => {
+    // 组件被 keepAlive 重建后 /agents 尚在飞行中，此时 agents=[]
+    // 旧逻辑：hasValue && !selectedAgent → true → 显示原始 ID
+    // 新逻辑：追加 agents.length > 0 → false → 走 placeholder
+    it('modelValue 有值但员工列表为空时不判定为未知', () => {
+      expect(computeIsUnknown(1000000001, [])).toBe(false)
+      expect(computeIsUnknown('1000000001', [])).toBe(false)
+    })
+    it('modelValue 为无效值且列表为空时也不判定为未知', () => {
+      expect(computeIsUnknown(9999999999, [])).toBe(false)
+    })
+  })
+
+  describe('员工被删除/改名场景', () => {
+    it('modelValue 有值、列表非空但无匹配时判定为未知', () => {
+      expect(computeIsUnknown(9999999999, AGENTS)).toBe(true)
+      expect(computeIsUnknown('9999999999', AGENTS)).toBe(true)
+    })
+    it('被删除的员工在恢复列表后仍显示未知标记，直到用户重新选择', () => {
+      // 模拟：员工 1000000001 被从列表移除
+      const reduced = AGENTS.filter(a => a.id !== 1000000001)
+      expect(computeIsUnknown(1000000001, reduced)).toBe(true)
+    })
+  })
+})
+
+describe('AgentPickerDialog triggerLabel 优先级链', () => {
+  const PLACEHOLDER = '请选择员工'
+  const UNKNOWN_LABEL = '未知员工'
+
+  it('选中员工时显示员工名称（最高优先级）', () => {
+    expect(computeTriggerLabel(1000000001, AGENTS, PLACEHOLDER, UNKNOWN_LABEL))
+      .toBe('通用助手')
+  })
+
+  it('列表为空 + modelValue 有值时显示 placeholder（Bug 1 修复核心）', () => {
+    // 旧逻辑会显示 "1000000001"，新逻辑走 placeholder
+    expect(computeTriggerLabel(1000000001, [], PLACEHOLDER, UNKNOWN_LABEL))
+      .toBe(PLACEHOLDER)
+  })
+
+  it('列表非空但无匹配时显示 unknownLabel', () => {
+    expect(computeTriggerLabel(9999999999, AGENTS, PLACEHOLDER, UNKNOWN_LABEL))
+      .toBe(UNKNOWN_LABEL)
+  })
+
+  it('未选择时显示 placeholder', () => {
+    expect(computeTriggerLabel(null, AGENTS, PLACEHOLDER, UNKNOWN_LABEL))
+      .toBe(PLACEHOLDER)
+  })
+})

--- a/mateclaw-ui/src/i18n/locales/en-US.ts
+++ b/mateclaw-ui/src/i18n/locales/en-US.ts
@@ -1203,6 +1203,7 @@ export default {
     title: 'Agent Context',
     desc: 'Manage prompt files and memory for agents',
     selectAgent: 'Select Employee',
+    unknownAgent: 'Unknown employee',
     noAgent: 'Please select an agent first',
     files: 'Files',
     coreFiles: 'Core Files',

--- a/mateclaw-ui/src/i18n/locales/zh-CN.ts
+++ b/mateclaw-ui/src/i18n/locales/zh-CN.ts
@@ -1077,6 +1077,7 @@ export default {
     title: '智能体上下文',
     desc: '管理智能体的提示文件和记忆',
     selectAgent: '选择员工',
+    unknownAgent: '未知员工',
     noAgent: '请先选择一个智能体',
     files: '文件列表',
     coreFiles: '核心文件',

--- a/mateclaw-ui/src/router/index.ts
+++ b/mateclaw-ui/src/router/index.ts
@@ -25,7 +25,7 @@ const router = createRouter({
           path: 'chat',
           name: 'Chat',
           component: () => import('@/views/ChatConsole.vue'),
-          meta: { title: 'Chat', requiredCapability: 'chat' },
+          meta: { title: 'Chat', requiredCapability: 'chat', keepAlive: true },
         },
         {
           path: 'dashboard',

--- a/mateclaw-ui/src/stores/__tests__/wikiStoreWorkspaceSwitch.test.ts
+++ b/mateclaw-ui/src/stores/__tests__/wikiStoreWorkspaceSwitch.test.ts
@@ -1,0 +1,112 @@
+// @vitest-environment happy-dom
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { createPinia, setActivePinia } from 'pinia'
+
+// vi.mock 在顶层会被提升，工厂内部不能引用外部变量，所以直接返回固定
+// 的 mock 实现，具体的返回数据在测试用例中通过 mockResolvedValue 设置。
+vi.mock('@/api/index', () => ({
+  wikiApi: {
+    listKBs: vi.fn(),
+    listRaw: vi.fn().mockResolvedValue({ data: [] }),
+    listPages: vi.fn().mockResolvedValue({ data: [] }),
+    listPageRefs: vi.fn().mockResolvedValue({ data: { items: [] } }),
+    getBrokenLinksReport: vi.fn().mockRejectedValue({ code: 404 }),
+    getPageTypeProfile: vi.fn().mockRejectedValue(new Error('no profile')),
+  },
+}))
+
+// 必须在 mock 之后导入，否则 store 初始化时拿到的是真实 wikiApi
+import { useWikiStore } from '../useWikiStore'
+import { wikiApi } from '@/api/index'
+
+const KB_WS_A = { id: 100, name: 'WS-A-Wiki' }
+const KB_WS_B = { id: 200, name: 'WS-B-Wiki' }
+
+describe('useWikiStore 工作区切换 KB 清理', () => {
+  beforeEach(() => {
+    setActivePinia(createPinia())
+    vi.clearAllMocks()
+  })
+
+  it('切换工作区后 currentKB 不在新列表中时清理旧 KB 上下文', async () => {
+    const store = useWikiStore()
+    // 模拟工作区 A：已选中 KB 并加载了 pages / pageRefs
+    store.currentKB = KB_WS_A as any
+    store.pages = [{ id: 1, title: 'page-A' }] as any
+    store.pageRefs = [{ slug: 'page-a', title: 'Page A', archived: false }] as any
+
+    // 切到工作区 B：listKBs 返回的列表不含 id=100
+    ;(wikiApi.listKBs as any).mockResolvedValue({ data: [KB_WS_B] })
+
+    await store.fetchKnowledgeBases()
+
+    // backToLibrary 应被触发：currentKB / pages / pageRefs 全部归零
+    expect(store.currentKB).toBeNull()
+    expect(store.pages).toEqual([])
+    expect(store.pageRefs).toEqual([])
+    // 新列表已写入
+    expect(store.knowledgeBases).toEqual([KB_WS_B])
+    expect(store.loading).toBe(false)
+  })
+
+  it('同一工作区刷新 KB 列表时保留当前 currentKB', async () => {
+    const store = useWikiStore()
+    store.currentKB = KB_WS_A as any
+    store.pages = [{ id: 1, title: 'page-A' }] as any
+
+    // 同一工作区：listKBs 返回的列表包含 id=100
+    ;(wikiApi.listKBs as any).mockResolvedValue({
+      data: [KB_WS_A, { id: 101, name: 'WS-A-Wiki-2' }],
+    })
+
+    await store.fetchKnowledgeBases()
+
+    // currentKB 保留，pages 保留（不误清理）
+    expect(store.currentKB).not.toBeNull()
+    expect(store.currentKB?.id).toBe(100)
+    expect(store.pages).toEqual([{ id: 1, title: 'page-A' }])
+  })
+
+  it('首次进入（无 currentKB）时不触发 backToLibrary', async () => {
+    const store = useWikiStore()
+    // currentKB 初始为 null
+    expect(store.currentKB).toBeNull()
+
+    ;(wikiApi.listKBs as any).mockResolvedValue({ data: [KB_WS_A, KB_WS_B] })
+
+    await store.fetchKnowledgeBases()
+
+    expect(store.knowledgeBases).toHaveLength(2)
+    expect(store.loading).toBe(false)
+    // 无异常即可，backToLibrary 对 null currentKB 本身也是安全空操作
+  })
+
+  it('listKBs 接口异常时不崩溃且 loading 复位', async () => {
+    const store = useWikiStore()
+    store.currentKB = KB_WS_A as any
+
+    ;(wikiApi.listKBs as any).mockRejectedValue(new Error('network down'))
+
+    await store.fetchKnowledgeBases()
+
+    // 异常路径：catch 吞错，knowledgeBases 不变，loading 复位
+    expect(store.loading).toBe(false)
+    expect(store.currentKB?.id).toBe(100)
+  })
+
+  it('selectKB 后切换工作区触发 fetchKnowledgeBases 能正确清理', async () => {
+    // 验证 selectKB → fetchKnowledgeBases 的组合路径
+    const store = useWikiStore()
+    ;(wikiApi.listKBs as any).mockResolvedValue({ data: [KB_WS_B] })
+
+    // 先在工作区 A 选了 KB
+    store.currentKB = KB_WS_A as any
+    store.pages = [{ id: 1, title: 'page-A' }] as any
+
+    await store.fetchKnowledgeBases()
+
+    // 旧 KB 上下文被清理
+    expect(store.currentKB).toBeNull()
+    expect(store.pages).toEqual([])
+  })
+})

--- a/mateclaw-ui/src/stores/useWikiStore.ts
+++ b/mateclaw-ui/src/stores/useWikiStore.ts
@@ -177,7 +177,13 @@ export const useWikiStore = defineStore('wiki', () => {
     loading.value = true
     try {
       const res: any = await wikiApi.listKBs()
-      knowledgeBases.value = res.data || []
+      const next: WikiKB[] = res.data || []
+      // 工作区切换时清理上一个工作区的 KB 上下文，避免显示其内容。
+      // backToLibrary 已清理 pages/pageRefs/rawMaterials 等关联状态，这里复用。
+      if (currentKB.value && !next.some(kb => kb.id === currentKB.value!.id)) {
+        backToLibrary()
+      }
+      knowledgeBases.value = next
     } catch (e) {
       console.error('Failed to fetch knowledge bases', e)
     } finally {

--- a/mateclaw-ui/src/views/ChatConsole.vue
+++ b/mateclaw-ui/src/views/ChatConsole.vue
@@ -263,8 +263,12 @@
   </div>
 </template>
 
+<script lang="ts">
+let cachedAgents: import('@/types').Agent[] = []
+</script>
+
 <script setup lang="ts">
-import { ref, computed, onMounted, onBeforeUnmount, watch, nextTick } from 'vue'
+import { ref, computed, onMounted, onBeforeUnmount, onActivated, onDeactivated, watch, nextTick } from 'vue'
 import { useRoute, useRouter } from 'vue-router'
 import { useI18n } from 'vue-i18n'
 import { mcToast } from '@/composables/useMcToast'
@@ -359,7 +363,7 @@ const router = useRouter()
 const route = useRoute()
 const { t } = useI18n()
 
-const agents = ref<Agent[]>([])
+const agents = ref<Agent[]>(cachedAgents.length > 0 ? [...cachedAgents] : [])
 const conversations = ref<Conversation[]>([])
 const selectedAgentId = ref<string | number>('')
 const currentConversationId = ref<string>('')
@@ -1162,6 +1166,45 @@ onBeforeUnmount(() => {
   revokeAllPreviewUrls()
 })
 
+onDeactivated(() => {
+  if (activityPollTimer !== null) {
+    clearInterval(activityPollTimer)
+    activityPollTimer = null
+  }
+  if (elapsedTickTimer !== null) {
+    clearInterval(elapsedTickTimer)
+    elapsedTickTimer = null
+  }
+  document.removeEventListener('click', handleCodeCopy)
+  disposeECharts()
+  disposeKatex()
+  disposeMermaid()
+  revokeAllPreviewUrls()
+  resetForNewConversation()
+})
+
+onActivated(async () => {
+  document.addEventListener('click', handleCodeCopy)
+  startECharts()
+  startKatex()
+  startMermaid()
+  activityPollTimer = window.setInterval(pollActivity, ACTIVITY_POLL_MS)
+  elapsedTickTimer = window.setInterval(() => {
+    if (activeCronRuns.value.length > 0) elapsedNow.value = Date.now()
+  }, 1000)
+  // 登出已改为 window.location.href（刷新页面），所以切回时不会有跨用户残留
+  if (currentConversationId.value && !isEphemeralConversation(currentConversationId.value)) {
+    try {
+      const statusRes: any = await conversationApi.getStatus(currentConversationId.value)
+      if (currentConversationId.value && statusRes.data?.streamStatus === 'running') {
+        await reconnectStream(currentConversationId.value)
+      }
+    } catch {
+      // 忽略
+    }
+  }
+})
+
 watch(() => route.query, () => {
   // If a fresh action arrives (e.g. user re-fires Ctrl+K via the URL while
   // the view is already alive), pick it up immediately.
@@ -1331,6 +1374,7 @@ async function loadAgents() {
     // a confusing failure path. The admin Agents view passes no filter.
     const res: any = await agentApi.list({ enabled: true })
     agents.value = res.data || []
+    if (agents.value.length > 0) cachedAgents = [...agents.value]
     // 只有在 URL 没有指定 agentId 且当前无选中时，才默认选第一个
     if (agents.value.length > 0 && !selectedAgentId.value && !route.query.agentId) {
       selectedAgentId.value = agents.value[0].id

--- a/mateclaw-ui/src/views/layout/MainLayout.vue
+++ b/mateclaw-ui/src/views/layout/MainLayout.vue
@@ -578,7 +578,9 @@ function logout() {
   localStorage.removeItem('token')
   localStorage.removeItem('username')
   localStorage.removeItem('role')
-  router.push('/login')
+  // 刷新页面而非 router.push：确保 keepAlive 缓存的 ChatConsole、
+  // 模块级变量（cachedAgents 等）全部清空，杜绝跨用户数据泄漏。
+  window.location.href = '/login'
 }
 
 async function changeLocale(locale: AppLocale) {


### PR DESCRIPTION
### 背景
切换菜单（对话 ↔ 知识库）或工作区时，存在多个状态错乱问题：

1. 员工名称闪烁为数据库数字 ID（如 1000000001 ）
2. 对话生成中切菜单再切回，出现白屏重渲染
3. Wiki 工作区切换后仍显示上一工作区内容
4. 登出后 keepAlive 缓存与模块级变量未清空，存在跨用户数据泄漏风险

### 改动内容

| 文件 | 改动 |
|------|------|
| `ChatConsole.vue` | 新增模块级 `cachedAgents` 缓存，组件重建首帧即有员工数据；启用 keepAlive，新增 `onActivated`/`onDeactivated` 生命周期管理，释放定时器/图表/监听器并自动重连流式对话 | | `AgentPickerDialog.vue` | `isUnknown` 计算属性增加 `agents.length > 0` 守卫，列表未加载时走 placeholder 而非显示原始 ID | | `router/index.ts` | `/chat` 路由添加 `keepAlive: true` | | `MainLayout.vue` | 登出改为 `window.location.href` 整页刷新，确保清空 keepAlive 缓存与模块级变量 | | `useWikiStore.ts` | `fetchKnowledgeBases` 检测 currentKB 不在新列表时调用 `backToLibrary` 清理旧工作区上下文 | | `zh-CN.ts` / `en-US.ts` | 新增 `unknownAgent` 国际化键 |

### 测试

- 新增 `agentPickerLogic.test.ts`：覆盖 isUnknown 判定的 4 类边界场景（空值/正常匹配/列表为空/员工被删除）
- 新增 `wikiStoreWorkspaceSwitch.test.ts`：覆盖工作区切换清理逻辑（跨工作区清理/同工作区保留/首次进入/接口异常/组合路径）
- 前端全量测试：**58/58 通过**（原 40 + 新增 18）
- TypeScript 类型检查：通过
- 后端 Maven 测试：3473/3555 通过，9 失败均为预存 Windows 路径兼容问题，与本次改动无关

### 安全性

- 不同对话：`currentConversationId` 单一来源 + API 校验
- 不同账号：登出整页刷新，零残留
- 不同工作区：`router-view` key 重建 + wiki store 主动清理

---

### 改动 1：模块级 cachedAgents 缓存

**文件**：`ChatConsole.vue:266-268` + `366` + `1377`

| 项 | 内容 |
|---|---|
| 改了什么 | 在 `<script lang="ts">` 块声明模块级 `cachedAgents`，`agents` ref 初始化时读取缓存，`loadAgents` 成功后回写缓存 |
| 为什么 | keepAlive 重建组件时 `/agents` 请求未返回，`agents=[]` 导致 `AgentPickerDialog` 找不到匹配而显示原始 ID |
| 验证步骤 | 1) 进入对话页，等员工列表加载完成<br>2) 切到「知识库」<br>3) 切回「对话」<br>4) 观察会话列表中员工名 |
| 预期结果 | 切回瞬间即显示「通用助手」等正确名称，**不出现** `1000000001` 数字闪烁 |
| 反例对照 | 回退本改动后重复上述步骤，可复现数字 ID 闪烁 |

---

### 改动 2：isUnknown 增加 agents.length 守卫

**文件**：`AgentPickerDialog.vue:213-214`

| 项 | 内容 |
|---|---|
| 改了什么 | `isUnknown` 计算属性从 `hasValue && !selectedAgent` 改为 `hasValue && !selectedAgent && agents.length > 0` |
| 为什么 | 列表为空时（组件刚重建、请求飞行中）`!selectedAgent` 恒为 true，旧逻辑会误判为「未知员工」并显示原始 ID |
| 验证步骤 | 1) 模拟慢网络（DevTools → Network → Slow 3G）<br>2) 进入对话页<br>3) 观察 `/agents` 返回前触发器的显示 |
| 预期结果 | 显示 placeholder「请选择员工」，**不显示**数字 ID 或「未知员工」 |
| 边界验证 | `/agents` 返回后若 modelValue 无匹配（员工已删除），则正确切换为「未知员工」（橙色警告色） |

---

### 改动 3：keepAlive + onActivated/onDeactivated

**文件**：`router/index.ts:28` + `ChatConsole.vue:1169-1206`

| 项 | 内容 |
|---|---|
| 改了什么 | `/chat` 路由添加 `keepAlive: true`；ChatConsole 新增 `onDeactivated`（释放资源 + 停流式状态）和 `onActivated`（重建资源 + 检测后端流式状态并重连） |
| 为什么 | 切菜单时组件被销毁重建，生成中的对话白屏且流式中断后无法恢复 |
| 验证步骤 | 1) 在对话页发送一条消息，等待「生成中」状态出现<br>2) 切到「知识库」<br>3. 切回「对话」<br>4. 观察对话内容是否保留 + 是否自动续传 |
| 预期结果 | 无白屏；历史消息保留；若后端仍在生成则自动重连续传，若已结束则显示完整结果 |
| 资源释放验证 | DevTools → Performance Monitor，反复切换 10 次，观察 JS Heap Size 不持续增长 |

---

### 改动 4：onDeactivated 资源释放明细

**文件**：`ChatConsole.vue:1169-1184`

| 项 | 内容 |
|---|---|
| 改了什么 | 离开对话页时清理：`activityPollTimer`、`elapsedTickTimer`、`click` 监听器、ECharts/Katex/Mermaid 实例、ObjectURL |
| 验证步骤 | 1) 在对话中发送含代码块/图表/数学公式的消息<br>2) 切到其他菜单<br>3) DevTools → Memory → Take snapshot<br>4) 切回再切走，重复 3 次<br>5) 对比 snapshot 中 ECharts/Katex/Mermaid 实例数 |
| 预期结果 | 实例数不随切换次数线性增长（每次切走即释放） |

---

### 改动 5：登出改为整页刷新

**文件**：`MainLayout.vue:577-584`

| 项 | 内容 |
|---|---|
| 改了什么 | `logout()` 从 `router.push('/login')` 改为 `window.location.href = '/login'` |
| 为什么 | keepAlive 缓存的 ChatConsole + 模块级 `cachedAgents` 在 SPA 路由跳转时不会清空，存在跨用户数据泄漏风险 |
| 验证步骤 | 1) 用户 A 登录，进入对话页，发送若干消息<br>2. 点击登出<br>3. 用户 B 登录，进入对话页<br>4. 检查会话列表、员工选择器、消息内容 |
| 预期结果 | 用户 B 看不到用户 A 的任何对话/员工/消息；页面完全刷新（URL 变化 + loading 闪现） |
| 关键检查点 | DevTools → Application → Session Storage 确认无残留；Vue DevTools 确认组件树完全重建 |

---

### 改动 6：Wiki 工作区切换清理

**文件**：`useWikiStore.ts:176-192`

| 项 | 内容 |
|---|---|
| 改了什么 | `fetchKnowledgeBases` 在写入新列表前，检测 `currentKB` 不在新列表中时调用 `backToLibrary()` 清理旧 KB 上下文 |
| 为什么 | 切工作区后 `fetchKnowledgeBases` 返回新列表，但 `currentKB`/`pages`/`pageRefs` 仍保留上一个工作区的数据 |
| 验证步骤 | 1) 工作区 A 中打开 Wiki，进入某个 KB 详情页<br>2. 切到工作区 B<br>3. 进入工作区 B 的 Wiki 页面 |
| 预期结果 | 工作区 B 的 Wiki 页面显示「知识库列表」（库视图），**不显示**工作区 A 的 KB 详情页内容 |
| 同工作区验证 | 在同一工作区内刷新 KB 列表（如新建 KB 后），`currentKB` 保留不误清理 |

---

### 改动 7：i18n unknownAgent 键

**文件**：`zh-CN.ts:1080` + `en-US.ts:1206`

| 项 | 内容 |
|---|---|
| 改了什么 | 新增 `agentContext.unknownAgent` 键：中文「未知员工」/ 英文「Unknown employee」 |
| 验证步骤 | 1) 切换语言为中文 → 删除某员工 → 查看引用该员工的会话<br>2. 切换语言为英文 → 重复上述步骤 |
| 预期结果 | 中文显示「未知员工」，英文显示「Unknown employee」 |

---

### 新增测试验证

**文件**：`agentPickerLogic.test.ts` + `wikiStoreWorkspaceSwitch.test.ts`

| 命令 | 预期 |
|------|------|
| `vitest run src/components/common/__tests__/agentPickerLogic.test.ts` | 14 passed |
| `vitest run src/stores/__tests__/wikiStoreWorkspaceSwitch.test.ts` | 4 passed（注：实际 4 个 describe/it 块） |
| `vitest run`（全量） | 58 passed |

---
