### PR TITLE
fix(ui): 修复工具目录层级切换按钮文字溢出——提升 .tier-btn 选择器特异性以压过 .row-btn

### DIFF
--- a/mateclaw-ui/src/views/Tools.vue
+++ b/mateclaw-ui/src/views/Tools.vue
@@ -274,8 +274,11 @@ async function toggleTool(tool: Tool) {
 .tools-section-title { font-size: 15px; font-weight: 700; color: var(--mc-text-primary); }
 .tools-section-count { font-size: 12px; font-weight: 600; color: var(--mc-text-secondary); background: var(--mc-bg-muted); padding: 2px 8px; border-radius: 10px; }
 .tools-section-hint { font-size: 12px; color: var(--mc-text-tertiary); }
-.tier-btn { width: auto; height: 30px; padding: 0 10px; font-size: 12px; font-weight: 600; line-height: 30px; white-space: nowrap; color: var(--mc-text-secondary); }
-.tier-btn:hover { background: var(--mc-bg-sunken); color: var(--mc-primary); border-color: var(--mc-primary); }
+/* 复合选择器 .row-btn.tier-btn (specificity 0,2,0) 必须高于 .row-btn (0,1,0),
+   否则 .row-btn 后置的 width:30px / display:flex 等会反向覆盖文字按钮的
+   width:auto / line-height,导致 "→ 扩展" / "← 核心" 文字溢出 30px 矮盒。 */
+.row-btn.tier-btn { width: auto; height: 30px; padding: 0 10px; font-size: 12px; font-weight: 600; line-height: 30px; white-space: nowrap; color: var(--mc-text-secondary); }
+.row-btn.tier-btn:hover { background: var(--mc-bg-sunken); color: var(--mc-primary); border-color: var(--mc-primary); }
 .tier-locked { display: inline-flex; align-items: center; padding: 0 8px; font-size: 11px; color: var(--mc-text-tertiary); cursor: help; }
 .btn-primary { display: flex; align-items: center; gap: 6px; padding: 10px 16px; background: linear-gradient(135deg, var(--mc-primary), var(--mc-primary-hover)); color: white; border: none; border-radius: 14px; font-size: 14px; font-weight: 600; cursor: pointer; box-shadow: var(--mc-shadow-soft); }
 .btn-primary:hover { background: var(--mc-primary-hover); }


### PR DESCRIPTION
## 背景

- #476 试图修复「设置 → 工具目录」核心/扩展工具切换按钮(「→ 扩展」「← 核心」)文字溢出,但打包后问题仍存在。
- 根因:按钮挂 `class="row-btn tier-btn"`,而 `.tier-btn`(行 277)与 `.row-btn`(行 310)在 Tools.vue `<style scoped>` 中**特异性相同**(均为单类 0,1,0)。按 CSS 规则,同特异性时源码顺序后者赢,因此 `.row-btn` 的 `width: 30px` / `display: flex` 反向覆盖了 `.tier-btn` 的 `width: auto` / `line-height: 30px`,导致按钮固定 30px 宽 + 20px 横向 padding,文字区只剩 10px,必然溢出。
- #476 只补了 `.tier-btn` 的属性,未提特异性,等于白补。

## 改动内容

### 文件改动

- **`mateclaw-ui/src/views/Tools.vue`** — 将 `.tier-btn` / `.tier-btn:hover` 选择器升级为复合选择器 `.row-btn.tier-btn` / `.row-btn.tier-btn:hover`,特异性从 0,1,0 提升到 0,2,0,稳压后置的 `.row-btn`,让 `width: auto` / `line-height: 30px` 等文字按钮属性真正生效。

### 测试

- 纯 CSS 选择器调整,无逻辑/ API / 后端代码改动,无需跑测试。
- 验证方式:`cd mateclaw-ui && pnpm dev`,进「设置 → 工具目录」查看核心/扩展工具切换按钮。

## 逐项验证

### 改动 1：`.tier-btn` 选择器特异性提升

**文件**：`mateclaw-ui/src/views/Tools.vue:277-281`

| 项 | 内容 |
|---|---|
| 改了什么 | 把 `.tier-btn { ... }` 与 `.tier-btn:hover { ... }` 两条规则的选择器改为 `.row-btn.tier-btn` 与 `.row-btn.tier-btn:hover`,声明块内容不变。 | | 为什么 | 按钮元素同时挂 `.row-btn` 和 `.tier-btn` 两个类。原 `.tier-btn`(行 277)与 `.row-btn`(行 310)同为单类选择器,特异性 0,1,0 相等;按 CSS 规则同特异性时源码顺序后者赢,`.row-btn` 写在后面,其 `width: 30px` 覆盖 `.tier-btn` 的 `width: auto`,`display: flex` 也覆盖,导致 30px 矮盒装不下「→ 扩展」「← 核心」文字。改为复合选择器 `.row-btn.tier-btn`(0,2,0)后特异性高于 `.row-btn`(0,1,0),文字按钮属性稳赢。 | | 验证步骤 | 1. `cd mateclaw-ui && pnpm install && pnpm dev`<br>2. 浏览器打开 `http://localhost:5173`<br>3. 登录后进入「设置 → 工具目录」<br>4. 查看核心工具区与扩展工具区每行操作列的「→ 扩展」/「← 核心」按钮<br>5. 与同行的编辑(铅笔)、删除(垃圾桶)图标按钮对比高度与对齐 | | 预期结果 | 「→ 扩展」/「← 核心」文字完整显示在按钮内部,不溢出按钮边界;按钮高度与同行编辑/删除图标按钮(30px)一致;hover 时背景变 `--mc-bg-sunken`、文字与边框变 `--mc-primary`。 |

- **反例对照**:若把改动回退为单类 `.tier-btn`,重新构建后文字会再次溢出,可复现原 bug,确认特异性是真正的根因。
- **同场景验证**:确认 Datasources.vue / Sessions.vue / CronJobsPanel.vue / TriggersPanel.vue 等其他页面的 `.row-btn` 图标按钮不受影响(本 PR 仅改 Tools.vue 的 `.row-btn.tier-btn`,且 `<style scoped>`,不串样式)。

## 回归检查清单

- [ ] 「设置 → 工具目录」核心工具区「→ 扩展」按钮文字不溢出
- [ ] 「设置 → 工具目录」扩展工具区「← 核心」按钮文字不溢出
- [ ] 切换按钮高度与同行编辑/删除图标按钮一致(30px)
- [ ] hover 切换按钮时有背景色与边框色变化
- [ ] 编辑/删除图标按钮样式与交互未受影响
- [ ] 其他页面(Datasources / Sessions / Scheduler 等)的 `.row-btn` 图标按钮样式未受影响