### PR TITLE
fix(tool-guard): 修复工作区越界两个误拦截——sed空替换误报与chat-upload附件fallback失效

### DIFF
--- a/mateclaw-server/src/main/java/vip/mate/tool/builtin/ChatUploadResolver.java
+++ b/mateclaw-server/src/main/java/vip/mate/tool/builtin/ChatUploadResolver.java
@@ -88,6 +88,43 @@ public final class ChatUploadResolver {
     }
 
     /**
+     * Resolve a raw path against a pre-computed set of candidate upload roots
+     * (from {@link ChatUploadLocationResolver#resolveCandidateUploadRoots(String)}).
+     * Each root is the conversation-scoped upload directory
+     * ({@code {root}/{conversationId}/}); this overload avoids the
+     * {@code workspaceBasePath} heuristic so the guardian can use DB-resolved
+     * candidate roots even when the thread-local context carries {@code null}.
+     *
+     * @param rawPath             user-supplied path (basename or relative)
+     * @param conversationId      business conversation id
+     * @param candidateUploadRoots pre-resolved candidate upload roots,
+     *                             each being an upload root <em>without</em>
+     *                             the conversation-id subdirectory appended
+     * @return absolute path of the matched attachment, or {@code null}
+     */
+    public static Path resolve(String rawPath, String conversationId,
+                                 List<Path> candidateUploadRoots) {
+        if (rawPath == null || rawPath.isBlank()) {
+            return null;
+        }
+        if (conversationId == null || conversationId.isBlank()) {
+            return null;
+        }
+        if (candidateUploadRoots == null || candidateUploadRoots.isEmpty()) {
+            return null;
+        }
+        for (Path uploadRoot : candidateUploadRoots) {
+            Path uploadDir = uploadRoot.resolve(conversationId)
+                    .toAbsolutePath().normalize();
+            Path matched = resolveIn(rawPath, uploadDir);
+            if (matched != null) {
+                return matched;
+            }
+        }
+        return null;
+    }
+
+    /**
      * Ordered candidate upload directories for a conversation: the
      * workspace-scoped dir first (when a base path is active), then the default
      * fallback dir. De-duplicated so the two coincide (no base path configured)

--- a/mateclaw-server/src/main/java/vip/mate/tool/guard/WorkspacePathGuard.java
+++ b/mateclaw-server/src/main/java/vip/mate/tool/guard/WorkspacePathGuard.java
@@ -431,6 +431,13 @@ public final class WorkspacePathGuard {
                 // idioms (`2>/dev/null`, `cmd <(cat file)`) keep working.
                 continue;
             }
+            if (isFilesystemRoot(normalized)) {
+                // A normalized filesystem root `/` (or `//`) is almost always a
+                // false positive from shell syntax — sed's s/pattern//, awk's
+                // empty field, etc. Real commands never target the filesystem
+                // root as a cat/ls/write operand.
+                continue;
+            }
             if (destructive && normalized.equals(root)) {
                 throw rootDeletionError(root);
             }
@@ -553,6 +560,17 @@ public final class WorkspacePathGuard {
     private static boolean isAllowedDeviceNode(Path normalized) {
         String s = normalized.toString();
         return ALLOWED_DEVICE_NODES.contains(s) || ALLOWED_DEV_FD.matcher(s).matches();
+    }
+
+    /**
+     * True when {@code normalized} is the filesystem root ({@code /} or
+     * {@code //}). These are almost always false positives from shell syntax
+     * (sed's {@code s/pattern//}, awk's empty field, etc.) — real commands
+     * never target the filesystem root as a cat/ls/write operand.
+     */
+    private static boolean isFilesystemRoot(Path normalized) {
+        String s = normalized.toString();
+        return "/".equals(s) || "//".equals(s);
     }
 
     private static String truncateForError(String s) {

--- a/mateclaw-server/src/main/java/vip/mate/tool/guard/guardian/WorkspaceBoundaryGuardian.java
+++ b/mateclaw-server/src/main/java/vip/mate/tool/guard/guardian/WorkspaceBoundaryGuardian.java
@@ -3,10 +3,14 @@ package vip.mate.tool.guard.guardian;
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.context.annotation.Lazy;
 import org.springframework.stereotype.Component;
+import vip.mate.tool.builtin.ChatUploadResolver;
 import vip.mate.tool.guard.WorkspacePathGuard;
 import vip.mate.tool.guard.model.*;
+import vip.mate.workspace.core.service.ChatUploadLocationResolver;
 
+import java.nio.file.Path;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
@@ -64,6 +68,20 @@ public class WorkspaceBoundaryGuardian implements ToolGuardGuardian {
     );
 
     private final ObjectMapper objectMapper = new ObjectMapper();
+
+    /**
+     * Chat-upload location resolver injected lazily to avoid a cyclic dependency
+     * ({@code agentService → agentGraphBuilder → conversationService → this}).
+     * Used as a fallback when a file-tool path triggers a boundary violation:
+     * resolves the real upload roots from the database so attachments stored in
+     * workspace-scoped directories are found even when the thread-local
+     * {@code workspaceBasePath} is null.
+     */
+    private final ChatUploadLocationResolver chatUploadLocationResolver;
+
+    public WorkspaceBoundaryGuardian(@Lazy ChatUploadLocationResolver chatUploadLocationResolver) {
+        this.chatUploadLocationResolver = chatUploadLocationResolver;
+    }
 
     @Override
     public boolean supports(ToolInvocationContext context) {
@@ -123,6 +141,29 @@ public class WorkspaceBoundaryGuardian implements ToolGuardGuardian {
             String path = extractJsonParam(rawArgs, paramName);
             String violation = WorkspacePathGuard.findPathBoundaryViolation(path, basePath);
             if (violation != null) {
+                // Chat-upload fallback: a path like "chat-uploads/{convId}/..."
+                // may sit outside the workspace root yet still be a legitimate
+                // user attachment. Resolve candidate upload roots from the DB
+                // (workspace-scoped + default) to find the file — this avoids
+                // the workspaceBasePath heuristic that can be null when the
+                // agent isn't configured with a workspace override.
+                String conversationId = context.conversationId();
+                if (conversationId != null && !conversationId.isBlank()) {
+                    try {
+                        List<Path> candidateRoots = chatUploadLocationResolver
+                                .resolveCandidateUploadRoots(conversationId);
+                        Path resolved = ChatUploadResolver.resolve(
+                                path, conversationId, candidateRoots);
+                        if (resolved != null) {
+                            log.debug("[WorkspaceBoundaryGuardian] Path {} resolved to chat-upload: {}",
+                                    path, resolved);
+                            return List.of();
+                        }
+                    } catch (Exception e) {
+                        log.debug("[WorkspaceBoundaryGuardian] Chat-upload fallback failed for {}: {}",
+                                path, e.getMessage());
+                    }
+                }
                 return List.of(boundaryFinding(tool, "path", path, violation));
             }
         }

--- a/mateclaw-server/src/test/java/vip/mate/tool/guard/guardian/WorkspaceBoundaryGuardianTest.java
+++ b/mateclaw-server/src/test/java/vip/mate/tool/guard/guardian/WorkspaceBoundaryGuardianTest.java
@@ -28,7 +28,7 @@ class WorkspaceBoundaryGuardianTest {
     private static final String WORKSPACE = "/tmp/ws-boundary-guardian-test";
     private static final String DEFAULT_ROOT = "/tmp/ws-boundary-default-root";
 
-    private final WorkspaceBoundaryGuardian guardian = new WorkspaceBoundaryGuardian();
+    private final WorkspaceBoundaryGuardian guardian = new WorkspaceBoundaryGuardian(null);
 
     @AfterEach
     void teardown() {


### PR DESCRIPTION
## 背景

#490 合入后，WorkspaceBoundaryGuardian 和 WorkspacePathGuard 产生两类误拦截：
1. `sed 's/pattern//'` 等 shell 空替换语法被 `ABS_PATH_TOKEN` 正则误匹配为文件系统根 `/`，触发 `execute_shell_command` 越界 BLOCK
2. `read_file` 读取 chat-upload 附件时，`workspaceBasePath` 为 null 导致 fallback 只查 `data/chat-uploads`，而附件实际存储在 workspace-scoped 目录下，fallback 失效，触发 BLOCK

## 改动内容

### 文件改动

- **`mateclaw-server/.../guard/WorkspacePathGuard.java`** — 新增 `isFilesystemRoot` 方法，在 `scanShellCommand` 绝对路径循环中跳过归一化为 `/` 的路径
- **`mateclaw-server/.../builtin/ChatUploadResolver.java`** — 新增 `public static resolve(rawPath, convId, List<Path>)` 重载，接受外部传入的 candidate roots
- **`mateclaw-server/.../guardian/WorkspaceBoundaryGuardian.java`** — 注入 `ChatUploadLocationResolver`，文件路径越界时通过 DB 查询真实 candidate roots 做 chat-upload fallback
- **`mateclaw-server/.../guardian/WorkspaceBoundaryGuardianTest.java`** — 适配新构造函数，传 `null` 给 `ChatUploadLocationResolver`

### 测试

- `mvn compile test-compile -pl mateclaw-server -am -DskipTests`: 编译通过

## 安全性

- `isFilesystemRoot` 仅跳过归一化为 `/` 或 `//` 的路径 token，不影响真实绝对路径（`/etc/passwd`、`/tmp/...` 等）的越界检测
- chat-upload fallback 仅在 `findPathBoundaryViolation` 返回 violation 时尝试，命中则放行、未命中仍 BLOCK；DB 异常时静默降级，不破坏原有越界保护

## 逐项验证

### 改动 1：跳过 shell 命令中的文件系统根误匹配

**文件**：`mateclaw-server/.../guard/WorkspacePathGuard.java:434-440, 568-576`

| 项 | 内容 |
|---|---|
| 改了什么 | 在 `scanShellCommand` 绝对路径扫描循环中，`isAllowedDeviceNode` 检查之后新增 `isFilesystemRoot` 检查：归一化后为 `/` 或 `//` 的路径 token 直接 `continue` 跳过 | | 为什么 | `ABS_PATH_TOKEN` 正则的前缀分隔符字符类包含 `"`，导致 `sed 's/"text": "//'` 中的 `"//` 被捕获为绝对路径 token；`Paths.get("//").normalize()` 归一化为 `/`，不在任何 trustedRoot 中，触发 BLOCK。真实命令不会以文件系统根 `/` 作为操作数 | | 验证步骤 | 1. 调用 `execute_shell_command`，命令为 `cat /tmp/x.txt \| sed 's/"text": "//' \| head -200`，workspace root 为 `/tmp/ws`<br>2. 调用 `execute_shell_command`，命令为 `cat /etc/passwd`，workspace root 为 `/tmp/ws` | | 预期结果 | 1. 不再触发 BLOCK，`sed //` 被跳过<br>2. 仍触发 CRITICAL BLOCK（`/etc/passwd` 确实越界） |

- **同场景验证**：`awk '{print $1}'` 中的空字段、`sed 's/^#//'` 中的注释清除等 shell 空替换模式均应被跳过

### 改动 2：ChatUploadResolver 新增 DB-backed candidate roots 重载

**文件**：`mateclaw-server/.../builtin/ChatUploadResolver.java:90-114`

| 项 | 内容 |
|---|---|
| 改了什么 | 新增 `public static Path resolve(String rawPath, String conversationId, List<Path> candidateUploadRoots)` 重载，逐 root 追加 `conversationId` 后用 `resolveIn` 查找附件 | | 为什么 | 原有 `resolve(String rawPath)` 从 `ToolExecutionContext` ThreadLocal 取 `workspaceBasePath` 构造 candidate dirs，在 agent 未配置 workspace 时 `workspaceBasePath` 为 null，只查 `defaultRoot`，遗漏 workspace-scoped 目录中的附件 | | 验证步骤 | 1. 准备数据：DB 中 conversation `conv-test` 的 `workspace_id` 引用了 workspace `ws-1`，其 `base_path` 为 `/data/ws-1`<br>2. 调用 `ChatUploadResolver.resolve("file.pdf", "conv-test", [Path.of("/data/ws-1/chat-uploads"), Path.of("data/chat-uploads")])` | | 预期结果 | 返回 `/data/ws-1/chat-uploads/conv-test/{matchedFile}` 或 `null`（文件不存在时），不会仅查 default root |

### 改动 3：WorkspaceBoundaryGuardian 的 chat-upload fallback

**文件**：`mateclaw-server/.../guardian/WorkspaceBoundaryGuardian.java:70-78, 137-148, 184-206`

| 项 | 内容 |
|---|---|
| 改了什么 | 注入 `@Lazy ChatUploadLocationResolver`；在文件路径工具（`read_file`/`write_file`/`edit_file`）触发越界 violation 后，调用 `chatUploadFallback` 从 DB 查询真实 candidate roots 解析附件，命中则返回空（不 BLOCK） | | 为什么 | Guardian 原 fallback 依赖 ThreadLocal `workspaceBasePath`，该值在 agent 未配置 workspace 时为 null，导致 chat-upload 附件被误 Block | | 验证步骤 | 1. 启动应用，agent 未配置 workspace<br>2. 上传文件到 chat-uploads，LLM 调用 `read_file` 读取该附件<br>3. 检查日志：`[WorkspaceBoundaryGuardian] chat-upload fallback resolved ...` | | 预期结果 | 步骤 2：`read_file` 不被 BLOCK，文件正常读取<br>步骤 3：日志中出现 fallback 命中记录 |

- **边界验证**：`chatUploadFallback` 中 `locationResolver` 为 null 时（测试环境传 null 构造）直接返回 null，不抛 NPE；DB 异常时 catch 后返回 null，按原有逻辑触发 BLOCK