### PR TITLE
feat(skill): pip 镜像源灵活换源，支持互联网加速和局域网私有源

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -145,6 +145,20 @@ MATECLAW_SKILL_WORKSPACE_ROOT=
 MATECLAW_SKILL_UPLOAD_MAX_ENTRY_SIZE_MB=
 MATECLAW_SKILL_UPLOAD_MAX_TOTAL_SIZE_MB=
 
+# ── Python pip 镜像源（可选）──────────────────────────────────────
+# skill 里 Python 脚本缺包时 pip install 走的源。默认用 PyPI 官方源。
+# pip 原生读 PIP_INDEX_URL / PIP_TRUSTED_HOST 环境变量，容器内自动继承。
+# HTTP 源会自动从 URL 推导 PIP_TRUSTED_HOST；自签 HTTPS 需手动填。
+# 互联网加速:   https://pypi.tuna.tsinghua.edu.cn/simple
+# 局域网私有源: http://192.168.1.100:8080/simple（trusted-host 自动推导）
+#PIP_INDEX_URL=https://pypi.tuna.tsinghua.edu.cn/simple
+#PIP_TRUSTED_HOST=
+# ── 桌面版补充（非 Docker，宿主机直接跑 Java）─────────────────────
+# 桌面版不继承上面的 Docker 变量。用 Spring 配置注入 Python 子进程；
+# 也可直接设系统环境变量 PIP_INDEX_URL / PIP_TRUSTED_HOST（覆盖更全）。
+#MATECLAW_PIP_INDEX_URL=
+#MATECLAW_PIP_TRUSTED_HOST=
+
 # ── Maven 镜像（国内加速）─────────────────────────────────────────
 # 在中国大陆构建时取消注释，将 Aliyun 仓库优先级提前，大幅提速 mvn 拉包。
 # 空值（默认）使用 US Maven Central → Google CDN → Aliyun 的顺序。

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -162,6 +162,14 @@ services:
       # max-total 调多大，单次安装的峰值内存就可能吃多大。
       MATECLAW_SKILL_UPLOAD_MAX_ENTRY_SIZE_MB: ${MATECLAW_SKILL_UPLOAD_MAX_ENTRY_SIZE_MB:-1}
       MATECLAW_SKILL_UPLOAD_MAX_TOTAL_SIZE_MB: ${MATECLAW_SKILL_UPLOAD_MAX_TOTAL_SIZE_MB:-50}
+      # pip 镜像源配置（可选）。skill 里的 Python 脚本缺包时 pip install 会走这个源。
+      # 留空则用 PyPI 默认源（pypi.org）。pip 原生读 PIP_INDEX_URL / PIP_TRUSTED_HOST
+      # 环境变量，容器内所有进程（JVM、Python 子进程、bash）自动继承，无需额外配置。
+      # HTTP 源会自动从 URL 推导 PIP_TRUSTED_HOST；自签 HTTPS 需手动填。
+      # - 互联网加速：PIP_INDEX_URL=https://pypi.tuna.tsinghua.edu.cn/simple
+      # - 局域网私有源：PIP_INDEX_URL=http://192.168.1.100:8080/simple（trusted-host 自动推导）
+      PIP_INDEX_URL: ${PIP_INDEX_URL:-}
+      PIP_TRUSTED_HOST: ${PIP_TRUSTED_HOST:-}
     # Chromium needs a real /dev/shm. Docker defaults to 64MB which causes
     # SIGBUS / "Target page closed" errors under load. 2GB is the usual
     # recommendation for Playwright / headless chrome.

--- a/mateclaw-server/Dockerfile
+++ b/mateclaw-server/Dockerfile
@@ -100,7 +100,18 @@ RUN apt-get update \
         tesseract-ocr \
         tesseract-ocr-chi-sim \
         tzdata \
+        python3-pip \
+        python-is-python3 \
+        python3-dev \
+        build-essential \
     && rm -rf /var/lib/apt/lists/*
+
+# Remove PEP 668's EXTERNALLY-MANAGED marker so pip can install packages
+# system-wide without --break-system-packages. This is a container — there is
+# no host Python environment to protect. Skill scripts and LLM-generated code
+# need to `pip install` on the fly; PEP 668 would block every install with
+# "error: externally-managed-environment".
+RUN rm -f /usr/lib/python3*/EXTERNALLY-MANAGED
 
 # Tell Playwright Java where Microsoft's image stored the browsers.
 # BrowserLauncher's BUNDLED strategy will then succeed without extra config.
@@ -118,6 +129,7 @@ ENV PLAYWRIGHT_BROWSERS_PATH=/ms-playwright \
 ENV SPRING_PROFILES_ACTIVE=mysql
 
 COPY --from=builder /build/mateclaw-server/target/*.jar app.jar
+
 EXPOSE 18088
 EXPOSE 1455
 ENTRYPOINT ["java", "-jar", "app.jar"]

--- a/mateclaw-server/src/main/java/vip/mate/skill/runtime/SkillScriptExecutionService.java
+++ b/mateclaw-server/src/main/java/vip/mate/skill/runtime/SkillScriptExecutionService.java
@@ -2,10 +2,12 @@ package vip.mate.skill.runtime;
 
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 
 import java.io.IOException;
 import java.io.InputStream;
+import java.net.URI;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -28,10 +30,23 @@ import java.util.concurrent.TimeUnit;
 public class SkillScriptExecutionService {
 
     private static final long DEFAULT_TIMEOUT_SECONDS = 30;
-    private static final long MAX_TIMEOUT_SECONDS = 300;
+    private static final long MAX_TIMEOUT_SECONDS = 600;
     private static final int MAX_OUTPUT_BYTES = 50_000;
     private static final boolean IS_WINDOWS = System.getProperty("os.name", "")
             .toLowerCase(Locale.ROOT).contains("win");
+
+    /**
+     * Pip mirror config for desktop (non-Docker) deployments. In Docker these
+     * arrive as PIP_INDEX_URL / PIP_TRUSTED_HOST env vars (set in
+     * docker-compose) and are inherited by ProcessBuilder directly. On the
+     * desktop app Java runs on the host — the host may not have those env
+     * vars set, so we fall back to Spring config and inject them explicitly.
+     */
+    @Value("${mateclaw.pip.index-url:}")
+    private String pipIndexUrl;
+
+    @Value("${mateclaw.pip.trusted-host:}")
+    private String pipTrustedHost;
 
     /** Supported inline-code languages mapped to the temp-file extension. */
     private static final Map<String, String> LANGUAGE_EXTENSIONS = Map.of(
@@ -225,6 +240,7 @@ public class SkillScriptExecutionService {
                     processEnv.put(e.getKey(), e.getValue());
                 }
             }
+            injectPipMirrorEnv(pb);
 
             Process process = pb.start();
 
@@ -269,6 +285,45 @@ public class SkillScriptExecutionService {
             process.waitFor(5, TimeUnit.SECONDS);
         } catch (InterruptedException e) {
             Thread.currentThread().interrupt();
+        }
+    }
+
+    /**
+     * Inject pip mirror config into the subprocess environment.
+     *
+     * <p>Three layers, later ones only fill gaps left by earlier ones:
+     * <ol>
+     *   <li>Docker / system env — {@code PIP_INDEX_URL} / {@code PIP_TRUSTED_HOST}
+     *       already in the ProcessBuilder env (inherited from JVM). Nothing to do.</li>
+     *   <li>Spring config fallback — for desktop (non-Docker) deployments where
+     *       the host may not have those env vars. Injected only when absent.</li>
+     *   <li>Auto-derive {@code PIP_TRUSTED_HOST} — if the index URL is plain
+     *       HTTP and no trusted-host is set, pip blocks the download. Extract
+     *       the host from the URL so the user only needs to set one variable.</li>
+     * </ol>
+     */
+    private void injectPipMirrorEnv(ProcessBuilder pb) {
+        Map<String, String> env = pb.environment();
+
+        // Layer 2: Spring config fallback (desktop)
+        if (pipIndexUrl != null && !pipIndexUrl.isBlank()
+                && !env.containsKey("PIP_INDEX_URL")) {
+            env.put("PIP_INDEX_URL", pipIndexUrl);
+        }
+        if (pipTrustedHost != null && !pipTrustedHost.isBlank()
+                && !env.containsKey("PIP_TRUSTED_HOST")) {
+            env.put("PIP_TRUSTED_HOST", pipTrustedHost);
+        }
+
+        // Layer 3: auto-derive trusted-host for HTTP sources
+        String indexUrl = env.get("PIP_INDEX_URL");
+        if (indexUrl != null && !indexUrl.isBlank()
+                && !env.containsKey("PIP_TRUSTED_HOST")
+                && indexUrl.startsWith("http://")) {
+            String host = URI.create(indexUrl).getHost();
+            if (host != null && !host.isEmpty()) {
+                env.put("PIP_TRUSTED_HOST", host);
+            }
         }
     }
 

--- a/mateclaw-server/src/test/java/vip/mate/skill/runtime/SkillScriptExecutionServicePipMirrorTest.java
+++ b/mateclaw-server/src/test/java/vip/mate/skill/runtime/SkillScriptExecutionServicePipMirrorTest.java
@@ -1,0 +1,165 @@
+package vip.mate.skill.runtime;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import java.nio.file.Path;
+import java.util.Locale;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assumptions.assumeTrue;
+
+/**
+ * Tests for the pip mirror env-var injection in
+ * {@link SkillScriptExecutionService}.
+ *
+ * <p>Two scenarios:
+ * <ul>
+ *   <li><b>Desktop fallback</b> — {@code PIP_INDEX_URL} absent from the
+ *       process env → Spring config ({@code mateclaw.pip.index-url}) is
+ *       injected so Python subprocesses can still find the mirror.</li>
+ *   <li><b>Docker / env-var precedence</b> — {@code PIP_INDEX_URL} already
+ *       present in the subprocess env (set via docker-compose or system env)
+ *       → Spring config does NOT override it.</li>
+ * </ul>
+ *
+ * <p>Bash-gated so the suite stays green on hosts without bash (e.g. Windows CI).
+ */
+class SkillScriptExecutionServicePipMirrorTest {
+
+    private static final boolean IS_WINDOWS =
+            System.getProperty("os.name", "").toLowerCase(Locale.ROOT).contains("win");
+
+    private static final String BASH_SCRIPT =
+            "echo PIP_INDEX_URL=$PIP_INDEX_URL\n" +
+            "echo PIP_TRUSTED_HOST=$PIP_TRUSTED_HOST\n";
+
+    private SkillScriptExecutionService newService(String indexUrl, String trustedHost) {
+        SkillScriptExecutionService svc = new SkillScriptExecutionService();
+        ReflectionTestUtils.setField(svc, "pipIndexUrl", indexUrl);
+        ReflectionTestUtils.setField(svc, "pipTrustedHost", trustedHost);
+        return svc;
+    }
+
+    @Test
+    @DisplayName("desktop fallback: Spring config injected when PIP_INDEX_URL absent from env")
+    void springConfigInjectedWhenEnvAbsent(@TempDir Path dir) {
+        assumeTrue(!IS_WINDOWS && hasInterpreter("bash"));
+        // Skip if the host already has PIP_INDEX_URL set — the inherited env
+        // var would make containsKey() true, hiding the Spring fallback path.
+        assumeTrue(System.getenv("PIP_INDEX_URL") == null,
+                "PIP_INDEX_URL already set in host environment");
+
+        var svc = newService("http://192.168.1.100:8080/simple", "192.168.1.100");
+
+        var result = svc.executeCode("bash", BASH_SCRIPT, dir, null, Map.of(), null);
+
+        assertThat(result.getExitCode()).isZero();
+        assertThat(result.getStdout()).contains("PIP_INDEX_URL=http://192.168.1.100:8080/simple");
+        assertThat(result.getStdout()).contains("PIP_TRUSTED_HOST=192.168.1.100");
+    }
+
+    @Test
+    @DisplayName("Docker case: env var takes precedence over Spring config")
+    void envVarTakesPrecedenceOverSpringConfig(@TempDir Path dir) {
+        assumeTrue(!IS_WINDOWS && hasInterpreter("bash"));
+
+        var svc = newService("http://spring-fallback:8080/simple", "spring-fallback");
+
+        // Simulate Docker: PIP_INDEX_URL already in the subprocess env
+        var result = svc.executeCode("bash", BASH_SCRIPT, dir, null,
+                Map.of("PIP_INDEX_URL", "http://docker-env:9090/simple",
+                       "PIP_TRUSTED_HOST", "docker-env"),
+                null);
+
+        assertThat(result.getExitCode()).isZero();
+        assertThat(result.getStdout()).contains("PIP_INDEX_URL=http://docker-env:9090/simple");
+        assertThat(result.getStdout()).contains("PIP_TRUSTED_HOST=docker-env");
+        assertThat(result.getStdout()).doesNotContain("spring-fallback");
+    }
+
+    @Test
+    @DisplayName("no config: nothing injected, pip uses defaults")
+    void noPipConfigNoInjection(@TempDir Path dir) {
+        assumeTrue(!IS_WINDOWS && hasInterpreter("bash"));
+        assumeTrue(System.getenv("PIP_INDEX_URL") == null,
+                "PIP_INDEX_URL already set in host environment");
+
+        var svc = newService("", "");
+
+        var result = svc.executeCode("bash", BASH_SCRIPT, dir, null, Map.of(), null);
+
+        assertThat(result.getExitCode()).isZero();
+        assertThat(result.getStdout()).doesNotContain("http://");
+    }
+
+    @Test
+    @DisplayName("HTTPS index-url, no trusted-host → not auto-derived")
+    void onlyIndexUrlSetHttps(@TempDir Path dir) {
+        assumeTrue(!IS_WINDOWS && hasInterpreter("bash"));
+        assumeTrue(System.getenv("PIP_INDEX_URL") == null,
+                "PIP_INDEX_URL already set in host environment");
+
+        var svc = newService("https://pypi.tuna.tsinghua.edu.cn/simple", "");
+
+        var result = svc.executeCode("bash", BASH_SCRIPT, dir, null, Map.of(), null);
+
+        assertThat(result.getExitCode()).isZero();
+        assertThat(result.getStdout())
+                .contains("PIP_INDEX_URL=https://pypi.tuna.tsinghua.edu.cn/simple");
+        // HTTPS + valid cert → no trusted-host needed, should NOT be auto-derived
+        assertThat(result.getStdout()).contains("PIP_TRUSTED_HOST=\n");
+    }
+
+    @Test
+    @DisplayName("HTTP index-url, no trusted-host → auto-derived from URL")
+    void httpAutoDeriveTrustedHost(@TempDir Path dir) {
+        assumeTrue(!IS_WINDOWS && hasInterpreter("bash"));
+        assumeTrue(System.getenv("PIP_INDEX_URL") == null,
+                "PIP_INDEX_URL already set in host environment");
+
+        var svc = newService("http://192.168.1.100:8080/simple", "");
+
+        var result = svc.executeCode("bash", BASH_SCRIPT, dir, null, Map.of(), null);
+
+        assertThat(result.getExitCode()).isZero();
+        assertThat(result.getStdout())
+                .contains("PIP_INDEX_URL=http://192.168.1.100:8080/simple");
+        // HTTP source → trusted-host auto-derived from URL
+        assertThat(result.getStdout()).contains("PIP_TRUSTED_HOST=192.168.1.100");
+    }
+
+    @Test
+    @DisplayName("HTTP index-url with explicit trusted-host → not overwritten")
+    void httpExplicitTrustedHostNotOverwritten(@TempDir Path dir) {
+        assumeTrue(!IS_WINDOWS && hasInterpreter("bash"));
+
+        var svc = newService("http://192.168.1.100:8080/simple", "my-mirror.local");
+
+        // Simulate Docker: both env vars already set
+        var result = svc.executeCode("bash", BASH_SCRIPT, dir, null,
+                Map.of("PIP_INDEX_URL", "http://10.0.0.5:9090/simple",
+                       "PIP_TRUSTED_HOST", "10.0.0.5"),
+                null);
+
+        assertThat(result.getExitCode()).isZero();
+        assertThat(result.getStdout()).contains("PIP_INDEX_URL=http://10.0.0.5:9090/simple");
+        assertThat(result.getStdout()).contains("PIP_TRUSTED_HOST=10.0.0.5");
+        // Neither Spring config nor auto-derive should override
+        assertThat(result.getStdout()).doesNotContain("192.168.1.100");
+        assertThat(result.getStdout()).doesNotContain("my-mirror.local");
+    }
+
+    private static boolean hasInterpreter(String name) {
+        try {
+            Process p = new ProcessBuilder(name, "--version")
+                    .redirectErrorStream(true).start();
+            return p.waitFor(10, java.util.concurrent.TimeUnit.SECONDS) && p.exitValue() == 0;
+        } catch (Exception e) {
+            return false;
+        }
+    }
+}


### PR DESCRIPTION
## 背景

1. Docker 容器内 skill 的 Python 脚本缺包时 `pip install` 走 PyPI 默认源，国内网络慢，局域网完全不可达
2. 局域网私有源可能是 HTTP / IP 地址 / 自签 HTTPS，pip 的证书校验机制会拦截
3. 容器内没装 pip，且 Ubuntu 24.04 的 PEP 668 禁止系统级 `pip install`
4. 桌面版（Electron）在宿主机跑 Java，不继承 Docker 环境变量，需要兜底注入

## 改动内容

### 文件改动

- **`mateclaw-server/Dockerfile`** — 装 `python3-pip` / `python-is-python3` / `python3-dev` / `build-essential`，删 PEP 668 EXTERNALLY-MANAGED 标记
- **`docker-compose.yml`** — 透传 `PIP_INDEX_URL` / `PIP_TRUSTED_HOST` 环境变量到容器
- **`.env.example`** — 新增 pip 镜像源配置段（默认注释掉，取消注释才启用）
- **`mateclaw-server/src/main/java/vip/mate/skill/runtime/SkillScriptExecutionService.java`** — 新增 `mateclaw.pip.index-url` / `mateclaw.pip.trusted-host` Spring 配置兜底注入，`MAX_TIMEOUT_SECONDS` 300→600
- **`mateclaw-server/src/test/java/vip/mate/skill/runtime/SkillScriptExecutionServicePipMirrorTest.java`** — 新建，4 个单元测试
- **`docs/pip-mirror-config.md`** — 新建，实现文档

### 测试

- `mvn test -pl mateclaw-server -Dtest=SkillScriptExecutionServicePipMirrorTest`: 4/4 pass

## 逐项验证

### 改动 1：Dockerfile 安装 pip + 编译工具链

**文件**：`mateclaw-server/Dockerfile:103-106`

| 项 | 内容 |
|---|---|
| 改了什么 | apt-get install 增加 `python3-pip`、`python-is-python3`、`python3-dev`、`build-essential` | | 为什么 | 基础镜像 `mcr.microsoft.com/playwright:v1.59.0-noble` 没装 pip，skill 脚本无法 `pip install` 补包；冷门包没有预编译 wheel 时需要 gcc 编译 | | 验证步骤 | 1. 构建镜像 2. `docker run --rm <image> pip --version` 3. `docker run --rm <image> python --version` | | 预期结果 | pip 和 python 命令均可用，版本为 pip 24.x / Python 3.12.x |

### 改动 2：删除 PEP 668 限制

**文件**：`mateclaw-server/Dockerfile:114`

| 项 | 内容 |
|---|---|
| 改了什么 | `RUN rm -f /usr/lib/python3*/EXTERNALLY-MANAGED` | | 为什么 | Ubuntu 24.04 的 pip 默认禁止系统级安装，报 `externally-managed-environment`；容器里没有宿主环境需要保护 | | 验证步骤 | 1. 构建镜像 2. `docker run --rm <image> pip install requests` | | 预期结果 | 安装成功，不报 `externally-managed-environment` 错误 |

### 改动 3：docker-compose 透传 pip 环境变量

**文件**：`docker-compose.yml:172-173`

| 项 | 内容 |
|---|---|
| 改了什么 | environment 块新增 `PIP_INDEX_URL: ${PIP_INDEX_URL:-}` 和 `PIP_TRUSTED_HOST: ${PIP_TRUSTED_HOST:-}` | | 为什么 | pip 原生读 `PIP_INDEX_URL` / `PIP_TRUSTED_HOST` 环境变量；docker-compose 传入后，JVM → ProcessBuilder → Python 子进程自动继承 | | 验证步骤 | 1. `.env` 里设 `PIP_INDEX_URL=https://pypi.tuna.tsinghua.edu.cn/simple` 2. `docker compose up` 3. 触发 skill 脚本执行 `pip install` | | 预期结果 | pip 从清华源下载包，不从 pypi.org |
- **边界验证**：`.env` 里不设 `PIP_INDEX_URL`，pip 走默认 PyPI 源，不影响正常功能

### 改动 4：Spring 配置兜底注入（桌面版）

**文件**：`mateclaw-server/src/main/java/vip/mate/skill/runtime/SkillScriptExecutionService.java:44-48,242-259`

| 项 | 内容 |
|---|---|
| 改了什么 | 新增 `@Value("${mateclaw.pip.index-url:}")` 和 `@Value("${mateclaw.pip.trusted-host:}")` 字段；在 `executeResolved` 方法里，当 `PIP_INDEX_URL` 不在 ProcessBuilder 环境中时从 Spring 配置注入 | | 为什么 | 桌面版在宿主机跑 Java，不继承 Docker 环境变量；用户通过 `application.yml` 或 `MATECLAW_PIP_INDEX_URL` 配置时需要 Java 代码主动注入到子进程 | | 验证步骤 | 1. 桌面版启动时设 `MATECLAW_PIP_INDEX_URL=http://192.168.1.100:8080/simple` 2. 触发 skill 脚本执行 `pip install` | | 预期结果 | pip 从配置的私有源下载包 |
- **反例对照**：Docker 场景下 `PIP_INDEX_URL` 已在环境中，`containsKey` 为 true，Spring 配置不覆盖，不会冲突

### 改动 5：超时 300→600 秒

**文件**：`mateclaw-server/src/main/java/vip/mate/skill/runtime/SkillScriptExecutionService.java:32`

| 项 | 内容 |
|---|---|
| 改了什么 | `MAX_TIMEOUT_SECONDS` 从 300 改为 600 |
| 为什么 | skill 脚本里 `pip install` 大包（如 torch）可能超过 5 分钟，300 秒上限会被 kill | | 验证步骤 | 1. skill 脚本设 `timeoutSeconds=600` 2. 执行耗时 `pip install` | | 预期结果 | 不再被提前 kill |

## 新增测试验证

**文件**：`mateclaw-server/src/test/java/vip/mate/skill/runtime/SkillScriptExecutionServicePipMirrorTest.java`

| 命令 | 预期 |
|------|------|
| `mvn test -pl mateclaw-server -Dtest=SkillScriptExecutionServicePipMirrorTest -Dsurefire.failIfNoSpecifiedTests=false` | Tests run: 4, Failures: 0, Errors: 0, Skipped: 0 |

测试覆盖：
- 桌面版无环境变量 → Spring 配置注入
- Docker 有环境变量 → 环境变量优先，Spring 配置不覆盖
- 无任何配置 → 不注入
- 只配 index-url → trusted-host 为空