### PR TITLE
fix(wiki): budget the system-prompt KB page listing to the model window (#521)

### DIFF
--- a/mateclaw-server/src/main/java/vip/mate/agent/AgentGraphBuilder.java
+++ b/mateclaw-server/src/main/java/vip/mate/agent/AgentGraphBuilder.java
@@ -1743,8 +1743,13 @@ public class AgentGraphBuilder {
                 """;
         }
 
-        // Wiki 知识库上下文注入
-        String wikiContext = wikiContextService.buildWikiContext(entity.getId());
+        // Wiki 知识库上下文注入。Share the same prefix budget as the memory
+        // block so a large KB's page listing can't consume a fixed
+        // maxContextChars-sized slice of a small model's window every turn
+        // (issue #521). Integer.MAX_VALUE (the unbudgeted default path) keeps
+        // the legacy chars-only cap for large cloud models.
+        Integer wikiBudgetTokens = memoryBudgetTokens == Integer.MAX_VALUE ? null : memoryBudgetTokens;
+        String wikiContext = wikiContextService.buildWikiContext(entity.getId(), wikiBudgetTokens);
 
         return basePrompt + ABOUT_YOU_BLOCK + toolGuidance + searchGuidance + wikiContext;
     }

--- a/mateclaw-server/src/main/java/vip/mate/wiki/service/WikiContextService.java
+++ b/mateclaw-server/src/main/java/vip/mate/wiki/service/WikiContextService.java
@@ -151,7 +151,22 @@ public class WikiContextService {
      * Build full wiki context for agent system prompt.
      */
     public String buildWikiContext(Long agentId) {
+        return buildWikiContext(agentId, null);
+    }
+
+    /**
+     * Budgeted variant of the system-prompt wiki listing. In addition to the
+     * absolute {@code maxContextChars} cap (sized for large cloud models), the
+     * enumerated page list may not exceed {@code budgetTokens} (estimated), so
+     * a large KB cannot consume a fixed ~{@code maxContextChars}-sized slice of
+     * a small local model's context window on every turn. A null budget keeps
+     * the previous chars-only behavior; a non-positive budget skips injection.
+     */
+    public String buildWikiContext(Long agentId, Integer budgetTokens) {
         if (!properties.isEnabled()) {
+            return "";
+        }
+        if (budgetTokens != null && budgetTokens <= 0) {
             return "";
         }
 
@@ -166,6 +181,9 @@ public class WikiContextService {
 
         int totalChars = 0;
         int maxChars = properties.getMaxContextChars();
+        // Running estimate of what has been appended, so the page enumeration
+        // (the part that scales with KB file count) can respect budgetTokens.
+        int totalTokens = TokenEstimator.estimateTokens(sb.toString());
 
         // Each KB renders as a HEADING-ONLY block (### <name>) followed by a
         // metadata line and its page list. The heading deliberately contains
@@ -180,16 +198,20 @@ public class WikiContextService {
             List<WikiPageEntity> pages = pageService.listSummaries(kb.getId());
             if (pages.isEmpty()) continue;
 
-            // Heading: pure KB name. This is what `kbName` expects verbatim.
-            sb.append("### ").append(kb.getName()).append("\n");
+            // Heading: pure KB name (what `kbName` expects verbatim) plus a
+            // metadata line — built as one string so its tokens are budgeted too.
+            StringBuilder heading = new StringBuilder();
+            heading.append("### ").append(kb.getName()).append("\n");
             // Metadata line: page count first (easy to scan), then optional
             // description. Lives on its own line so it can't be confused for
             // part of the name.
-            sb.append(pages.size()).append(" pages");
+            heading.append(pages.size()).append(" pages");
             if (kb.getDescription() != null && !kb.getDescription().isBlank()) {
-                sb.append(" — ").append(kb.getDescription());
+                heading.append(" — ").append(kb.getDescription());
             }
-            sb.append("\n\n");
+            heading.append("\n\n");
+            sb.append(heading);
+            totalTokens += TokenEstimator.estimateTokens(heading.toString());
 
             boolean compact = pages.size() > 20;
 
@@ -204,12 +226,15 @@ public class WikiContextService {
                     }
                     line += "\n";
                 }
-                if (totalChars + line.length() > maxChars) {
+                int lineTokens = TokenEstimator.estimateTokens(line);
+                if (totalChars + line.length() > maxChars
+                        || (budgetTokens != null && totalTokens + lineTokens > budgetTokens)) {
                     sb.append("- ... and more (use wiki_list_pages to see all)\n");
                     break;
                 }
                 sb.append(line);
                 totalChars += line.length();
+                totalTokens += lineTokens;
             }
             sb.append("\n");
         }

--- a/mateclaw-server/src/test/java/vip/mate/wiki/service/WikiContextServiceBudgetTest.java
+++ b/mateclaw-server/src/test/java/vip/mate/wiki/service/WikiContextServiceBudgetTest.java
@@ -7,6 +7,7 @@ import org.mockito.Mockito;
 import vip.mate.wiki.WikiProperties;
 import vip.mate.wiki.dto.PageSearchResult;
 import vip.mate.wiki.model.WikiKnowledgeBaseEntity;
+import vip.mate.wiki.model.WikiPageEntity;
 
 import java.util.List;
 
@@ -17,12 +18,15 @@ import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.ArgumentMatchers.anyString;
 
 /**
- * Tests for the token-budgeted knowledge-base relevance injection in
- * {@link WikiContextService}.
+ * Tests for the token-budgeted knowledge-base injection in
+ * {@link WikiContextService} — both the per-query relevance block
+ * ({@code buildRelevantContext}) and the system-prompt page listing
+ * ({@code buildWikiContext}).
  */
 class WikiContextServiceBudgetTest {
 
     private WikiKnowledgeBaseService kbService;
+    private WikiPageService pageService;
     private HybridRetriever hybridRetriever;
     private WikiProperties properties;
     private WikiContextService service;
@@ -31,7 +35,7 @@ class WikiContextServiceBudgetTest {
     void setUp() {
         kbService = Mockito.mock(WikiKnowledgeBaseService.class);
         hybridRetriever = Mockito.mock(HybridRetriever.class);
-        WikiPageService pageService = Mockito.mock(WikiPageService.class);
+        pageService = Mockito.mock(WikiPageService.class);
         properties = new WikiProperties();
         service = new WikiContextService(kbService, pageService, hybridRetriever, properties);
 
@@ -83,5 +87,54 @@ class WikiContextServiceBudgetTest {
         String result = service.buildRelevantContext(1L, "如何配置数据库连接", 0);
         assertEquals("", result);
         Mockito.verifyNoInteractions(hybridRetriever);
+    }
+
+    // ---- buildWikiContext (system-prompt page listing) budget (issue #521) ----
+
+    private void stubKbWithPages(int pageCount) {
+        WikiKnowledgeBaseEntity kb = new WikiKnowledgeBaseEntity();
+        kb.setId(7L);
+        kb.setName("产品知识库");
+        Mockito.when(kbService.listByAgentId(anyLong())).thenReturn(List.of(kb));
+
+        List<WikiPageEntity> pages = new java.util.ArrayList<>();
+        for (int i = 0; i < pageCount; i++) {
+            WikiPageEntity p = new WikiPageEntity();
+            p.setSlug("page-" + i);
+            p.setTitle("知识库页面标题" + i);
+            pages.add(p);
+        }
+        Mockito.when(pageService.listSummaries(anyLong())).thenReturn(pages);
+    }
+
+    @Test
+    @DisplayName("null budget lists all pages (chars-only legacy behavior)")
+    void wikiContextNullBudgetListsAll() {
+        stubKbWithPages(50);
+        String result = service.buildWikiContext(1L, null);
+        assertTrue(result.contains("page-0"));
+        assertTrue(result.contains("page-49"));
+        assertFalse(result.contains("... and more"));
+    }
+
+    @Test
+    @DisplayName("token budget truncates the page listing and appends the search hint")
+    void wikiContextBudgetTruncates() {
+        stubKbWithPages(50);
+        // Each compact line ("- page-N: 知识库页面标题N\n") is ~10+ CJK tokens; a
+        // small budget must cut the listing well before all 50 pages.
+        String result = service.buildWikiContext(1L, 80);
+        assertTrue(result.contains("page-0"));
+        assertFalse(result.contains("page-49"));
+        assertTrue(result.contains("... and more (use wiki_list_pages to see all)"));
+    }
+
+    @Test
+    @DisplayName("zero or negative budget skips the wiki block entirely")
+    void wikiContextZeroBudgetSkips() {
+        String result = service.buildWikiContext(1L, 0);
+        assertEquals("", result);
+        Mockito.verifyNoInteractions(kbService);
+        Mockito.verifyNoInteractions(pageService);
     }
 }


### PR DESCRIPTION
## 问题

排查 #521 问题1（KB 文件多时"工具 token 预估"塞满上下文）。

`WikiContextService.buildWikiContext` 把 Agent 绑定知识库的**页清单枚举进系统提示词**，只有 `maxContextChars`（默认 10000，为大模型设定）一个上限。小上下文模型上，大知识库因此**每轮固定吃掉一大块窗口**。

补充定位：这块增长落在**系统提示词**桶，不是"工具与技能"桶——wiki 工具（`wiki_search`/`wiki_read_page` 等）schema 固定，**不随文件数增长**。用户看到的"工具占用"多半是把两个桶归错；叠加估算器对中文按 1 字≈1 token（`TokenEstimator.java:59`）使显示数字偏高。

## 改动（仅后端）

- 新增预算版重载 `buildWikiContext(agentId, budgetTokens)`，镜像已有的 `buildRelevantContext` 预算模式：页枚举在**估算 token 超预算**时停止，追加既有的 `... and more (use wiki_list_pages)` 提示。
- `AgentGraphBuilder.buildEnhancedPrompt` 把已用于 memory 块的同一份前缀预算传给 wiki；旧的 `Integer.MAX_VALUE`（无预算）路径保留大模型的 chars-only 行为，无行为回归。

小上下文模型上 wiki 清单按模型窗口自动缩减，大模型不受影响。

## 测试

扩展 `WikiContextServiceBudgetTest`：null 预算（全列）、token 预算截断（含搜索提示）、零预算跳过。共 7/7 通过。

## 验证

- ✅ `mvn -o test -Dtest=WikiContextServiceBudgetTest` → Tests run: 7, Failures: 0, Errors: 0
- ✅ BUILD SUCCESS（主代码编译通过）

## 说明

本 PR 只处理 #521 的问题1。问题2（工具调用重复显示）单独提 PR；问题3（memory）偏配置/设计，已在 issue 下请报告者补充信息。
