### PR TITLE
fix(agents): 偏好供应商同一模型可被重复选择

### DIFF
--- a/mateclaw-ui/src/views/Agents.vue
+++ b/mateclaw-ui/src/views/Agents.vue
@@ -606,8 +606,15 @@
                 <span class="provider-pref-rank">{{ idx + 1 }}</span>
                 <span class="provider-pref-name">{{ providerNameById(pref.providerId) }}</span>
                 <select class="provider-pref-model" v-model="pref.modelId">
-                  <option :value="null">{{ t('agents.binding.providerDefaultModel') }}</option>
-                  <option v-for="m in modelsForProvider(pref.providerId)" :key="m.id" :value="m.id">
+                  <option :value="null" :disabled="isProviderChoiceTaken(pref.providerId, null, idx)">
+                    {{ t('agents.binding.providerDefaultModel') }}
+                  </option>
+                  <option
+                    v-for="m in modelsForProvider(pref.providerId)"
+                    :key="m.id"
+                    :value="m.id"
+                    :disabled="isProviderChoiceTaken(pref.providerId, m.id, idx)"
+                  >
                     {{ m.modelName }}
                   </option>
                 </select>
@@ -625,6 +632,7 @@
                 v-for="p in availableProviders"
                 :key="p.id"
                 class="provider-pref-add-btn"
+                :disabled="!hasFreeProviderChoice(p.id)"
                 @click="addProviderEntry(p.id)"
               >+ {{ p.name }}</button>
             </div>
@@ -1251,10 +1259,38 @@ function modelsForProvider(providerId: string) {
   return availableModels.value.filter(m => m.provider === providerId)
 }
 
-// Append a new chain entry (defaults to the provider's default model). The same
-// provider may appear more than once, so we never dedup here.
+// Whether a specific (provider, model) — or the provider's default slot when
+// modelId === null — is already chosen in another row. Keeps each
+// (provider, model) unique across the chain. `exceptIdx` excludes one row
+// (pass the current row's index so its own value stays selectable); pass -1
+// to check against every row (used when appending).
+function isProviderChoiceTaken(providerId: string, modelId: string | null, exceptIdx: number): boolean {
+  return selectedProviderPrefs.value.some(
+    (pref, i) => i !== exceptIdx && pref.providerId === providerId && pref.modelId === modelId,
+  )
+}
+
+// Whether the provider still has any free (provider, model) slot to add.
+function hasFreeProviderChoice(providerId: string): boolean {
+  if (!isProviderChoiceTaken(providerId, null, -1)) return true
+  return modelsForProvider(providerId).some(m => !isProviderChoiceTaken(providerId, m.id, -1))
+}
+
+// Append a new chain entry. The same provider may repeat across the chain,
+// but each (provider, model) must stay unique: take the default slot if it is
+// still free, otherwise the first unused model. If every option is already
+// picked there is nothing to add.
 function addProviderEntry(providerId: string) {
-  selectedProviderPrefs.value.push({ providerId, modelId: null })
+  if (!isProviderChoiceTaken(providerId, null, -1)) {
+    selectedProviderPrefs.value.push({ providerId, modelId: null })
+    return
+  }
+  const firstFree = modelsForProvider(providerId).find(
+    m => !isProviderChoiceTaken(providerId, m.id, -1),
+  )
+  if (firstFree) {
+    selectedProviderPrefs.value.push({ providerId, modelId: firstFree.id })
+  }
 }
 
 function removeProviderEntry(idx: number) {


### PR DESCRIPTION
## 背景 / Background

Fixes #530

在「编辑员工 → 偏好供应商」tab 中，每个供应商支持选择多个模型，但同一个 `(供应商, 模型)` 组合可以被重复选中——同一供应商的同一个模型能被反复添加/勾选。预期行为：**同一供应商的模型不应被重复选择**（供应商本身可在 fallback 链中重复出现，但每个 `(provider, model)` 应保持唯一）。

## 问题根因 / Root Cause

`mateclaw-ui/src/views/Agents.vue`：

1. `addProviderEntry()` 无任何去重，直接 `push({ providerId, modelId: null })`，注释甚至写着 *"we never dedup here"*。
2. 模型下拉 `<option>` 渲染该供应商下所有启用模型，没有 `disabled` 状态，因此已在别的行选中的模型仍可再次选中。

迁移 `V161__agent_provider_preference_model.sql` 的注释声称 *"the UI prevents that"*，但 UI 实际并未阻止；唯一索引 `uk_agent_provider_model(agent_id, provider_id, model_id)` 因 SQL 对 `NULL` 的处理（NULL 视为互异）也无法拦截「供应商默认模型」（`model_id IS NULL`）的重复。

## 修复方案 / Changes

- **`isProviderChoiceTaken(providerId, modelId, exceptIdx)`**：检测某个 `(provider, model)` 槽位——或供应商默认槽位（`modelId === null`）——是否已在其它行被占用。`exceptIdx` 排除当前行，使其自身已选值仍可选。
- **模型 `<option>` 与「供应商默认模型」选项**：已被占用时 `:disabled`，从而无法重复选择。
- **`addProviderEntry()`**：默认槽位空闲则用它，否则取第一个未使用的模型；若所有选项都已占用则不添加。
- **「+ 供应商」按钮**：当该供应商已无可用 `(provider, model)` 槽位时禁用，避免点击后无反应。

## 复现步骤 / Reproduction

1. admin 登录 → Agents 页面 → 编辑某员工 → 切到「偏好供应商」tab
2. 点「+ 某供应商」连续添加两行
3. 修改前：两行都能选成同一模型（或都保持「供应商默认模型」），可保存
4. 修改后：已被选中的模型/默认项在下拉中置灰不可选；供应商所有选项用尽时「+ 供应商」按钮禁用

## 验证 / Verification

- `vue-tsc --noEmit` 对 `Agents.vue` 无类型错误
- 手动验证：同一供应商同一模型无法被重复选择，不同模型仍可正常添加并保存