### PR TITLE
fix/add gitignore for .env

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -94,8 +94,13 @@ deploy/nginx/ssl/*.crt
 deploy/nginx/ssl/*.key
 deploy/nginx/ssl/*.pem
 
-# Deploy env
-deploy/.env
+# Env files (real secrets - do not commit)
+# .env matches any level; .env.example / *.env.example are templates and stay tracked.
+.env
+.env.local
+.env.*.local
+!.env.example
+!**/.env.example
 
 # Claude Code local settings
 CLAUDE.md


### PR DESCRIPTION
## 问题
当前 `.gitignore` 没有排除 `.env` 文件，存在安全隐患。

## 解决方案
添加精确的 `.env` 忽略规则：
- 忽略 `.env`、`.env.local`、`.env.*.local`
- 保留 `.env.example` 和 `**/.env.example` 作为模板

```gitignore
# Env files (real secrets - do not commit)
.env
.env.local
.env.*.local
!.env.example
!**/.env.example